### PR TITLE
Enrich angel investors — batches 02d + 02e (records 39-48)

### DIFF
--- a/supabase/migrations/20260422130700_enrich_angel_investors_batch_02d.sql
+++ b/supabase/migrations/20260422130700_enrich_angel_investors_batch_02d.sql
@@ -1,0 +1,235 @@
+-- Enrich angel investors — batch 02d (records 39-43: Brendan Hill → Brisbane Angels)
+
+BEGIN;
+
+UPDATE investors SET
+  description = 'Sydney-based exited e-commerce founder turned full-time angel investor and venture partner. Venture Partner at TEN13. Syndicate Lead at Logan and Wayne. Active AngelList syndicate. UNSW Founders Program mentor. Big-cheque angel — $350k–$1M ticket sizes.',
+  basic_info = 'Brendan Hill is a Sydney-based angel investor who reverse-engineered his way into venture from operating. He built and exited a sports-memorabilia e-commerce business in 2016, and has spent the years since deploying capital and time into Australian early-stage technology.
+
+He is currently Venture Partner at TEN13 (Steve Baxter''s syndicate-VC platform), Syndicate Lead at Logan and Wayne (a syndicate vehicle investing in early-stage tech), and runs his own active AngelList syndicate. He also mentors at the UNSW Founders Program and contributes to ecosystem-building via the Sydney Startup Hub community.
+
+His angel portfolio includes some of Australia''s most-talked-about early-stage names — Everlab (preventative health, Melbourne), Instant (employment/payments), Heidi Health (clinical AI scribe) and a small allocation into SpaceX. His ticket band of $350k–$1M sits at the top of the Australian angel range and reflects his exit-funded balance sheet plus syndicated co-investment vehicles.',
+  why_work_with_us = 'For Australian founders raising $750k–$2M pre-seed/seed rounds, Brendan is a rare angel who can lead and pull syndicate capital alongside his own cheque. Particularly relevant for healthtech, future-of-work, employment/payments and ambitious deeptech founders who want venture-style support at angel speed.',
+  sector_focus = ARRAY['HealthTech','Future of Work','Employment Tech','SaaS','DeepTech','Consumer','Space'],
+  stage_focus = ARRAY['Pre-seed','Seed','Series A'],
+  check_size_min = 350000,
+  check_size_max = 1000000,
+  linkedin_url = 'https://au.linkedin.com/in/itsbrendanhill',
+  contact_email = 'brendan@loganwayne.com',
+  location = 'Sydney, NSW',
+  country = 'Australia',
+  currently_investing = true,
+  leads_deals = true,
+  portfolio_companies = ARRAY['Everlab','Instant','Heidi Health','SpaceX','GROW Inc.','Logan and Wayne (Syndicate Lead)','TEN13 (Venture Partner)'],
+  meta_title = 'Brendan Hill — TEN13 / Logan and Wayne | Sydney Big-Cheque Angel',
+  meta_description = 'Sydney exited e-commerce founder turned angel. Venture Partner TEN13, Syndicate Lead Logan and Wayne. Portfolio: Everlab, Instant, Heidi Health. $350k–$1M.',
+  details = jsonb_build_object(
+    'current_roles', ARRAY[
+      'Venture Partner, TEN13',
+      'Syndicate Lead, Logan and Wayne',
+      'Mentor, UNSW Founders Program',
+      'AngelList Syndicate Lead'
+    ],
+    'prior_roles', ARRAY[
+      'Founder, sports-memorabilia e-commerce business (exited 2016)'
+    ],
+    'angellist_syndicate','https://venture.angellist.com/brendan-hill/syndicate',
+    'investment_thesis','Australian early-stage technology with venture-scale ambition. Lead rounds where possible; syndicate co-investment from network. Particularly active in healthtech, future-of-work and ambitious deeptech.',
+    'check_size_note','$350k–$1M (top of Australian angel band)',
+    'sources', jsonb_build_object(
+      'linkedin','https://au.linkedin.com/in/itsbrendanhill',
+      'unsw_founders','https://www.founders.unsw.edu.au/brendan-hill',
+      'angellist_syndicate','https://venture.angellist.com/brendan-hill/syndicate',
+      'crunchbase','https://www.crunchbase.com/person/brendan-hill-57ce',
+      'wellfound','https://wellfound.com/p/brendanhill',
+      'yaro_blog_interview','https://yaro.blog/brendan-hill/',
+      'kintell_advisor','https://kintell.com/advisors/brendan-hill/angel-investing',
+      'dayone','https://dayone.fm/people/brendan-hill',
+      'sydney_startup_hub','https://community.sydneystartuphub.com/u/brendanhill',
+      'history_aus_startup_podcast','https://open.spotify.com/episode/39aeENrgSWBZ2RrbejVkqu'
+    ),
+    'corrections','CSV portfolio truncated ("Everlab, Instant, GROW In..."). "GROW In..." resolved to GROW Inc. (Australian future-of-work company). Verified additional names (Heidi Health, SpaceX) from the Brendan Hill public profile and AngelList syndicate.'
+  ),
+  updated_at = now()
+WHERE name = 'Brendan Hill';
+
+UPDATE investors SET
+  description = 'Sydney-based startup mentor and angel investor with 15+ years in the Australian startup ecosystem. UNSW staff (Start@UNSW). Past Director of Community Development at SoftLayer (IBM Cloud). Founded ShopFree.com (1999) and RecipeLover (2004). $25k cheques in AdTech and B2C.',
+  basic_info = 'Brendan Yell is a Sydney-based startup mentor and angel investor with 15+ years of experience helping Australian founders move from initial concept to successful exit. His operator track record includes founding ShopFree.com (1999) — one of the earliest Australian e-commerce platforms — and RecipeLover (2004).
+
+He spent several years as Director of Community Development at SoftLayer (acquired by IBM and now part of IBM Cloud), where he supported startups with cloud infrastructure packages and enterprise-customer introductions. He is also affiliated with Start@UNSW and the broader UNSW startup community.
+
+Today he runs his own personal mentoring and angel-investing practice (brendanyell.com) and writes $25k cheques into ad-tech and B2C consumer-tech founders. His public posts emphasise the importance of authentic founder-investor relationships and warmly recommend other ecosystem operators in the Sydney scene.',
+  why_work_with_us = 'For ad-tech and B2C founders, Brendan offers a $25k first cheque plus deep cloud-infrastructure relationships from his SoftLayer/IBM era and 15+ years of accumulated mentor-network access in Sydney. Particularly useful for founders early on the journey who need help navigating cloud cost optimisation, enterprise customer intros and broader ecosystem warm intros.',
+  sector_focus = ARRAY['AdTech','B2C','Consumer','SaaS','E-commerce'],
+  stage_focus = ARRAY['Pre-seed','Seed'],
+  check_size_min = 25000,
+  check_size_max = 25000,
+  website = 'http://brendanyell.com/',
+  linkedin_url = 'https://au.linkedin.com/in/brendanyell',
+  contact_email = 'me@brendanyell.com',
+  location = 'Sydney, NSW',
+  country = 'Australia',
+  currently_investing = true,
+  portfolio_companies = ARRAY['GoTradie','Stickler','Landmark','ShopFree.com (founder, 1999)','RecipeLover (founder, 2004)'],
+  meta_title = 'Brendan Yell — UNSW / Startup Mentor | Sydney AdTech B2C Angel',
+  meta_description = 'Sydney startup mentor and angel. 15+ years in startups; UNSW. Ex-Director Community Development, SoftLayer. ShopFree.com & RecipeLover founder. $25k cheques.',
+  details = jsonb_build_object(
+    'founder_of', ARRAY['ShopFree.com (1999)','RecipeLover (2004)'],
+    'current_roles', ARRAY[
+      'Startup Mentor & Angel Investor (brendanyell.com)',
+      'UNSW (Start@UNSW affiliated)'
+    ],
+    'prior_roles', ARRAY[
+      'Director of Community Development, SoftLayer (now IBM Cloud)'
+    ],
+    'speaker', ARRAY['AMZ Summits (Amazon ecosystem speaker)'],
+    'investment_thesis','Small-cheque AdTech and B2C investments with mentor-network value. Bias toward founders early in the journey who benefit from cloud-infra and enterprise-intro support.',
+    'check_size_note','$25k typical',
+    'sources', jsonb_build_object(
+      'website','http://brendanyell.com/',
+      'linkedin','https://au.linkedin.com/in/brendanyell',
+      'crunchbase','https://www.crunchbase.com/person/brendan-yell',
+      'amz_summits','https://amzsummits.com/speakers/brendan-yell/',
+      'unsw_start','https://www.student.unsw.edu.au/startunsw'
+    ),
+    'corrections','CSV portfolio was truncated ("GoTradie, Stickler, Landm..."). Resolved "Landm..." to Landmark (most likely candidate). These three names taken from CSV directly; could not be independently corroborated via public-source search. Founder companies (ShopFree.com, RecipeLover) added to portfolio_companies as he is the founder of both.'
+  ),
+  updated_at = now()
+WHERE name = 'Brendan Yell';
+
+UPDATE investors SET
+  description = 'Sydney-based founder/CEO of Wattblock (energy-efficiency platform for strata-titled multi-tenant buildings, founded 2014 with Ross McIntyre via muru-D accelerator). Cleantech and fintech operator-angel. 1,000+ Australian buildings assisted; 100+ strata buildings energy-upgraded.',
+  basic_info = 'Brent Clark is a Sydney-based cleantech and fintech operator turned angel investor. He is the Founder and CEO of Wattblock, an Australian SaaS platform that produces customised energy-saving roadmaps for strata-titled multi-tenant buildings. Wattblock was founded in 2014 with Ross McIntyre as part of muru-D (Telstra''s accelerator) and has since assisted over 1,000 multi-tenant buildings across Australia and energy-upgraded more than 100 strata buildings — reducing common-area energy costs by up to 65%.
+
+His path into cleantech began as Chairperson of his own Sydney apartment building, where he ran 13 energy-saving initiatives over three years to cut common-area energy costs by 77% — the data and learnings from that experiment formed Wattblock''s commercial product.
+
+He is an Australian Graduate School of Management (AGSM) alumnus. As an angel investor he writes cheques into fintech and energy-related startups. The CSV directory lists Eshares.com.au and GPayments among his investments — names tied to the Sydney/Australian fintech and identity/payments scene — although the full portfolio could not be independently corroborated from public-source search.',
+  why_work_with_us = 'A practitioner-grade cleantech operator with a public Australian SaaS scale story (Wattblock). Particularly relevant for cleantech, energytech, strata-tech, fintech and B2B SaaS founders selling into Australian property, energy and finance verticals.',
+  sector_focus = ARRAY['CleanTech','EnergyTech','PropTech','FinTech','SaaS','B2B'],
+  stage_focus = ARRAY['Pre-seed','Seed'],
+  website = 'https://www.wattblock.com',
+  linkedin_url = 'https://www.linkedin.com/in/brent-clark-2896921/',
+  location = 'Sydney, NSW',
+  country = 'Australia',
+  currently_investing = true,
+  portfolio_companies = ARRAY['Wattblock (founder, CEO)','Eshares.com.au','GPayments'],
+  meta_title = 'Brent Clark — Wattblock founder | Sydney CleanTech Angel',
+  meta_description = 'Sydney founder/CEO Wattblock (1,000+ buildings, ~65% common-area energy savings). muru-D alum. Cleantech/fintech angel. Sectors: Energy, FinTech, PropTech.',
+  details = jsonb_build_object(
+    'founder_of', ARRAY['Wattblock (2014, co-founder with Ross McIntyre via muru-D)'],
+    'current_roles', ARRAY[
+      'Founder & CEO, Wattblock'
+    ],
+    'origin_story','Ran 13 energy-saving initiatives over 3 years as Chairperson of his Sydney apartment building, cutting common-area energy costs by 77% — data became Wattblock''s commercial product.',
+    'wattblock_stats', jsonb_build_object(
+      'founded',2014,
+      'co_founder','Ross McIntyre',
+      'incubator','muru-D (Telstra accelerator)',
+      'buildings_assisted','1,000+',
+      'strata_buildings_upgraded','100+',
+      'energy_savings_potential','Up to 65% common-area energy reduction'
+    ),
+    'education', ARRAY['AGSM (Australian Graduate School of Management)'],
+    'investment_thesis','Small-cheque angel cheques into fintech and energy-related startups, with cleantech operator perspective.',
+    'check_size_note','Undisclosed; CSV did not specify',
+    'sources', jsonb_build_object(
+      'wattblock_team','https://www.wattblock.com/team.html',
+      'wattblock_about','https://www.wattblock.com/background.html',
+      'linkedin','https://www.linkedin.com/in/brent-clark-2896921/',
+      'crunchbase','https://www.crunchbase.com/organization/wattblock',
+      'fifth_estate_results','https://thefifthestate.com.au/energy-lead/energy/great-results-for-wattblock-in-strata-energy-project/',
+      'fifth_estate_capital_raise','https://thefifthestate.com.au/business/investment-deals/wattblock-undertaking-million-dollar-capital-raise/',
+      'strata_member_focus','https://nsw.strata.community/member-focus-brent-clark-wattblock/',
+      'startup_galaxy','https://startupgalaxy.com.au/startups/wattblock'
+    ),
+    'corrections','CSV LinkedIn URL empty — populated from public Wattblock profile. CSV portfolio "Eshares.com.au, GPayme..." resolved "GPayme..." to GPayments (Sydney identity/payments company, widely known). Both portfolio names retained as listed but not independently corroborated as Brent Clark personal investments.'
+  ),
+  updated_at = now()
+WHERE name = 'Brent Clark';
+
+UPDATE investors SET
+  description = 'Singapore-based sector-agnostic angel investor with Australian deal-flow exposure. $10k–$50k cheques. Limited public profile — multiple "Brian Lim" investors on the Singapore scene; specific identity could not be uniquely corroborated.',
+  basic_info = 'Brian Lim is listed in the Australian angel investor directory as a Singapore-based sector-agnostic angel writing $10k–$50k cheques. Singapore is a recognised cross-border hub for South-East Asian and Australian early-stage venture: Singapore-based angels often invest into Australian deals through syndicate platforms (Aussie Angels, AngelList) and via family-office-backed structures.
+
+The directory entry has not been uniquely corroborated to a single LinkedIn or Crunchbase profile. Multiple Brian Lims exist in the Singapore venture and finance ecosystem (including a Pantheon Ventures partner with 25+ years private-equity experience and a Bagchaser-affiliated entrepreneur). Founders should expect to validate his profile and thesis directly via the listed email when they make contact.',
+  why_work_with_us = 'For Australian founders raising small first cheques and looking for cross-border South-East Asia exposure, Brian provides a sector-agnostic Singapore-based ticket. Best treated as a referral- or warm-intro-based first conversation rather than a primary-source investor signal.',
+  sector_focus = ARRAY['SaaS','Consumer','FinTech','Marketplace'],
+  stage_focus = ARRAY['Pre-seed','Seed'],
+  check_size_min = 10000,
+  check_size_max = 50000,
+  linkedin_url = 'https://www.linkedin.com/in/brianlimdaging/',
+  contact_email = 'brianlim1218@gmail.com',
+  location = 'Singapore',
+  country = 'Singapore',
+  currently_investing = true,
+  meta_title = 'Brian Lim — Singapore Angel Investor | Sector Agnostic',
+  meta_description = 'Singapore-based sector-agnostic angel writing $10k–$50k cheques into Australian and SE Asian early-stage technology startups.',
+  details = jsonb_build_object(
+    'investment_thesis','Sector-agnostic small-cheque angel investing with Singapore + Australian deal-flow exposure. Best for founders early in the round building Asia-Pacific cross-border investor mix.',
+    'check_size_note','$10k–$50k',
+    'unverified', ARRAY[
+      'Could not uniquely match the directory listing to a single public investor profile (multiple Brian Lims in Singapore venture/finance).',
+      'No portfolio companies listed in CSV; none independently identified.'
+    ],
+    'sources', jsonb_build_object(
+      'australian_angel_list_pdf','https://www.scribd.com/document/767032518/Angels-Australia',
+      'angelmatch_singapore','https://angelmatch.io/investors/by-location/singapore',
+      'csv_linkedin','https://www.linkedin.com/in/brianlimdaging/'
+    ),
+    'corrections','CSV LinkedIn URL kept as listed (https://www.linkedin.com/in/brianlimdaging/). Could not corroborate or contradict from public sources. Sector_focus tightened from "Sector Agnostic" to common cross-border angel verticals while preserving sector-agnostic stance.'
+  ),
+  updated_at = now()
+WHERE name = 'Brian Lim';
+
+UPDATE investors SET
+  description = 'One of Australia''s oldest and most active angel groups (incorporated 2006, New Farm-headquartered). Member-run organisation of 50+ entrepreneurs, CEOs and high-net-worth investors. Won "Most Active Angel Group in Australia" three consecutive years (2019, 2020, 2021). 16-company portfolio includes Vaxxas, Spoke Phone, Five Faces and Aurtra (acquired by Schneider Electric, March 2022).',
+  basic_info = 'Brisbane Angels is one of the largest and most active business-angel networks in Australia, established in 2006 and headquartered in New Farm, Queensland. It is a member-run organisation whose 50+ members are entrepreneurs, CEOs and high-net-worth business leaders who have founded, financed and developed exceptional companies — bringing diverse industry knowledge and operating experience to the Queensland startup ecosystem.
+
+The group focuses primarily on seed-stage investments in Australian companies with high growth potential, strong market position and sustainable competitive advantages. Notable portfolio companies (drawn from a 16-company verified list) include Vaxxas (needle-free vaccine delivery), Spoke Phone (cloud telephony), Five Faces (digital signage and CX) and Aurtra — which was acquired by Schneider Electric in March 2022. Coverage is heavily weighted toward enterprise applications and high-tech.
+
+Recognition includes winning "Most Active Angel Group in Australia" three consecutive years (2019, 2020, 2021). The group is registered with Gust as an accredited angel investment group.',
+  why_work_with_us = 'For Queensland-based or QLD-relevant founders, Brisbane Angels is the highest-leverage angel introduction in the state — 50+ active members, 20+ years of accumulated deal-flow process, public exit track record (Aurtra/Schneider) and Most Active Group recognition. Member-driven decision-making means founders pitch to a curated audience of operators with cheque authority.',
+  sector_focus = ARRAY['Enterprise SaaS','HealthTech','MedTech','HighTech','SaaS','Telephony','Digital Signage','DeepTech'],
+  stage_focus = ARRAY['Pre-seed','Seed'],
+  website = 'https://www.brisbaneangels.com.au',
+  linkedin_url = 'https://au.linkedin.com/company/brisbaneangelsgrouplimited',
+  location = 'New Farm, QLD (Brisbane)',
+  country = 'Australia',
+  currently_investing = true,
+  leads_deals = true,
+  portfolio_companies = ARRAY['Vaxxas','Spoke Phone','Five Faces','Aurtra (Schneider Electric exit, March 2022)'],
+  meta_title = 'Brisbane Angels — Australia''s Most Active Angel Group (3x)',
+  meta_description = 'Brisbane Angels (est. 2006, New Farm). 50+ member-run angel group. Most Active Angel Group Australia 2019/2020/2021. Portfolio: Vaxxas, Spoke Phone, Five Faces, Aurtra.',
+  details = jsonb_build_object(
+    'founded',2006,
+    'hq','New Farm, QLD',
+    'structure','Member-run; each member makes own investment decision',
+    'members','50+',
+    'portfolio_size','16 companies (verified per Tracxn)',
+    'highlight_deals', jsonb_build_array(
+      jsonb_build_object('company','Vaxxas','category','Needle-free vaccine delivery'),
+      jsonb_build_object('company','Spoke Phone','category','Cloud telephony'),
+      jsonb_build_object('company','Five Faces','category','Digital signage / CX'),
+      jsonb_build_object('company','Aurtra','status','Acquired by Schneider Electric, March 2022')
+    ),
+    'awards', ARRAY[
+      'Most Active Angel Group in Australia — 2019',
+      'Most Active Angel Group in Australia — 2020',
+      'Most Active Angel Group in Australia — 2021'
+    ],
+    'investment_thesis','Seed-stage Australian companies with high growth potential, strong market position and sustainable advantages. Bias toward enterprise applications and high-tech.',
+    'sources', jsonb_build_object(
+      'website','https://www.brisbaneangels.com.au/',
+      'angels_page','https://www.brisbaneangels.com.au/angels',
+      'tracxn','https://tracxn.com/d/angel-network/brisbane-angels/__1FGUjrDnjy6tJt72U5pYRfq4FrGrQ1KTY0bk_61i5t8',
+      'gust','https://gust.com/organizations/brisbane-angels/',
+      'crunchbase','https://www.crunchbase.com/organization/brisbane-angels',
+      'linkedin','https://au.linkedin.com/company/brisbaneangelsgrouplimited'
+    ),
+    'corrections','CSV LinkedIn URL empty — populated from public profile. CSV portfolio "50+" appears to refer to member count rather than portfolio companies; clarified in details.members. Verified portfolio names added from Tracxn and public press.'
+  ),
+  updated_at = now()
+WHERE name = 'Brisbane Angels';
+
+COMMIT;

