### PR TITLE
Add gitignore entries for scrape/enrichment export files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ dist-ssr
 
 # Supabase CLI temp files
 supabase/.temp/
+
+# Scrape / enrichment exports (contain contact PII; do not commit)
+Phantom_-_*.csv
+phantom_*.csv


### PR DESCRIPTION
## Summary
Updated `.gitignore` to exclude CSV files generated from scraping and data enrichment operations that contain personally identifiable information (PII).

## Changes
- Added two new gitignore patterns to prevent accidental commits of contact data exports:
  - `Phantom_-_*.csv` - Matches Phantom-branded export files
  - `phantom_*.csv` - Matches phantom-prefixed export files

## Details
These CSV files are generated during scraping and enrichment workflows and contain sensitive contact information. By adding them to gitignore, we ensure that PII is never accidentally committed to the repository.

https://claude.ai/code/session_0143myVvBrdF5MinMLvMrmRs