### PR TITLE
Update email sender to hello@ and add reply-to

### DIFF
--- a/supabase/functions/_shared/email/resend.ts
+++ b/supabase/functions/_shared/email/resend.ts
@@ -2,7 +2,8 @@
 
 import type { ResendResult } from "./types.ts";
 
-const FROM_EMAIL = "Market Entry Secrets <noreply@marketentrysecrets.com>";
+const FROM_EMAIL = "Market Entry Secrets <hello@marketentrysecrets.com>";
+const REPLY_TO_EMAIL = "stephen@marketentrysecrets.com";
 const RESEND_TIMEOUT_MS = 10_000;
 
 /**
@@ -32,6 +33,7 @@ export async function sendViaResendTemplate(
       },
       body: JSON.stringify({
         from: FROM_EMAIL,
+        reply_to: REPLY_TO_EMAIL,
         to: [to],
         template: {
           id: templateId,
@@ -83,6 +85,7 @@ export async function sendViaResend(
       },
       body: JSON.stringify({
         from: FROM_EMAIL,
+        reply_to: REPLY_TO_EMAIL,
         to: [to],
         subject,
         html,


### PR DESCRIPTION
## Summary
- Change sender address from `noreply@marketentrysecrets.com` to `hello@marketentrysecrets.com` for a friendlier appearance
- Add `reply_to: stephen@marketentrysecrets.com` so user replies go directly to Stephen
- Both `sendViaResendTemplate` and `sendViaResend` functions updated

## Test plan
- [x] Deployed as `send-email` v10 and `process-email-queue` v5 — both active
- [ ] Verify next email sent shows `hello@` as sender
- [ ] Verify reply-to header routes replies to `stephen@marketentrysecrets.com`

https://claude.ai/code/session_01Jnr3YB3sx6F6ZTp2u2t1yT