--- a/supabase/migrations/20260422130800_enrich_angel_investors_batch_02e.sql
+++ b/supabase/migrations/20260422130800_enrich_angel_investors_batch_02e.sql
@@ -1,0 +1,248 @@
+-- Enrich angel investors — batch 02e (records 44-48: Byron Bay Angels → Charlene Liu)
+
+BEGIN;
+
+UPDATE investors SET
+  description = 'Northern Rivers (NSW) regional angel investment group, established 2018. ~43 members. Focus on purposeful, mission-driven early-stage companies. $100,000–$500,000 cheque band. Portfolio includes Ping (telco), Humble Bee (biotech materials) and Vaulta (battery technology).',
+  basic_info = 'Byron Bay Angels (also known as Byron Angels and originally Northern Rivers Angels) is a regional angel investment group based in Byron Bay, NSW, established in 2018. With approximately 43 members across the Northern Rivers region, the group has positioned itself as the angel network for purposeful, mission-driven early-stage Australian companies — emphasising businesses with measurable social, environmental or community impact in addition to commercial returns.
+
+The group runs an active monthly cadence of pitch nights and member events, and is registered as an accredited angel group on Gust. They also list a connected investing vehicle through AngelList syndicates. Verified portfolio companies drawn from public listings include Ping (telco), Humble Bee (sustainable biotech materials) and Vaulta (battery technology / energy storage).
+
+The group operates with a $100,000–$500,000 syndicate-cheque band, with individual members each writing tickets within that envelope.',
+  why_work_with_us = 'Best for purposeful and impact-led founders raising $100k–$500k seed cheques who can articulate clear social or environmental benefit alongside commercial returns. Northern Rivers regional concentration means a tight-knit operator network and a high signal/noise ratio in the room.',
+  sector_focus = ARRAY['Climate','Biotech','EnergyTech','Telco','Impact','Consumer','Regional Tech'],
+  stage_focus = ARRAY['Pre-seed','Seed'],
+  check_size_min = 100000,
+  check_size_max = 500000,
+  website = 'https://www.byronbayangels.com',
+  linkedin_url = 'https://www.linkedin.com/company/byron-angels/',
+  location = 'Byron Bay, NSW',
+  country = 'Australia',
+  currently_investing = true,
+  leads_deals = true,
+  portfolio_companies = ARRAY['Ping','Humble Bee','Vaulta'],
+  meta_title = 'Byron Bay Angels — Northern Rivers Impact Angel Group',
+  meta_description = 'Byron Bay Angels (est. 2018). ~43 members. Purposeful, mission-driven AU early-stage companies. $100k–$500k cheques. Portfolio: Ping, Humble Bee, Vaulta.',
+  details = jsonb_build_object(
+    'founded',2018,
+    'hq','Byron Bay, NSW (Northern Rivers)',
+    'aka', ARRAY['Byron Angels','Northern Rivers Angels'],
+    'members','~43',
+    'angellist_syndicate','https://venture.angellist.com/marc-sofer/syndicate',
+    'investment_thesis','Purposeful, mission-driven Australian early-stage companies with measurable impact alongside commercial returns. Particularly active in climate, biotech, energy storage and regional tech.',
+    'check_size_note','$100,000 – $500,000 (syndicate band)',
+    'sources', jsonb_build_object(
+      'website','https://www.byronbayangels.com',
+      'byronangels_org','https://www.byronangels.org/',
+      'pitchbook','https://pitchbook.com/profiles/investor/530680-69',
+      'gust','https://gust.com/organizations/northern-rivers-angels',
+      'angelmatch','https://angelmatch.io/investors/by-location/byron-bay',
+      'angellist_marc_sofer','https://venture.angellist.com/marc-sofer/syndicate',
+      'linkedin','https://www.linkedin.com/company/byron-angels/',
+      'founders_northern_rivers','http://foundersnorthernrivers.com/'
+    ),
+    'corrections','CSV portfolio truncated ("Ping, Humble Bee, Vaulta,..."). Three names retained as verified Byron Bay Angels portfolio entries; trailing item could not be uniquely identified. CSV cheque band ("$100,000 - $500,0...") completed to $100,000 – $500,000.'
+  ),
+  updated_at = now()
+WHERE name = 'Byron Bay Angels';
+
+UPDATE investors SET
+  description = 'Sydney-based former founder turned full-time investor. Chartered Accountant (CA(SA)). Principal — Mergers, Acquisitions & Venture Capital at Backbone Partners (Sydney VC + advisory firm, since May 2023). Sector-agnostic with deepest experience in fintech. $5k–$100k cheques. Trades and writes publicly via byrongoldberg.com.',
+  basic_info = 'Byron Goldberg ("BIG") is a Sydney-based investor with a Chartered Accountant background (CA(SA)) and a former-founder operating story. Since May 2023 he has been Principal — Mergers, Acquisitions & Venture Capital at Backbone Partners, a Sydney-based venture-capital and technology-advisory firm founded in 2022 that bridges advisory and investment for technology companies, founders, VC funds and investors.
+
+He maintains an active personal site at byrongoldberg.com where he writes about M&A, product, technology, AI, crypto and behavioural psychology — and where he publishes his current investment thesis. He has contributed bylines to FS Private Wealth on financial-services and venture topics.
+
+His angel posture is sector-agnostic but with the deepest accumulated experience in fintech (a function of his CA training and earlier founder/operating roles). The CSV directory lists him at $5k–$100k — a wide elastic band consistent with someone who calibrates his cheque to the deal stage, founder relationship and conviction level.',
+  why_work_with_us = 'For founders running a structured fundraise, Byron offers a dual-track path: a personal angel cheque ($5k–$100k) plus, where the deal fits Backbone Partners'' technology-investment thesis, a potential institutional pathway. CA-trained financial diligence is unusual on the Sydney angel scene and useful for founders who want a sharp eye on cap-table mechanics and deal structure.',
+  sector_focus = ARRAY['FinTech','SaaS','M&A','AI','Crypto','Technology'],
+  stage_focus = ARRAY['Pre-seed','Seed','Series A'],
+  check_size_min = 5000,
+  check_size_max = 100000,
+  website = 'https://byrongoldberg.com/',
+  linkedin_url = 'https://www.linkedin.com/in/byrongoldberg/',
+  location = 'Sydney, NSW',
+  country = 'Australia',
+  currently_investing = true,
+  portfolio_companies = ARRAY['Backbone Partners (Principal — M&A and VC)'],
+  meta_title = 'Byron Goldberg (BIG) — Backbone Partners | Sydney Angel & VC',
+  meta_description = 'Sydney CA-trained ex-founder. Principal M&A/VC, Backbone Partners (since May 2023). Sector-agnostic, fintech-deepest. $5k–$100k cheques. byrongoldberg.com.',
+  details = jsonb_build_object(
+    'credentials','CA(SA) — Chartered Accountant (South African Institute)',
+    'firm','Backbone Partners (Sydney VC + technology advisory; founded 2022)',
+    'role','Principal — Mergers, Acquisitions & Venture Capital (since May 2023)',
+    'personal_site','https://byrongoldberg.com/',
+    'public_writing_topics', ARRAY['M&A','Product','Technology','AI','Crypto','Behavioural Psychology'],
+    'media_presence', ARRAY['FS Private Wealth bylines'],
+    'investment_thesis','Sector-agnostic angel cheques with fintech depth. Cheques calibrated to deal stage and conviction. Where deal fits Backbone Partners'' tech-investment thesis, optional institutional pathway.',
+    'check_size_note','$5k–$100k (elastic, conviction-calibrated)',
+    'sources', jsonb_build_object(
+      'website','https://byrongoldberg.com/',
+      'about','https://byrongoldberg.com/about',
+      'linkedin','https://www.linkedin.com/in/byrongoldberg/',
+      'backbone_partners','https://www.backbonepartners.com.au/',
+      'backbone_pitchbook','https://pitchbook.com/profiles/investor/529211-71',
+      'fs_private_wealth','https://www.fsprivatewealth.com.au/author/byron-goldberg-177270264',
+      'clay_earth','https://clay.earth/profile/byron-goldberg'
+    ),
+    'corrections','CSV LinkedIn URL verified. CSV email field showed only "Email" placeholder — left contact_email NULL. CSV portfolio empty; populated with verified firm affiliation (Backbone Partners) rather than fabricating individual portfolio companies.'
+  ),
+  updated_at = now()
+WHERE name = 'Byron Goldberg (BIG)';
+
+UPDATE investors SET
+  description = 'Australia''s first formally-incorporated angel investment group. Established by lunch-table conversation and incorporated as a Company Limited by Guarantee in 2005, headquartered in Canberra. Each member makes their own decision and writes their own cheque (no group-investment vehicle). Sector breadth reflects the Capital Region economy: financial, life-science/biotech, software, IT, technical services, internet, gaming and consumer. Notable past investment: Instaclustr.',
+  basic_info = 'Capital Angels was the first formally-incorporated angel investment group in Australia — set up over lunch by a small group of Canberra-based investors and incorporated as a Company Limited by Guarantee in 2005. Headquartered in Canberra, the network supports Capital Region (ACT and surrounding NSW) entrepreneurs through both investment and direct-activity support of portfolio companies.
+
+A defining feature of Capital Angels is that the group does **not** invest as a fund. Each member proactively decides whether to participate in a deal and writes their own cheque directly to the company; the group provides the deal-flow filter, due-diligence cadence, member-network introductions and post-investment governance support.
+
+Sector coverage reflects the Capital Region economy — heavily weighted to high-technology and government/professional services — but the membership''s individual interests span financial services, life science and biotech, software of all kinds, technical services, IT, transportation services, gaming, retail, internet and consumer products. The group has facilitated numerous investments in ACT and Capital Region companies, with Instaclustr (open-source data-platform-as-a-service) being among its most-cited successes.',
+  why_work_with_us = 'For Canberra and Capital Region founders, this is the most established and longest-running angel network in Australia (20+ years of continuous operation). Member-by-member decision-making means deal velocity depends on individual conviction rather than committee consensus, which can be faster for compelling deals. Particularly relevant for ACT-based deeptech, defence-adjacent, govtech, fintech and software founders.',
+  sector_focus = ARRAY['Government Tech','DeepTech','Software','SaaS','HealthTech','Biotech','Defence','FinTech'],
+  stage_focus = ARRAY['Pre-seed','Seed'],
+  website = 'https://www.capitalangels.com.au',
+  linkedin_url = 'https://au.linkedin.com/company/capital-angels-pty-ltd',
+  location = 'Canberra, ACT',
+  country = 'Australia',
+  currently_investing = true,
+  portfolio_companies = ARRAY['Instaclustr'],
+  meta_title = 'Capital Angels — Australia''s First Angel Investment Group',
+  meta_description = 'Canberra. Australia''s first incorporated angel group (2005). Members invest individually. Capital Region focus. Notable: Instaclustr.',
+  details = jsonb_build_object(
+    'founded',2005,
+    'incorporation','Company Limited by Guarantee',
+    'first_in_australia',true,
+    'hq','Canberra, ACT',
+    'structure','Members invest individually — group does not pool capital. Group provides deal flow, due diligence, member intros and governance support.',
+    'sector_coverage', ARRAY[
+      'Financial services',
+      'Media',
+      'Life science and biotech',
+      'Software (all kinds)',
+      'Technical services',
+      'IT',
+      'Transportation services',
+      'Games',
+      'Retail',
+      'Internet',
+      'Consumer products and technology'
+    ],
+    'notable_investments', ARRAY['Instaclustr'],
+    'investment_thesis','Member-driven deal flow into ACT and Capital Region high-technology, services and software businesses. Tier reflects member individual conviction.',
+    'sources', jsonb_build_object(
+      'website','https://www.capitalangels.com.au/',
+      'message_chair','https://www.capitalangels.com.au/message-chair.html',
+      'linkedin','https://au.linkedin.com/company/capital-angels-pty-ltd',
+      'tracxn','https://tracxn.com/d/angel-network/capital-angels-network/__IVb_0E6NQsotffcwmAnOXEyotRgsexDgMUzk3Bel3oo',
+      'crunchbase','https://www.crunchbase.com/organization/capital-angels-australia'
+    ),
+    'corrections','CSV portfolio listed as "lots, been active since 20..." — interpreted as a stylistic placeholder rather than literal portfolio data. Replaced with verified notable investment (Instaclustr) and noted member-individual investment structure to set founder expectations correctly.'
+  ),
+  updated_at = now()
+WHERE name = 'Capital Angels';
+
+UPDATE investors SET
+  description = 'Melbourne-based serial founder turned 100+ portfolio angel investor. Co-founder 1Form (REA Group exit, 2014), Fillr (Rakuten exit, 2020) and Inhouse Ventures (Scalare Partners exit, early 2025). Three exits, three companies. Sector-agnostic. $10k–$50k cheques. Active mentor on MentorCruise and Intro.co.',
+  basic_info = 'Chad Stephens is a Melbourne-based serial founder turned full-time angel investor with one of Australia''s longest individual angel-portfolio track records — 100+ angel investments across Australia and the United States.
+
+His three exits are unusually concentrated for an Australian operator-angel:
+- Co-founded **1Form** (online tenancy application platform), grew it to 90%+ of the Australian rental market, exited to ASX-listed REA Group in 2014.
+- Co-founded **Fillr** (autofill-as-a-service tech embedded into Klarna, Afterpay and Zip), raised $5M from SoftBank and Reinventure, exited to Rakuten in 2020.
+- Co-founded **Inhouse Ventures** in July 2022 with Elliot Spiegel and Mark Cameron — a marketplace connecting founders, investors and ecosystem leaders that grew to 10,000+ users before exiting to ASX-listed Scalare Partners in early 2025.
+
+His verified angel portfolio includes Designerex, Vitadrop, Recime, EdTripper, Aussie Angels, Birchal, Cloutly, Threadicated, Skoutli, ListSocial, Loop, Loop Fans, TRENDii and Living Legacy Forest. He works as a fractional COO, advisor and mentor — bookable via Intro.co and MentorCruise — and writes $10k–$50k cheques.',
+  why_work_with_us = 'Among the highest-leverage Australian angel relationships available: three exits across consumer-marketplace (REA), fintech-embedded SaaS (Rakuten) and ecosystem-marketplace (Scalare). 100+ portfolio gives Chad pattern recognition that few angels in Australia can match. Particularly useful for marketplace, B2B SaaS, fintech-adjacent and consumer founders looking for a fractional-COO style hands-on cheque.',
+  sector_focus = ARRAY['Marketplace','SaaS','FinTech','Consumer','PropTech','EdTech','HealthTech','SaaS Marketplaces'],
+  stage_focus = ARRAY['Pre-seed','Seed','Series A'],
+  check_size_min = 10000,
+  check_size_max = 50000,
+  linkedin_url = 'https://au.linkedin.com/in/chadstephens1',
+  location = 'Melbourne, VIC',
+  country = 'Australia',
+  currently_investing = true,
+  leads_deals = true,
+  portfolio_companies = ARRAY['1Form (co-founder; REA Group exit 2014)','Fillr (co-founder; Rakuten exit 2020)','Inhouse Ventures (co-founder; Scalare Partners exit 2025)','Designerex','Vitadrop','Recime','EdTripper','Aussie Angels','Birchal','Cloutly','Threadicated','Skoutli','ListSocial','Loop','Loop Fans','TRENDii','Living Legacy Forest'],
+  meta_title = 'Chad Stephens — 1Form, Fillr, Inhouse | Melbourne Operator-Angel',
+  meta_description = 'Melbourne 100+ angel portfolio. Three exits: 1Form (REA 2014), Fillr (Rakuten 2020), Inhouse Ventures (Scalare 2025). $10k–$50k cheques.',
+  details = jsonb_build_object(
+    'founder_of', ARRAY['1Form (co-founder; REA Group exit 2014)','Fillr (co-founder; Rakuten exit 2020)','Inhouse Ventures (co-founder; Scalare Partners exit 2025)'],
+    'exits', jsonb_build_array(
+      jsonb_build_object('company','1Form','category','Online tenancy applications (90%+ AU rental market)','acquirer','REA Group (ASX)','year',2014),
+      jsonb_build_object('company','Fillr','category','Autofill-as-a-Service (Klarna/Afterpay/Zip)','funding_aud','$5M from SoftBank + Reinventure','acquirer','Rakuten Inc.','year',2020),
+      jsonb_build_object('company','Inhouse Ventures','category','Founder-investor marketplace (10,000+ users)','co_founders',ARRAY['Elliot Spiegel','Mark Cameron'],'acquirer','Scalare Partners (ASX)','year',2025)
+    ),
+    'angel_portfolio_count','100+ across Australia and the US',
+    'current_roles', ARRAY[
+      'Active angel investor',
+      'Fractional COO, advisor and mentor',
+      'Bookable via Intro.co and MentorCruise'
+    ],
+    'investment_thesis','Sector-agnostic, with strong pattern recognition in marketplaces, SaaS, fintech-embedded SaaS, consumer and ecosystem businesses. Operator-grade hands-on support post-investment.',
+    'check_size_note','$10k–$50k',
+    'sources', jsonb_build_object(
+      'linkedin','https://au.linkedin.com/in/chadstephens1',
+      'crunchbase','https://www.crunchbase.com/person/chad-stephens',
+      'intro_co','https://intro.co/ChadStephens',
+      'mentorcruise','https://mentorcruise.com/mentor/chadstephens/',
+      'kenobe_ventures','https://www.kenobe.com/chad-stephens',
+      'inhouse_ventures_event','https://events.humanitix.com/from-startup-to-exit',
+      'enterprise_angel_list','https://shizune.co/investors/enterprise-angel-investors-australia'
+    ),
+    'corrections','CSV portfolio empty — populated with 14 verified angel investments plus three founder/exit companies. CSV had email field empty; left contact_email NULL pending direct contact (Intro.co/MentorCruise are public booking channels).'
+  ),
+  updated_at = now()
+WHERE name = 'Chad Stephens';
+
+UPDATE investors SET
+  description = 'Shenzhen-based Investment Manager at AUKEY (Chinese consumer-electronics group, AuGroup). Sequoia Fellow alumna (Sequoia Capital). Cross-border investor with Australian educational and professional background — Master of Commerce (Excellence) from UNSW; Bachelor of Business from Monash. DTC consumer-electronics and cross-border logistics focus. Portfolio includes Navitas and J&T Express.',
+  basic_info = 'Charlene (Qianyu) Liu is a Shenzhen-based investment professional with strong Australian academic and operating ties. She is a Manager — Investment at AUKEY (parent group AuGroup), a major Chinese consumer-electronics brand operating multiple D2C/marketplace channels including Amazon US/EU. AUKEY''s investment arm makes both strategic and financial early-stage investments in consumer-electronics, e-commerce infrastructure and logistics-tech.
+
+She is a Sequoia Fellow alumna (Sequoia Capital fellowship program) and has held prior roles at Cloud Joy Capital, CITIC Securities, LW Asset Management Advisors, Convoy Financial Services, Baby Direct and Accenture. Her academic credentials are unusually deep for an Australian-Asian cross-border investor: Master of Commerce (With Excellence) from UNSW Sydney and Bachelor of Business from Monash University in Melbourne.
+
+Her CSV-listed portfolio includes Navitas (Australian education-services group, ASX-listed before privatisation) and J&T Express (Indonesian-founded global delivery company, founded August 2015 in Jakarta, now one of South-East Asia''s largest courier brands). Her cheque-size ceiling is unusually high (CSV: <USD$8M) — consistent with deploying balance-sheet rather than personal-angel capital, likely on behalf of AUKEY/AuGroup investment vehicles.',
+  why_work_with_us = 'For Australian DTC, consumer-electronics and cross-border-logistics founders looking to scale into China and South-East Asia, Charlene is one of the more institutional Shenzhen-side relationships available. Her Australian academic and professional background means quicker context-establishment than typical China-based investors. Particularly relevant for hardware, smart-home, e-commerce-infrastructure and logistics-tech founders.',
+  sector_focus = ARRAY['DTC','Consumer Electronics','Hardware','E-commerce','Logistics','Cross-border'],
+  stage_focus = ARRAY['Seed','Series A','Series B','Growth'],
+  check_size_min = NULL,
+  check_size_max = 12000000,
+  linkedin_url = 'https://www.linkedin.com/in/qianyuliu00/',
+  location = 'Shenzhen, China',
+  country = 'China',
+  currently_investing = true,
+  leads_deals = true,
+  portfolio_companies = ARRAY['Navitas','J&T Express'],
+  meta_title = 'Charlene Liu — AUKEY Investment | Shenzhen DTC + Cross-Border',
+  meta_description = 'Shenzhen Investment Manager at AUKEY (AuGroup). Sequoia Fellow. UNSW + Monash educated. DTC, consumer electronics, cross-border logistics. Portfolio: Navitas, J&T Express.',
+  details = jsonb_build_object(
+    'firm','AUKEY (AuGroup) — Investment Management',
+    'role','Manager, Investment',
+    'sequoia_fellowship',true,
+    'prior_employers', ARRAY[
+      'Sequoia Capital (Sequoia Fellow)',
+      'Cloud Joy Capital',
+      'CITIC Securities',
+      'LW Asset Management Advisors',
+      'Convoy Financial Services',
+      'Baby Direct',
+      'Accenture'
+    ],
+    'education', ARRAY[
+      'Master of Commerce (With Excellence), UNSW Sydney',
+      'Bachelor of Business, Monash University, Melbourne'
+    ],
+    'australia_link','Studied at Monash and UNSW; meaningful Australian academic and operating context for cross-border deals.',
+    'investment_thesis','Strategic and financial early-stage and growth investments into DTC consumer-electronics, hardware, e-commerce-infrastructure and cross-border logistics — particularly companies with China/SE Asia scale ambitions.',
+    'check_size_note','Cheque ceiling listed at <USD$8M; consistent with corporate-balance-sheet deployment rather than personal angel capital',
+    'sources', jsonb_build_object(
+      'linkedin_au','https://www.linkedin.com/in/qianyuliu00/',
+      'linkedin_cn','https://cn.linkedin.com/in/qianyuliu00/en',
+      'aukey','https://www.zoominfo.com/p/Charlene-Liu/5467906147',
+      'rocketreach','https://rocketreach.co/charlene-liu-email_307741741',
+      'jt_express_wikipedia','https://en.wikipedia.org/wiki/J%26T_Express',
+      'shenzhen_angel_pitchbook','https://pitchbook.com/profiles/investor/343104-49'
+    ),
+    'corrections','CSV portfolio truncated ("Navitas, J&T Express, Sur..."). Resolved to two confirmed names; "Sur..." could not be uniquely identified. CSV cheque ceiling "<USD$8m" stored as $12M AUD upper bound (rough USD→AUD conversion at 0.67 USD/AUD; check_size_min left NULL since CSV did not specify a floor).'
+  ),
+  updated_at = now()
+WHERE name = 'Charlene Liu';
+
+COMMIT;


### PR DESCRIPTION
## Summary

Continues the angel-investor enrichment series. Two atomic migrations, ten records total.

### Batch 02d (records 39-43)

| # | Investor | Anchor signal |
|---|---|---|
| 39 | Brendan Hill | Sydney exited e-commerce founder. Venture Partner TEN13. Syndicate Lead Logan and Wayne. AngelList syndicate. Portfolio: Everlab, Instant, Heidi Health, SpaceX. **$350k–$1M cheques.** |
| 40 | Brendan Yell | Sydney UNSW startup mentor & angel. Founded ShopFree.com (1999), RecipeLover (2004). Ex-Director Community Development, SoftLayer. AdTech/B2C. |
| 41 | Brent Clark | Sydney founder/CEO Wattblock (energy SaaS for strata buildings, muru-D 2014). 1,000+ buildings assisted. CleanTech/FinTech. |
| 42 | Brian Lim | Singapore. Sector-agnostic small-cheque angel. **Common-name caveat flagged in `details.unverified`.** |
| 43 | Brisbane Angels | Australia's 3× Most Active Angel Group (2019/2020/2021). Est. 2006, New Farm. 50+ members. Notable: Vaxxas, Spoke Phone, Five Faces, **Aurtra (Schneider Electric exit March 2022)**. |

### Batch 02e (records 44-48)

| # | Investor | Anchor signal |
|---|---|---|
| 44 | Byron Bay Angels | Northern Rivers regional angel group, est. 2018. ~43 members. Purposeful/impact mandate. $100k–$500k. Portfolio: Ping, Humble Bee, Vaulta. |
| 45 | Byron Goldberg (BIG) | Sydney CA-trained ex-founder. Principal M&A/VC at Backbone Partners (since May 2023). Sector-agnostic with fintech depth. $5k–$100k. |
| 46 | Capital Angels | **Australia's first incorporated angel group (2005, Canberra).** Members invest individually. Capital Region focus. Notable: Instaclustr. |
| 47 | Chad Stephens | Melbourne 100+ portfolio angel. **THREE exits:** 1Form (REA 2014), Fillr (Rakuten 2020), Inhouse Ventures (Scalare 2025). |
| 48 | Charlene Liu | Shenzhen Investment Manager at AUKEY/AuGroup. Sequoia Fellow alumna. UNSW + Monash educated. DTC/consumer-electronics/cross-border logistics. |

Each row receives expanded `sector_focus`, verified `portfolio_companies`, `description` / `basic_info` / `why_work_with_us` prose, verified `linkedin_url` (where uniquely identifiable), `check_size_min`/`check_size_max` where public, and a `details` JSONB block with investment thesis, current/prior roles, sources object (used by investor-detail Sources section), and corrections flagging CSV truncations or unverifiable items.

**Series state after this PR:** pilot (3) + 01a–01d (20) + 02a–02e (25) = **48 of 267** angel investors enriched.

## Files changed

- `supabase/migrations/20260422130700_enrich_angel_investors_batch_02d.sql` (new, 235 lines, single BEGIN/COMMIT)
- `supabase/migrations/20260422130800_enrich_angel_investors_batch_02e.sql` (new, 248 lines, single BEGIN/COMMIT)

## Test plan

- [ ] CI Supabase preview branch applies both migrations cleanly in order
- [ ] Spot-check Brisbane Angels detail page renders the Aurtra/Schneider Electric exit correctly in `highlight_deals`
- [ ] Spot-check Chad Stephens detail page renders all three exits and the 14-company verified portfolio
- [ ] Confirm Brendan Hill `$350k–$1M` cheque band displays correctly (top of Australian angel range)
- [ ] Verify Capital Angels disambiguation messaging — members invest individually, not as a fund
- [ ] Confirm Brian Lim row displays with `details.unverified` flags appropriately
- [ ] Charlene Liu `check_size_max` of $12M AUD (rough USD→AUD conversion of <USD$8M) — sanity-check display in directory filter

## Notes for review

- **Conservative entries:** Brian Lim flagged in `details.unverified` (multiple Singapore Brian Lims; cannot uniquely identify). Brendan Yell portfolio names (GoTradie, Stickler, Landmark) retained from CSV but not independently corroborated — flagged in `corrections`.
- **Brent Clark:** CSV portfolio "Eshares.com.au, GPaymen..." resolved "GPaymen..." to **GPayments** (well-known Sydney identity/payments company). Names retained but flagged as not independently corroborated as Brent Clark personal investments.
- **Byron Goldberg (BIG):** CSV email field was just "Email" placeholder — left `contact_email` NULL pending direct contact details.
- **Capital Angels:** CSV portfolio listed as "lots, been active since 20..." — interpreted as stylistic placeholder rather than literal data. Replaced with verified notable investment (Instaclustr) and prominent disambiguation that members invest individually rather than via group fund.
- **Charlene Liu:** Cheque ceiling stored as $12M AUD (approximate AUD conversion of CSV `<USD$8m`). `check_size_min` left NULL.

https://claude.ai/code/session_017Zvz2r5Y2U8bP3eY4cwAFe

---
_Generated by [Claude Code](https://claude.ai/code/session_01XsHLVbJ1rAJ3oafzHY6j2N)_