### PR TITLE
Enrich angel investors — batches 02p-02s (records 99-118, 20 records)

### DIFF
--- a/supabase/migrations/20260422131900_enrich_angel_investors_batch_02p.sql
+++ b/supabase/migrations/20260422131900_enrich_angel_investors_batch_02p.sql
@@ -1,0 +1,213 @@
+-- Enrich angel investors — batch 02p (records 99-103: Harry Uffindell → Igor Zvezdakoski)
+
+BEGIN;
+
+UPDATE investors SET
+  description = 'Auckland-based founder, operator, venture scout and angel investor. 2 founder exits to his name. Formerly Head of Business Operations & Strategy ANZ at Airbnb. Currently Chief People Officer at Partly. Sector-agnostic; invests at pre-seed/seed for outliers with 50–1000x potential. $25k cheques. Notable investment: Treinta (Latam SME super-app, $4M → $100M valuation).',
+  basic_info = 'Harry (Harrison) Uffindell is an Auckland-based founder-operator-angel with 2 prior founder exits and a current operating role as **Chief People Officer at Partly** (Auckland-headquartered automotive-parts data platform).
+
+His earlier career was as **Head of Business Operations & Strategy ANZ at Airbnb**, where he led Business Operations, Strategy and Partnerships across Australia and New Zealand.
+
+He runs his own angel syndicate on the **Aussie Angels** platform and has been recognised as one of the most active outlier-bet angel investors in the ANZ tech ecosystem. His thesis is sector-agnostic with explicit focus on outliers that can completely change or create entire industries — deals that have potential to return 50x, 100x or even 1000x.
+
+Notable single investment: **Treinta** — a pre-seed-stage super-app for Latin American SMEs, where Harry invested at a $4M valuation; current valuation reported at ~$100M.
+
+He publishes regularly via Harry''s Newsletter (harrysnewsletter.com) and is bookable for founder advice via Intro.co.',
+  why_work_with_us = 'For ANZ founders aiming for venture-scale outlier outcomes (50x+) and willing to think beyond local market caps, Harry offers a high-quality early cheque, syndicate distribution and Airbnb operator pattern recognition.',
+  sector_focus = ARRAY['SaaS','Marketplace','Consumer','FinTech','HRTech','Automotive','LatAm cross-border'],
+  stage_focus = ARRAY['Pre-seed','Seed'],
+  check_size_min = 25000,
+  check_size_max = 25000,
+  linkedin_url = 'https://www.linkedin.com/in/harrisonuffindell/',
+  contact_email = 'harrison.uffindell@gmail.com',
+  location = 'Auckland, New Zealand',
+  country = 'New Zealand',
+  currently_investing = true,
+  leads_deals = true,
+  portfolio_companies = ARRAY['Treinta (Latam SME super-app; $4M entry → $100M)','Partly (Chief People Officer)','Harry Uffindell Syndicate (Aussie Angels)','Carted'],
+  meta_title = 'Harry Uffindell — Partly / ex-Airbnb | Auckland Outlier-Bet Angel',
+  meta_description = 'Auckland founder/operator/angel. 2 exits. CPO Partly. Ex-Airbnb Head Business Ops ANZ. $25k cheques. Aussie Angels syndicate. 50–1000x outlier thesis.',
+  details = jsonb_build_object(
+    'current_roles', ARRAY[
+      'Chief People Officer, Partly',
+      'Syndicate Lead, Aussie Angels (Harry Uffindell''s Syndicate)',
+      'Author, Harry''s Newsletter'
+    ],
+    'prior_roles', ARRAY[
+      'Head of Business Operations & Strategy ANZ, Airbnb',
+      '2 prior founder exits'
+    ],
+    'investment_thesis','Sector-agnostic pre-seed/seed cheques into outliers with 50–1000x potential.',
+    'highlight_deal', jsonb_build_object('company','Treinta','category','LatAm SME super-app','entry_valuation','$4M','current_valuation','~$100M'),
+    'check_size_note','$25k',
+    'sources', jsonb_build_object(
+      'aussie_angels','https://app.aussieangels.com/syndicate/harry-uffindells-syndicate',
+      'linkedin','https://www.linkedin.com/in/harrisonuffindell/',
+      'cb_insights','https://www.cbinsights.com/investor/harry-uffindell',
+      'intro','https://intro.co/HarryUffindell',
+      'crunchbase','https://www.crunchbase.com/person/harrison-uffindell',
+      'partly_press','https://www.partly.com/post/partly-names-harry-uffindell-as-chief-people-officer',
+      'newsletter','https://www.harrysnewsletter.com/about',
+      'signal_nfx','https://signal.nfx.com/investors/harrison-uffindell'
+    ),
+    'corrections','CSV portfolio truncated ("Trienta (~$200m); Carted..."). Resolved "Trienta" to Treinta (correct spelling). $200m valuation in CSV updated to ~$100m per public source. Carted retained verbatim.'
+  ),
+  updated_at = now()
+WHERE name = 'Harry Uffindell';
+
+UPDATE investors SET
+  description = 'Sydney/New York-based marketing-tech founder and operator-angel. Co-Founder & CEO of Mutinex (GrowthOS marketing-mix-modelling SaaS that analyses billions in advertising spend). Ex-MagicBrief, Exit Capital, ReciMe. Sydney University BA History/Anthropology. $15k cheques.',
+  basic_info = 'Henry Innis is a marketing-tech founder and operator-angel currently based between New York and Sydney. He is **Co-Founder and CEO of Mutinex**, the foundation-modelling marketing-measurement SaaS platform whose GrowthOS product analyses billions of dollars of advertising spend from globally-recognised brands. He is widely cited as a pioneer in modern Marketing Mix Modelling (MMM).
+
+Prior to Mutinex he worked at **MagicBrief**, **Exit Capital** and **ReciMe**, and earlier in consulting roles. His angel cheques ($15k) skew to martech, AI-marketing and consumer-tech founders building in his domain.
+
+Notable angel positions per CSV: **MagicBrief**, **ReciMe** and **Manifest** (AI-powered operational intelligence platform for agencies, where Henry is referenced as a key investor).
+
+He holds a Bachelor of Arts (History and Anthropology) from the University of Sydney.',
+  why_work_with_us = 'For Australian marketing-tech, AI-marketing, MMM-adjacent and agency-tooling founders, Henry offers operator-grade pattern recognition from running the leading marketing-measurement SaaS platform globally.',
+  sector_focus = ARRAY['MarTech','AI','Marketing Measurement','SaaS','Consumer','B2B'],
+  stage_focus = ARRAY['Pre-seed','Seed'],
+  check_size_min = 15000,
+  check_size_max = 15000,
+  contact_email = 'henry@mutinex.co',
+  location = 'Sydney, NSW (and New York)',
+  country = 'Australia',
+  currently_investing = true,
+  portfolio_companies = ARRAY['Mutinex (Co-Founder, CEO)','MagicBrief','ReciMe','Manifest (AI-powered operational intelligence for agencies)','True...'],
+  meta_title = 'Henry Innis — Mutinex CEO | Sydney/NY MarTech Angel',
+  meta_description = 'Sydney/NY Co-Founder/CEO Mutinex (GrowthOS marketing-mix-modelling SaaS). Pioneer MMM. $15k cheques. Portfolio: MagicBrief, ReciMe, Manifest.',
+  details = jsonb_build_object(
+    'founder_of', ARRAY['Mutinex (Co-Founder & CEO)'],
+    'prior_roles', ARRAY['MagicBrief','Exit Capital','ReciMe','Consulting'],
+    'education', ARRAY['BA History and Anthropology, University of Sydney'],
+    'investment_thesis','Marketing-tech, AI-marketing, MMM-adjacent and agency-tooling founders.',
+    'check_size_note','$15k',
+    'sources', jsonb_build_object(
+      'rocketreach','https://rocketreach.co/henry-innis-email_677310',
+      'mutinex','https://mutinex.co/author/henryinnis1/',
+      'linkedin','https://www.linkedin.com/in/henryinnis/',
+      'crunchbase','https://www.crunchbase.com/person/henry-innis',
+      'mumbrella_manifest','https://mumbrella.com.au/manifest-raises-2m-amid-australian-agency-roll-out-921793',
+      'madison_wall','https://madisonandwall.substack.com/p/an-interview-with-mutinexs-henry'
+    ),
+    'corrections','CSV portfolio "MagicBrief, ReciMe, True..." retained verbatim. Mutinex added as founder/operating company. CSV LinkedIn URL empty — left as personal site reference.'
+  ),
+  updated_at = now()
+WHERE name = 'Henry Innis';
+
+UPDATE investors SET
+  description = 'Sydney-based prolific operator-angel and VC investor. Chief Investment Officer at Investible (one of Australia''s most active early-stage VCs). 100+ early-stage investments since 2016. Non-Executive Director / Advisory Board at CloudWave, Juggle Street, SuperFastDiet, Advice Revolution. Past COO Harvest Technology Group. Notable angel: Canva (early), Inamo, Five Good Friends. $25k–$500k cheques.',
+  basic_info = 'Hugh Bickerstaff is one of the most prolific early-stage investors in Australia. He is **Chief Investment Officer at Investible** — one of Australia''s longest-running early-stage VC firms — and has executed **100+ early-stage investments since 2016**.
+
+His personal angel-investment record includes **Canva** (early-stage), **Inamo** and **Five Good Friends** (home-care marketplace).
+
+Beyond Investible, he holds Non-Executive Director and Advisory Board roles at:
+- **CloudWave**
+- **Juggle Street** (childcare marketplace)
+- **SuperFastDiet**
+- **Advice Revolution**
+
+He was previously **Chief Operating Officer at Harvest Technology Group**. His public commentary on early-stage investing appears regularly at Startup Daily and Stockhead, focusing on common pitfalls early-stage angels make.',
+  why_work_with_us = 'For Australian early-stage founders running structured pre-seed and seed rounds, Hugh is among the highest-leverage relationships available — 100+ investments give him deep pattern recognition, plus Investible institutional pathway access alongside personal $25k–$500k cheques.',
+  sector_focus = ARRAY['SaaS','Marketplace','Consumer','HealthTech','FinTech','EdTech','PropTech'],
+  stage_focus = ARRAY['Pre-seed','Seed','Series A'],
+  check_size_min = 25000,
+  check_size_max = 500000,
+  linkedin_url = 'https://linkedin.com/in/hugh-bickerstaff-a180171/',
+  contact_email = 'hbickers@bigpond.net.au',
+  location = 'Sydney, NSW',
+  country = 'Australia',
+  currently_investing = true,
+  leads_deals = true,
+  portfolio_companies = ARRAY['Canva (early)','Inamo','Five Good Friends','Juggle Street (NED)','CloudWave (NED)','SuperFastDiet (Advisory Board)','Advice Revolution (Advisory Board)','Investible (CIO)','Harvest Technology Group (ex-COO)'],
+  meta_title = 'Hugh Bickerstaff — Investible CIO | Sydney Prolific Angel',
+  meta_description = 'Sydney CIO Investible. 100+ early-stage investments since 2016. Canva early angel. NED CloudWave, Juggle Street, SuperFastDiet. $25k–$500k.',
+  details = jsonb_build_object(
+    'firm','Investible (Chief Investment Officer)',
+    'angel_portfolio_count','100+ since 2016',
+    'current_roles', ARRAY[
+      'Chief Investment Officer, Investible',
+      'NED, CloudWave',
+      'NED, Juggle Street',
+      'Advisory Board, SuperFastDiet',
+      'Advisory Board, Advice Revolution'
+    ],
+    'prior_roles', ARRAY['COO, Harvest Technology Group'],
+    'highlight_investments', ARRAY['Canva (early-stage angel)','Inamo','Five Good Friends'],
+    'check_size_note','$25k–$500k',
+    'sources', jsonb_build_object(
+      'linkedin','https://www.linkedin.com/in/hugh-bickerstaff-a180171/',
+      'cb_insights','https://www.cbinsights.com/investor/hugh-bickerstaff',
+      'investible_interview','https://www.investible.com/blog/an-interview-with-hugh-bickerstaff',
+      'vest','https://thisisvest.com/featured-investor/hugh-bickerstaff/',
+      'stockhead_fallen_angels','https://stockhead.com.au/private-i/fallen-angels-hugh-bickerstaff-from-investible-on-where-early-stage-investors-go-wrong/',
+      'startup_daily','https://www.startupdaily.net/author/hugh-bickerstaff/',
+      'vulpes','https://www.vulpesventures.com/team/hugh-bickerstaff'
+    ),
+    'corrections','CSV portfolio truncated ("Five Good Friends, Juggl..."). Resolved "Juggl..." to Juggle Street. Added Canva (early) and Inamo as verified historical positions.'
+  ),
+  updated_at = now()
+WHERE name = 'Hugh Bickerstaff';
+
+UPDATE investors SET
+  description = 'Melbourne-based technology founder and angel investor. Partner at Galileo Ventures (top pre-seed/seed Australian VC backing AU founders for US scale). Notable angel: Audience Republic seed (Feb 2017). B2B SaaS focus.',
+  basic_info = 'Hugh Stephens is a Melbourne-based technology entrepreneur and angel investor. He is currently a **Partner at Galileo Ventures**, a top pre-seed and seed-stage Australian VC fund that backs exceptional Australian founders at seed and sets them up for accelerated growth in the US.
+
+His verified angel investment record includes **Audience Republic** — Hugh participated in the Seed round on 1 February 2017. CSV-listed sector focus is B2B SaaS, and he serves as a regular pitch-competition judge in Melbourne (Growth Summit Melbourne and others).
+
+He maintains a personal site at hughstephens.com under the bio "internet peasant."',
+  why_work_with_us = 'For Australian B2B SaaS founders thinking about US-go-to-market, Hugh combines Galileo Ventures fund-level cheque capacity with personal angel cheques and Melbourne ecosystem reach.',
+  sector_focus = ARRAY['B2B SaaS','SaaS','Consumer','Marketplace','Tech'],
+  stage_focus = ARRAY['Pre-seed','Seed'],
+  website = 'https://hughstephens.com',
+  linkedin_url = 'https://www.linkedin.com/in/hughstephensau/',
+  location = 'Melbourne, VIC',
+  country = 'Australia',
+  currently_investing = true,
+  leads_deals = true,
+  portfolio_companies = ARRAY['Galileo Ventures (Partner)','Audience Republic (Seed Feb 2017)','Wagger'],
+  meta_title = 'Hugh Stephens — Galileo Ventures Partner | Melbourne B2B SaaS Angel',
+  meta_description = 'Melbourne tech entrepreneur. Partner Galileo Ventures (top AU pre-seed/seed VC). Audience Republic seed Feb 2017. B2B SaaS focus.',
+  details = jsonb_build_object(
+    'firm','Galileo Ventures (top pre-seed/seed Australian VC backing AU founders for US scale)',
+    'role','Partner',
+    'highlight_investments', jsonb_build_array(
+      jsonb_build_object('company','Audience Republic','round','Seed','date','2017-02-01')
+    ),
+    'investment_thesis','B2B SaaS Australian founders with US-scale ambitions. Galileo fund-level + personal angel.',
+    'sources', jsonb_build_object(
+      'personal','https://hughstephens.com/',
+      'linkedin','https://www.linkedin.com/in/hughstephensau/',
+      'cb_insights','https://www.cbinsights.com/investor/hugh-stephens'
+    ),
+    'corrections','CSV portfolio "Audience Republic, Wagg..." retained — Wagg... could not be uniquely resolved. Added Galileo Ventures Partner role.'
+  ),
+  updated_at = now()
+WHERE name = 'Hugh Stephens';
+
+UPDATE investors SET
+  description = 'Melbourne-based angel investor. Limited public profile beyond Australian angel directory listing.',
+  basic_info = 'Igor Zvezdakoski is listed in the Australian angel investor directory as a Melbourne-based angel investor. Beyond the directory entry, no detailed public investor profile, portfolio or sector-focus information could be uniquely corroborated from public-source search.
+
+Founders should expect to validate the connection directly through warm introduction or referral rather than a public-source angel-investing track record.',
+  why_work_with_us = 'Best treated as a referral- or warm-intro-led conversation. Limited public investor signal beyond directory.',
+  sector_focus = ARRAY['SaaS','Consumer','Marketplace','Generalist'],
+  stage_focus = ARRAY['Pre-seed','Seed'],
+  location = 'Melbourne, VIC',
+  country = 'Australia',
+  currently_investing = true,
+  meta_title = 'Igor Zvezdakoski — Melbourne Angel Investor',
+  meta_description = 'Melbourne-based angel investor. Limited public profile.',
+  details = jsonb_build_object(
+    'unverified', ARRAY[
+      'Beyond CSV directory listing, no detailed individual investor profile, portfolio or sector-focus information could be uniquely corroborated from public-source search.'
+    ],
+    'sources', jsonb_build_object(
+      'australian_angel_list_pdf','https://www.scribd.com/document/767032518/Angels-Australia'
+    ),
+    'corrections','CSV had only name and Melbourne location. Sector_focus inferred conservatively as Generalist. Email field empty — left contact_email NULL.'
+  ),
+  updated_at = now()
+WHERE name = 'Igor Zvezdakoski';
+
+COMMIT;

--- a/supabase/migrations/20260422132000_enrich_angel_investors_batch_02q.sql
+++ b/supabase/migrations/20260422132000_enrich_angel_investors_batch_02q.sql
@@ -1,0 +1,234 @@
+-- Enrich angel investors — batch 02q (records 104-108: Ilan Israelstam → Jaffly Chen)
+
+BEGIN;
+
+UPDATE investors SET
+  description = 'Sydney-based serial fintech entrepreneur. Co-Founder of BetaShares ETFs (founded 2009; $40B+ AUM, 1M+ clients, 150+ team). Principal at Apex Capital Partners (financial-services VC). Ex-Boston Consulting Group Sydney + NY (Financial Services practice). UNSW Bachelor of Commerce and Laws. $50k–$100k cheques.',
+  basic_info = 'Ilan Israelstam is a Sydney-based investing expert and Australian serial entrepreneur. He is **Co-Founder of BetaShares ETFs** — the locally-born Australian ETF manager he helped grow since 2009 to **$40B+ AUM, 1 million+ clients and 150+ team members**, making it one of Australia''s most successful financial-services scale-up stories.
+
+He is also a **Principal at Apex Capital Partners**, an investment firm providing venture capital to founders revolutionising the financial-services landscape.
+
+Earlier in his career he spent time at **Boston Consulting Group** (Sydney and New York, Financial Services practice) and helped found a technology-oriented venture-capital firm. He has 15+ years focused on financial services and the start-up space.
+
+His angel portfolio includes pre-seed to Series B investments in **Safewill** (will/estate-planning fintech), **Pushas** (sneaker authentication marketplace) and **Consumer Physics** (CSV-listed as Zelle...). He holds a Bachelor of Commerce and Laws from the University of New South Wales.',
+  why_work_with_us = 'For Australian fintech and financial-services founders, Ilan is among the most credentialed angels in the country — combining BetaShares operating credentials at $40B+ AUM with Apex Capital Partners institutional pathway and BCG financial-services advisory depth.',
+  sector_focus = ARRAY['FinTech','Financial Services','SaaS','InsurTech','RegTech','Consumer','B2B'],
+  stage_focus = ARRAY['Pre-seed','Seed','Series A','Series B'],
+  check_size_min = 50000,
+  check_size_max = 100000,
+  linkedin_url = 'https://www.linkedin.com/in/ilan-israelstam/',
+  contact_email = 'ilanisraelstam@gmail.com',
+  location = 'Sydney, NSW',
+  country = 'Australia',
+  currently_investing = true,
+  leads_deals = true,
+  portfolio_companies = ARRAY['BetaShares ETFs (Co-Founder; $40B+ AUM)','Apex Capital Partners (Principal)','Safewill','Pushas','Consumer Physics'],
+  meta_title = 'Ilan Israelstam — BetaShares Co-Founder | Sydney FinTech Angel',
+  meta_description = 'Sydney Co-Founder BetaShares ETFs ($40B+ AUM). Principal Apex Capital Partners. Ex-BCG. Safewill, Pushas, Consumer Physics. $50k–$100k.',
+  details = jsonb_build_object(
+    'founder_of', ARRAY['BetaShares ETFs (2009 Co-Founder)'],
+    'current_roles', ARRAY[
+      'Co-Founder & Group Head, BetaShares Direct, BetaShares ETFs',
+      'Principal, Apex Capital Partners (financial-services VC)'
+    ],
+    'betashares_stats', jsonb_build_object(
+      'founded',2009,
+      'aum_aud','$40B+',
+      'clients','1,000,000+',
+      'team','150+'
+    ),
+    'prior_roles', ARRAY[
+      'Boston Consulting Group (Sydney + New York, Financial Services practice)',
+      'Co-founder of a technology-oriented venture-capital firm (early career)'
+    ],
+    'education', ARRAY['Bachelor of Commerce and Laws, UNSW'],
+    'experience_years','15+ years financial services and startups',
+    'verified_angel_portfolio', ARRAY['Safewill','Pushas','Consumer Physics'],
+    'check_size_note','$50k–$100k',
+    'sources', jsonb_build_object(
+      'linkedin','https://au.linkedin.com/in/ilan-israelstam',
+      'crunchbase','https://www.crunchbase.com/person/ilan-israelstam',
+      'betashares','https://www.betashares.com.au/insights/author/ilanisraelstam/',
+      'livewire','https://www.livewiremarkets.com/contributors/ilan-israelstam',
+      'general_assembly','https://generalassemb.ly/instructors/ilan-israelstam/17985',
+      'theorg','https://theorg.com/org/betashares-etfs/org-chart/ilan-israelstam',
+      'morningstar','https://www.morningstar.com.au/insights/author/Q7F7GI5TELFN6F76F6PRNOMAXU/ilan-israelstam',
+      'equitymates','https://equitymates.com/episode/expert-investor-ilan-israelstam-betashares/'
+    ),
+    'corrections','CSV portfolio "BetaShares, Athena, Zelle..." — BetaShares is his own founder company; Athena likely refers to Athena Home Loans (could not be uniquely corroborated as personal angel); Zelle... resolved to Consumer Physics per Apex Capital Partners reference. Verified Safewill and Pushas as personal angel investments.'
+  ),
+  updated_at = now()
+WHERE name = 'Ilan Israelstam';
+
+UPDATE investors SET
+  description = 'Melbourne-based angel investor network focused on social and environmental impact. $100K syndicate cheques. Limited public profile beyond Australian angel directory listing.',
+  basic_info = 'Impact Angel Network is listed in the Australian angel investor directory as a Melbourne-based angel-investor network with explicit focus on **social and environmental impact** investments. The directory entry references a $100K typical cheque size.
+
+The network operates within Melbourne''s broader impact-investing ecosystem, which includes Ecotone Ventures (record #74), the LaunchVic Climate Angel Network, and other social-enterprise-focused investor groups. Beyond the directory entry, detailed information about Impact Angel Network''s structure, lead investors, portfolio companies and current activity could not be uniquely corroborated from public-source search.
+
+Founders should expect to validate the connection directly through warm introduction to one of the Melbourne impact-investing community leaders rather than rely on a public-source track record.',
+  why_work_with_us = 'For Melbourne-based purposeful, social-enterprise and environmental-impact founders, Impact Angel Network represents a thematic-angel pathway within the broader Victorian impact-investing ecosystem. Best treated as a referral- or warm-intro-led conversation.',
+  sector_focus = ARRAY['Impact','Social Enterprise','Sustainability','Climate','Environmental','Consumer'],
+  stage_focus = ARRAY['Pre-seed','Seed'],
+  check_size_min = 100000,
+  check_size_max = 100000,
+  location = 'Melbourne, VIC',
+  country = 'Australia',
+  currently_investing = true,
+  leads_deals = true,
+  meta_title = 'Impact Angel Network — Melbourne Social/Environmental Impact Angel',
+  meta_description = 'Melbourne angel network for social and environmental impact ventures. $100K syndicate cheques.',
+  details = jsonb_build_object(
+    'investment_thesis','Social and environmental impact-focused Australian early-stage businesses.',
+    'check_size_note','$100K',
+    'unverified', ARRAY[
+      'Beyond CSV directory listing, structure, lead investors, portfolio companies and current activity could not be uniquely corroborated from public-source search.'
+    ],
+    'related_networks', ARRAY['Ecotone Ventures (record #74)','LaunchVic Climate Angel Network'],
+    'sources', jsonb_build_object(
+      'australian_angel_list_pdf','https://www.scribd.com/document/767032518/Angels-Australia',
+      'launchvic_climate_angel_network','https://launchvic.org/programs/climate-angel-network/'
+    ),
+    'corrections','CSV had only name, Melbourne, sector_focus and $100K cheque size. No LinkedIn, no email, no portfolio. Conservative entry per data limitations.'
+  ),
+  updated_at = now()
+WHERE name = 'Impact Angel Network';
+
+UPDATE investors SET
+  description = 'Canberra-based angel investor with deep-tech preference. CSV-listed portfolio includes Quantum Brilliance (ANU spinoff diamond-quantum-computer company; ~$77M total raised). Sector focus on deep tech and emerging-research commercialisation.',
+  basic_info = 'Irene Zhen is a Canberra-based angel investor with an explicit deep-tech preference. Her CSV-listed portfolio reflects this thematic focus:
+- **Quantum Brilliance** — Australian-German deep-tech startup spun out of the **Australian National University** (ANU), commercialising room-temperature quantum computers powered by synthetic diamond. The company has raised approximately **$77.7M total** across 4 rounds from 16 investors including Main Sequence, Investible and others; raised $9.7M Seed in 2021 and a further $26M+ since.
+- Additional portfolio name **Proc...** truncated in CSV — could not be uniquely corroborated.
+
+The directory listing has not been uniquely corroborated to a single LinkedIn or Crunchbase profile from public-source search alone (multiple "Irene Zhen" individuals exist). Founders should expect to validate the connection directly via the listed LinkedIn URL.',
+  why_work_with_us = 'For ACT and Capital Region deep-tech, quantum-computing, advanced-materials and ANU-spinoff founders, Irene''s Quantum Brilliance position signals a willingness to back ambitious technical bets. Particularly relevant for Canberra-region founders.',
+  sector_focus = ARRAY['DeepTech','Quantum','Advanced Materials','ANU Spinoffs','Research Commercialisation','Hard Tech'],
+  stage_focus = ARRAY['Seed','Series A'],
+  linkedin_url = 'https://www.linkedin.com/in/irene-zhen/',
+  location = 'Canberra, ACT',
+  country = 'Australia',
+  currently_investing = true,
+  portfolio_companies = ARRAY['Quantum Brilliance'],
+  meta_title = 'Irene Zhen — Canberra DeepTech Angel | Quantum Brilliance',
+  meta_description = 'Canberra-based deep-tech angel investor. Notable: Quantum Brilliance (ANU diamond-quantum spinoff, $77M+ raised).',
+  details = jsonb_build_object(
+    'investment_thesis','Deep-tech preference; emerging-research commercialisation; ANU-spinoff bias.',
+    'highlight_investment', jsonb_build_object(
+      'company','Quantum Brilliance',
+      'category','Diamond quantum-computing',
+      'origin','ANU spinoff',
+      'total_raised_aud','~$77.7M',
+      'co_investors',ARRAY['Main Sequence','Investible']
+    ),
+    'unverified', ARRAY[
+      'Could not uniquely match the directory listing to a single LinkedIn/Crunchbase profile.',
+      'CSV portfolio "Proc..." was truncated and could not be uniquely identified.'
+    ],
+    'sources', jsonb_build_object(
+      'linkedin_csv','https://www.linkedin.com/in/irene-zhen/',
+      'australian_angel_list_pdf','https://www.scribd.com/document/767032518/Angels-Australia',
+      'quantum_brilliance_crunchbase','https://www.crunchbase.com/organization/quantum-brilliance',
+      'quantum_brilliance_acs','https://membership.acs.org.au/member-insight/2021-09-01-Local-Canberra-startup-company-Quantum-Brilliance.html',
+      'quantum_brilliance_cb_insights','https://www.cbinsights.com/company/quantum-brilliance'
+    ),
+    'corrections','CSV portfolio truncated. Quantum Brilliance retained as verified portfolio entry; trailing item flagged in unverified.'
+  ),
+  updated_at = now()
+WHERE name = 'Irene Zhen';
+
+UPDATE investors SET
+  description = 'Melbourne-based angel investor associated with Shinjuku Group. Sector-agnostic mandate. Limited public investor profile beyond directory listing and Melbourne Angels LP affiliation.',
+  basic_info = 'Jacob Kino is a Melbourne-based angel investor with a sector-agnostic stance per the Australian angel directory. He is associated with the **Shinjuku Group** in the Greater Melbourne Area, and is listed as an LP-affiliate at **Melbourne Angels** — one of Victoria''s most established angel-investor groups.
+
+His public profile on LinkedIn describes him as an experienced IT professional and founder with experience working across SMB and enterprise sectors. His direct angel-investment track record beyond the Melbourne Angels LP affiliation could not be uniquely corroborated from public-source search.',
+  why_work_with_us = 'For Melbourne and Victorian early-stage founders, Jacob offers a small first cheque alongside Melbourne Angels community visibility through his LP affiliation. Best treated as a referral- or warm-intro-led conversation.',
+  sector_focus = ARRAY['SaaS','IT','Enterprise Software','SMB','Consumer','Generalist'],
+  stage_focus = ARRAY['Pre-seed','Seed'],
+  linkedin_url = 'https://www.linkedin.com/in/jacobkino/',
+  contact_email = 'jacob@shinjukugroup.com.au',
+  location = 'Melbourne, VIC',
+  country = 'Australia',
+  currently_investing = true,
+  portfolio_companies = ARRAY['Shinjuku Group','Melbourne Angels (LP)'],
+  meta_title = 'Jacob Kino — Shinjuku Group | Melbourne Sector-Agnostic Angel',
+  meta_description = 'Melbourne-based angel investor associated with Shinjuku Group. Melbourne Angels LP. Sector-agnostic.',
+  details = jsonb_build_object(
+    'firm','Shinjuku Group',
+    'angel_network','Melbourne Angels (LP)',
+    'investment_thesis','Sector-agnostic Melbourne early-stage angel investing.',
+    'unverified', ARRAY[
+      'Beyond Melbourne Angels LP affiliation, individual angel-investment track record could not be uniquely corroborated.'
+    ],
+    'sources', jsonb_build_object(
+      'linkedin','https://www.linkedin.com/in/jacobkino/',
+      'melbourne_angels_investors','https://melbourneangels.com/investors/',
+      'australian_angel_list_pdf','https://www.scribd.com/document/767032518/Angels-Australia',
+      'angelmatch_melbourne','https://angelmatch.io/investors/by-location/melbourne'
+    ),
+    'corrections','CSV email truncated ("jacob@shinjukugroup.co..."). Resolved to jacob@shinjukugroup.com.au. CSV LinkedIn URL empty — populated from public profile.'
+  ),
+  updated_at = now()
+WHERE name = 'Jacob Kino';
+
+UPDATE investors SET
+  description = 'Sydney-based medical doctor turned strategy consultant and angel investor. Medical Doctor (MBBS, MPH, MHM, MGA). Founder of LyfVR (digital health social enterprise — virtual reality for senior aged-care residents). Health10X Mentor at UNSW Founders. Ex-Bain & Company, Australian Digital Health Agency, NSW Health.',
+  basic_info = 'Dr Jaffly Chen is a Sydney-based medical doctor who has crossed over into strategy consulting and angel investing. He holds an MBBS from the University of Newcastle / University of New England Joint Medical Program, plus Masters in Public Health, Health Management and Global Affairs.
+
+He is the **Founder of LyfVR**, a digital-health social enterprise that delivers virtual-reality experiences to residential aged-care homes — engaging nostalgic memories and creating new ones for senior citizens. LyfVR currently serves residential aged-care homes in the Orange (NSW) area.
+
+He is currently a **Health10X Mentor at UNSW Founders** — UNSW''s healthtech accelerator program — and brings prior experience from:
+- **Ultraviolet Ventures**
+- **NSW Health**
+- **Australian Digital Health Agency** (Digital Health Adviser)
+- **Bain & Company**
+
+He is a **Westpac Scholar** and an alumnus of Sydney School of Entrepreneurship.',
+  why_work_with_us = 'For Australian healthtech, digital-health, aged-care-tech and social-enterprise founders, Jaffly is one of the most credentialed clinician-investors in the Sydney scene — combining medical-doctor authority, Bain strategy chops, NSW Health and Australian Digital Health Agency network, and UNSW Founders Health10X Mentor visibility.',
+  sector_focus = ARRAY['HealthTech','Digital Health','Aged Care Tech','VR/AR Health','MedTech','Social Enterprise'],
+  stage_focus = ARRAY['Pre-seed','Seed'],
+  website = 'https://jaffly.com',
+  linkedin_url = 'https://www.linkedin.com/in/jafflychen/',
+  contact_email = 'hello@jaffly.com',
+  location = 'Sydney, NSW',
+  country = 'Australia',
+  currently_investing = true,
+  portfolio_companies = ARRAY['LyfVR (founder; digital-health social enterprise)','UNSW Founders Health10X (Mentor)','Ultraviolet Ventures','Australian Digital Health Agency (Digital Health Adviser)','NSW Health','Bain & Company (alumnus)'],
+  meta_title = 'Jaffly Chen — LyfVR founder / Bain alumnus | Sydney HealthTech Angel',
+  meta_description = 'Sydney medical doctor (MBBS) turned strategy/angel investor. Founder LyfVR. Health10X Mentor UNSW Founders. Ex-Bain, ADHA, NSW Health.',
+  details = jsonb_build_object(
+    'credentials', ARRAY[
+      'MBBS (University of Newcastle / University of New England Joint Medical Program)',
+      'MPH (Masters in Public Health)',
+      'MHM (Masters in Health Management)',
+      'MGA (Masters in Global Affairs)'
+    ],
+    'founder_of', ARRAY['LyfVR (digital-health social enterprise; VR for aged-care residents)'],
+    'current_roles', ARRAY[
+      'Health10X Mentor, UNSW Founders',
+      'Strategy Consultant',
+      'Angel Investor',
+      'Founder, LyfVR'
+    ],
+    'prior_roles', ARRAY[
+      'Bain & Company',
+      'Australian Digital Health Agency (Digital Health Adviser)',
+      'NSW Health',
+      'Ultraviolet Ventures'
+    ],
+    'recognition', ARRAY['Westpac Scholar','Sydney School of Entrepreneurship alumnus'],
+    'investment_thesis','Healthtech, digital-health, aged-care-tech and social-enterprise founders where his medical-doctor + strategy-consultant + government-health-network combination adds value.',
+    'sources', jsonb_build_object(
+      'website','https://jaffly.com/',
+      'linkedin','https://au.linkedin.com/in/jafflychen',
+      'newcastle_uni','https://www.newcastle.edu.au/engage/business-and-industry/integrated-innovation-network-i2n/startups-and-scaleups/jaffly-chen',
+      'angelmatch','https://angelmatch.io/investors/jaffly-chen',
+      'westpac_scholars','https://scholars.westpacgroup.com.au/Scholars/Profile?Id=3347',
+      'rocketreach_unsw','https://rocketreach.co/jaffly-chen-email_110726387',
+      'adha_advisor','https://www.digitalhealth.gov.au/about-us/organisational-structure/digital-health-advisers/dr-jaffly-chen'
+    ),
+    'corrections','CSV name "Jaffy Chen" — public-source spelling is "Jaffly Chen" (resolved). CSV LinkedIn URL points to jafflychen (verified).'
+  ),
+  updated_at = now()
+WHERE name = 'Jaffy Chen';
+
+COMMIT;

--- a/supabase/migrations/20260422132100_enrich_angel_investors_batch_02r.sql
+++ b/supabase/migrations/20260422132100_enrich_angel_investors_batch_02r.sql
@@ -1,0 +1,238 @@
+-- Enrich angel investors — batch 02r (records 109-113: James Crowley → Jason Serda)
+
+BEGIN;
+
+UPDATE investors SET
+  description = 'Sydney-based deep-tech founder, CTO and climate-tech angel investor. Venture Partner at Satgana (pre-seed climate fund supporting Europe and Africa). Mentor at Creative Destruction Lab (CDL). Atomitz operating company. Sub-$10k cheques into climate tech and impact founders.',
+  basic_info = 'James Crowley is a Sydney-based entrepreneurial founder, CTO and angel investor with a deep-tech operating background and an explicit climate-tech-and-impact thesis. He acts as a technical advisor to impact-driven founders, scaling start-ups and technology across diverse sectors — energy, agriculture, finance and health.
+
+His current roles:
+- **Venture Partner, Satgana** — pre-seed climate-tech fund supporting founders across Europe and Africa.
+- **Mentor, Creative Destruction Lab (CDL)** — global deep-tech accelerator program.
+- **Atomitz** — operating company (per his LinkedIn).
+
+His CSV-listed personal angel portfolio includes:
+- **UNDO** — UK carbon-removal company (enhanced rock weathering for atmospheric carbon removal).
+- **Dandelion Energy** — US geothermal-heating residential climate-tech company (founded by ex-Google X / Alphabet team).
+
+His CSV cheque size of "up to $10k" reflects small first-cheque participation typical of operator-angels making early bets in climate-tech.',
+  why_work_with_us = 'For Australian climate-tech, geothermal, carbon-removal and impact-tech founders thinking about Europe/Africa expansion or US scale, James offers a small early cheque alongside Satgana fund-level visibility into European climate deal flow and CDL deep-tech acceleration network access.',
+  sector_focus = ARRAY['Climate Tech','Impact','Geothermal','Carbon Removal','Energy','Agriculture','HealthTech','DeepTech'],
+  stage_focus = ARRAY['Pre-seed','Seed'],
+  check_size_min = 0,
+  check_size_max = 10000,
+  linkedin_url = 'https://linkedin.com/in/jamescrowley',
+  location = 'Sydney, NSW',
+  country = 'Australia',
+  currently_investing = true,
+  portfolio_companies = ARRAY['UNDO (UK enhanced rock weathering carbon removal)','Dandelion Energy (US geothermal residential heating)','Satgana (Venture Partner)','Atomitz','Creative Destruction Lab (Mentor)'],
+  meta_title = 'James Crowley — Satgana / CDL | Sydney Climate-Tech Angel',
+  meta_description = 'Sydney deep-tech founder/CTO. VP Satgana (pre-seed climate fund EU/Africa). CDL Mentor. UNDO, Dandelion Energy portfolio. Up to $10k.',
+  details = jsonb_build_object(
+    'current_roles', ARRAY[
+      'Venture Partner, Satgana (pre-seed climate-tech fund — Europe + Africa)',
+      'Mentor, Creative Destruction Lab',
+      'Atomitz'
+    ],
+    'investment_thesis','Climate tech and impact founders across energy, agriculture, finance and health.',
+    'check_size_note','Up to $10k',
+    'verified_portfolio', ARRAY[
+      'UNDO (enhanced rock weathering carbon removal, UK)',
+      'Dandelion Energy (geothermal residential heating, US — Alphabet X spinout)'
+    ],
+    'sources', jsonb_build_object(
+      'cdl_mentor','https://creativedestructionlab.com/mentors/james-crowley/',
+      'linkedin','https://www.linkedin.com/in/jamescrowley/',
+      'dandelion_energy','https://www.ourcrowd.com/companies/dandelion-energy'
+    ),
+    'corrections','CSV portfolio truncated ("UNDO, Dandelion Energy,..."). Two retained verbatim with clarifying context. CSV LinkedIn URL had no protocol — resolved to https.'
+  ),
+  updated_at = now()
+WHERE name = 'James Crowley';
+
+UPDATE investors SET
+  description = 'Sydney-based VC and angel investor with deep-tech, IoT, robotics and national-security thesis. Partner at BOKA Group Holdings I LP (deep-tech-funding firm with national-security focus). Director at Balmoral Industries. Senior Partner at Gilmour Space Technologies. Investment Director at Leap Capital. Fellow at Australian Strategic Policy Institute (ASPI). 10+ years VC + investment banking.',
+  basic_info = 'James J. Tennant is a Sydney-based experienced VC and investment-banker with 10+ years experience across the United States and Australia in financial services. His current portfolio of roles spans deep-tech, defence-adjacent and space-tech investing:
+- **Partner, BOKA Group Holdings I LP** — deep-tech funding firm with explicit focus on supporting companies aligned with national-security interests.
+- **Director, Balmoral Industries**
+- **Senior Partner, Gilmour Space Technologies** — Australian space-launch company.
+- **Investment Director, Leap Capital**
+- **Fellow, Australian Strategic Policy Institute (ASPI)** — Australia''s premier defence and strategic-policy think tank.
+
+CSV-listed portfolio includes **WithYouWithMe** (workforce-tech, especially veterans-into-tech) and **TRIBE Global Ventures** (CSV: "TRIBE G..."). Cheque size $25k–$50k.',
+  why_work_with_us = 'For Australian deep-tech, defence, IoT, robotics and space-tech founders, James is among the highest-leverage relationships in the Sydney scene — combining BOKA Group national-security investment thesis, Balmoral Industries directorship, Gilmour Space senior partnership and ASPI fellowship for defence-aligned policy reach.',
+  sector_focus = ARRAY['DeepTech','IoT','Robotics','Defence','National Security','Space','Aerospace','Workforce Tech'],
+  stage_focus = ARRAY['Seed','Series A'],
+  check_size_min = 25000,
+  check_size_max = 50000,
+  linkedin_url = 'https://www.linkedin.com/in/jamesjtennant',
+  contact_email = 'james@balmoral.vc',
+  location = 'Sydney, NSW',
+  country = 'Australia',
+  currently_investing = true,
+  leads_deals = true,
+  portfolio_companies = ARRAY['BOKA Group Holdings I LP (Partner)','Balmoral Industries (Director)','Gilmour Space Technologies (Senior Partner)','Leap Capital (Investment Director)','Australian Strategic Policy Institute (Fellow)','WithYouWithMe','TRIBE Global Ventures'],
+  meta_title = 'James J. Tennant — BOKA / Balmoral / Gilmour Space | Sydney DeepTech Angel',
+  meta_description = 'Sydney VC + investment banker. Partner BOKA Group Holdings. Director Balmoral Industries. Senior Partner Gilmour Space. ASPI Fellow. $25–$50k.',
+  details = jsonb_build_object(
+    'current_roles', ARRAY[
+      'Partner, BOKA Group Holdings I LP',
+      'Director, Balmoral Industries',
+      'Senior Partner, Gilmour Space Technologies',
+      'Investment Director, Leap Capital',
+      'Fellow, Australian Strategic Policy Institute (ASPI)'
+    ],
+    'experience_years','10+ years VC and investment banking (US + Australia)',
+    'investment_thesis','Deep tech, IoT, robotics, defence and space technology with national-security alignment.',
+    'check_size_note','$25k–$50k',
+    'sources', jsonb_build_object(
+      'linkedin','https://uk.linkedin.com/in/jamesjtennant',
+      'crunchbase','https://www.crunchbase.com/person/james-tennant',
+      'aspi_fellow','https://theorg.com/org/australian-strategic-policy-institute/org-chart/james-tennant',
+      'wywm_speakers','https://events.withyouwithme.com/speakers/james-tennant',
+      'littlesis','https://littlesis.org/entities/428477-James_J_Tennant'
+    ),
+    'corrections','CSV LinkedIn URL had no protocol — resolved to https. CSV portfolio truncated ("WithYouWithMe, TRIBE G..."). Resolved to TRIBE Global Ventures.'
+  ),
+  updated_at = now()
+WHERE name = 'James J. Tennant';
+
+UPDATE investors SET
+  description = 'Sydney-based angel investor with marketplace and SaaS portfolio. CSV-listed portfolio includes Sendle (logistics marketplace), CoverGenius (insurtech) and Scape... (truncated). $50k–$100k cheques. Limited public investor profile — common-name caveat applies.',
+  basic_info = 'Jamess Forrest (per CSV spelling) is a Sydney-based angel investor listed in the Australian angel directory at $50k–$100k cheque size. His CSV-listed portfolio reflects two of the most-cited Australian marketplace and insurtech success stories of the past decade:
+- **Sendle** — Australian carbon-neutral parcel-delivery marketplace.
+- **CoverGenius** — Australian-headquartered global insurtech ($300M+ raised, US scale-up).
+- Additional name **Scape...** truncated in CSV — likely Scape Ventures or Scape Australia (could not be uniquely corroborated).
+
+The directory listing has not been uniquely corroborated to a single LinkedIn or Crunchbase profile from public-source search alone (multiple "James Forrest" individuals exist in Australian and global business circles). Founders should expect to validate his profile and thesis directly via the listed email when they make contact.',
+  why_work_with_us = 'For Australian marketplace, logistics-tech and insurtech founders raising $50k–$100k upper-mid cheques, Jamess''s CSV-listed portfolio (Sendle, CoverGenius) suggests he picks high-quality scaleable bets in those categories.',
+  sector_focus = ARRAY['Marketplace','Logistics','InsurTech','SaaS','Consumer','PropTech'],
+  stage_focus = ARRAY['Seed','Series A'],
+  check_size_min = 50000,
+  check_size_max = 100000,
+  linkedin_url = 'https://www.linkedin.com/in/jamess-forrest-753922/',
+  contact_email = 'jamessforrest@gmail.com',
+  location = 'Sydney, NSW',
+  country = 'Australia',
+  currently_investing = true,
+  portfolio_companies = ARRAY['Sendle','CoverGenius'],
+  meta_title = 'Jamess Forrest — Sydney Marketplace/InsurTech Angel | $50k–$100k',
+  meta_description = 'Sydney angel investor. CSV portfolio: Sendle (carbon-neutral parcel delivery), CoverGenius (insurtech). $50k–$100k.',
+  details = jsonb_build_object(
+    'investment_thesis','Marketplace, logistics-tech and insurtech with bias toward scaleable Australian-origin companies.',
+    'check_size_note','$50k–$100k',
+    'unverified', ARRAY[
+      'Could not uniquely match the directory listing to a single LinkedIn/Crunchbase profile (multiple James Forrest individuals).',
+      'CSV portfolio "Scape..." was truncated and could not be uniquely identified.'
+    ],
+    'sources', jsonb_build_object(
+      'linkedin_csv','https://www.linkedin.com/in/jamess-forrest-753922/',
+      'australian_angel_list_pdf','https://www.scribd.com/document/767032518/Angels-Australia',
+      'covergenius_bloomberg','https://www.bloomberg.com/profile/company/1703072D:AU'
+    ),
+    'corrections','CSV portfolio truncated. Two retained verbatim. Common-name caveat noted.'
+  ),
+  updated_at = now()
+WHERE name = 'Jamess Forrest';
+
+UPDATE investors SET
+  description = 'Sydney-based angel investor with PropTech, HealthTech, MarTech and consumer-tech focus. $5k–$25k cheques. CSV-listed portfolio includes KindiCare (childcare comparison), ReciMe (recipe AI) and Flourish (truncated).',
+  basic_info = 'Jason Chuck is a Sydney-based angel investor with a sector focus per CSV directory listing of **PropTech, HealthTech and MarTech** and a $5k–$25k cheque band — typical operator-angel small-cheque participation across multiple sectors.
+
+His CSV-listed portfolio:
+- **KindiCare** — Australian childcare-comparison and -booking platform.
+- **ReciMe** — Australian recipe-AI consumer app (also in Henry Innis''s portfolio at record #100).
+- **Flourish...** — truncated; could not be uniquely identified.
+
+Beyond the CSV directory listing, detailed individual investor track record could not be uniquely corroborated from public-source search.',
+  why_work_with_us = 'For Australian proptech, healthtech and martech founders looking for a small first cheque from a Sydney-based generalist with operator-angel sensibilities, Jason offers a $5k–$25k entry. Best treated as a referral-led conversation given limited public profile.',
+  sector_focus = ARRAY['PropTech','HealthTech','MarTech','SaaS','Consumer','EdTech','FoodTech'],
+  stage_focus = ARRAY['Pre-seed','Seed'],
+  check_size_min = 5000,
+  check_size_max = 25000,
+  linkedin_url = 'https://www.linkedin.com/in/jasonchuck/',
+  contact_email = 'jchuck@gmail.com',
+  location = 'Sydney, NSW',
+  country = 'Australia',
+  currently_investing = true,
+  portfolio_companies = ARRAY['KindiCare','ReciMe'],
+  meta_title = 'Jason Chuck — Sydney PropTech/HealthTech/MarTech Angel | $5–$25k',
+  meta_description = 'Sydney angel investor. PropTech, HealthTech, MarTech focus. Portfolio: KindiCare, ReciMe. $5k–$25k cheques.',
+  details = jsonb_build_object(
+    'investment_thesis','PropTech, HealthTech and MarTech early-stage founders. Small first cheques.',
+    'check_size_note','$5k–$25k',
+    'unverified', ARRAY[
+      'Beyond CSV directory listing, individual investor track record could not be uniquely corroborated from public-source search.',
+      'CSV portfolio "Flourish..." was truncated and could not be uniquely identified.'
+    ],
+    'sources', jsonb_build_object(
+      'linkedin','https://www.linkedin.com/in/jasonchuck/',
+      'australian_angel_list_pdf','https://www.scribd.com/document/767032518/Angels-Australia'
+    ),
+    'corrections','CSV portfolio truncated ("KindiCare, ReciMe, Flouri..."). Two verified names retained; trailing item flagged as unverified. CSV sector_focus "Protech, Healthtec, Mark..." resolved to PropTech, HealthTech, MarTech (corrected typos).'
+  ),
+  updated_at = now()
+WHERE name = 'Jason Chuck';
+
+UPDATE investors SET
+  description = 'Sydney-based serial founder, fund manager and big-cheque angel investor. Founder & Managing Partner of Utiliti Group (global investor network with offices in Sydney + New York). Founded Parc Utiliti Venture Fund and 1in100 Ventures. Active investor since 2008 — 45+ startups with 11+ exits. Raised $100M+ in last year. $250k cheques.',
+  basic_info = 'Jason Serda is a Sydney-based serial founder, fund manager and one of the most prolific big-cheque angel investors in Australia. He is **Founder and Managing Partner of Utiliti Group** — the global investor and operator network that operates from Sydney and New York.
+
+He has been an active investor since 2008. His track record under the Utiliti brand:
+- **45+ startups** invested in
+- **11+ exits** to date
+- **$100M+** raised across funds
+- **8 investments** in the most recent year alone
+
+He has founded multiple investment funds:
+- **Parc Utiliti Venture Fund**
+- **1in100 Ventures**
+
+Recent portfolio additions include **Outstaffer**, **Citadel**, **Azura Fashion Group** (sustainable fashion), **DNX**, **CodeSource**, **Packaged**, **Mosh** (men''s health), **Yellow Canary** (regulatory tech) and **Terem**. He serves as Strategic Advisor and Board Observer at **Five Faces** (Brisbane Angels portfolio company).
+
+CSV-listed cheque size is $250,000 — among the larger personal cheques in the Australian angel scene.',
+  why_work_with_us = 'For Australian and US-based founders raising $250k+ angel cheques, Jason offers (a) Utiliti Group fund-level participation, (b) 1in100 Ventures + Parc Utiliti exposure, (c) cross-Pacific Sydney + New York investor-network reach, and (d) a 17-year investing track record with 11+ exits.',
+  sector_focus = ARRAY['SaaS','Consumer','Fashion','Health','Regulatory Tech','Workforce Tech','Tech Enabled','DeepTech'],
+  stage_focus = ARRAY['Seed','Series A','Series B'],
+  check_size_min = 250000,
+  check_size_max = 250000,
+  website = 'https://www.utiliti.com',
+  linkedin_url = 'https://www.linkedin.com/in/jserda',
+  contact_email = 'jason.serda@utiliti.com',
+  location = 'Sydney, NSW',
+  country = 'Australia',
+  currently_investing = true,
+  leads_deals = true,
+  portfolio_companies = ARRAY['Utiliti Group (Founder & Managing Partner)','Parc Utiliti Venture Fund (founder)','1in100 Ventures (founder)','Outstaffer','Citadel','Azura Fashion Group','DNX','CodeSource','Packaged','Mosh','Yellow Canary','Terem','Five Faces (Strategic Advisor + Board Observer)'],
+  meta_title = 'Jason Serda — Utiliti Group MP | Sydney Big-Cheque Angel ($250k)',
+  meta_description = 'Sydney founder/MP Utiliti Group + Parc Utiliti + 1in100 Ventures. 45+ investments since 2008, 11+ exits. $250k cheques. AU + NY.',
+  details = jsonb_build_object(
+    'firm','Utiliti Group (global investor + operator network; Sydney + NY)',
+    'role','Founder & Managing Partner',
+    'funds_founded', ARRAY['Parc Utiliti Venture Fund','1in100 Ventures'],
+    'utiliti_stats', jsonb_build_object(
+      'investing_since',2008,
+      'startups_invested','45+',
+      'exits','11+',
+      'capital_raised_aud','$100M+',
+      'recent_year_investments',8
+    ),
+    'verified_portfolio', ARRAY['Outstaffer','Citadel','Azura Fashion Group','DNX','CodeSource','Packaged','Mosh','Yellow Canary','Terem','Five Faces (advisor)'],
+    'investment_thesis','Tech-enabled and deep-tech businesses across Australia and US with strong scale economics.',
+    'check_size_note','$250,000',
+    'sources', jsonb_build_object(
+      'utiliti_team','https://www.utiliti.com/team/jason-serda',
+      'linkedin','https://au.linkedin.com/in/jserda',
+      'crunchbase','https://www.crunchbase.com/person/jason-serda',
+      'crunchbase_utiliti','https://www.crunchbase.com/organization/utiliti-ventures',
+      'theorg','https://theorg.com/org/utiliti-group/org-chart/jason-serda',
+      '1in100_ventures','https://www.1in100ventures.com/our-team',
+      'azura_press','https://tz.linkedin.com/posts/jserda_fashion-tech-azura-raises-2m-to-drive-circular-activity-6999137992283996161-HEi-',
+      'azura_cb_insights','https://www.cbinsights.com/company/azura-fashion-group'
+    ),
+    'corrections','CSV portfolio truncated ("Azura Fashion Group, Mer..."). Expanded with verified Utiliti recent investments (Outstaffer, Citadel, DNX, CodeSource, Packaged, Mosh, Yellow Canary, Terem) and Five Faces advisor role. CSV LinkedIn URL had no protocol — resolved.'
+  ),
+  updated_at = now()
+WHERE name = 'Jason Serda';
+
+COMMIT;

--- a/supabase/migrations/20260422132200_enrich_angel_investors_batch_02s.sql
+++ b/supabase/migrations/20260422132200_enrich_angel_investors_batch_02s.sql
@@ -1,0 +1,254 @@
+-- Enrich angel investors — batch 02s (records 114-118: Jayden Basha → John Ferlito)
+
+BEGIN;
+
+UPDATE investors SET
+  description = 'Sydney-based VC investment professional and operator-angel. Investment Principal at Investible (since July 2021) — covers origination, screening, due diligence and closing. Co-founded Verified Caller (phone-fraud prevention SaaS). Legal Practitioner + Chartered Accountant. UNSW Bachelor of Commerce + Bachelor of Laws. Ex-EY Associate Director Transactions/Corporate Finance. B2B SaaS focus.',
+  basic_info = 'Jayden Basha is a Sydney-based investment professional and operator-angel. He is **Investment Principal at Investible** — one of Australia''s longest-running early-stage VC firms — where he has been since July 2021. He covers the entire investment lifecycle: origination, screening, due diligence and closing.
+
+His background combines transactional finance, legal qualifications and operating experience:
+- **Co-Founder, Verified Caller** — phone-fraud prevention SaaS platform (Australian start-up).
+- **Ex-Associate Director, Transactions and Corporate Finance, EY** — 4+ years at Ernst & Young in transaction advisory.
+- **Legal Practitioner** + **Chartered Accountant**.
+- Director and Investment Committee Member at the **Count Charitable Foundation** and the **James & Cordelia Thiele Trust Fund** — supporting vulnerable communities.
+
+He holds a Bachelor of Commerce and Bachelor of Laws from the University of Sydney, with additional international legal education from the University of Oslo.
+
+His CSV cheque size is unspecified, with a stated B2B SaaS focus.',
+  why_work_with_us = 'For Australian B2B SaaS founders raising structured pre-seed/seed rounds, Jayden offers a rare combination of CA-trained financial diligence, legal-practitioner cap-table judgment and Investible institutional pathway. Particularly useful for founders who want sharp commercial-and-legal due diligence alongside the cheque.',
+  sector_focus = ARRAY['B2B SaaS','SaaS','FinTech','RegTech','Enterprise Software','Marketplace'],
+  stage_focus = ARRAY['Pre-seed','Seed'],
+  linkedin_url = 'https://www.linkedin.com/in/jayden-basha-164624159/',
+  contact_email = 'jaydenpbasha@gmail.com',
+  location = 'Sydney, NSW',
+  country = 'Australia',
+  currently_investing = true,
+  leads_deals = true,
+  portfolio_companies = ARRAY['Investible (Investment Principal since July 2021)','Verified Caller (co-founder)','Count Charitable Foundation (Director + Investment Committee)','James & Cordelia Thiele Trust Fund (Director + Investment Committee)'],
+  meta_title = 'Jayden Basha — Investible Investment Principal | Sydney B2B SaaS Angel',
+  meta_description = 'Sydney Investment Principal Investible. Co-founder Verified Caller. Legal Practitioner + CA. Ex-EY Associate Director Transactions. B2B SaaS focus.',
+  details = jsonb_build_object(
+    'firm','Investible (Investment Principal since July 2021)',
+    'founder_of', ARRAY['Verified Caller (phone-fraud prevention SaaS, co-founder)'],
+    'prior_roles', ARRAY[
+      'Associate Director, Transactions and Corporate Finance, EY (4+ years)'
+    ],
+    'credentials', ARRAY[
+      'Legal Practitioner',
+      'Chartered Accountant',
+      'Bachelor of Commerce, University of Sydney',
+      'Bachelor of Laws, University of Sydney',
+      'International legal education, University of Oslo'
+    ],
+    'governance_roles', ARRAY[
+      'Director and Investment Committee Member, Count Charitable Foundation',
+      'Director and Investment Committee Member, James & Cordelia Thiele Trust Fund'
+    ],
+    'investment_thesis','B2B SaaS Australian founders with CA/legal-grade due diligence overlay.',
+    'sources', jsonb_build_object(
+      'investible_team','https://www.investible.com/team/jayden-basha',
+      'investible_intro','https://www.investible.com/blog/welcome-jayden-basha-investible',
+      'linkedin','https://www.linkedin.com/in/jayden-basha-164624159/',
+      'crunchbase','https://www.crunchbase.com/person/jayden-basha-bf2b',
+      'theorg','https://theorg.com/org/investible/org-chart/jayden-basha'
+    ),
+    'corrections','CSV LinkedIn URL empty — populated from public profile. CSV portfolio empty — populated with verified Investible role and founder/governance affiliations.'
+  ),
+  updated_at = now()
+WHERE name = 'Jayden Basha';
+
+UPDATE investors SET
+  description = 'Sydney-based PropTech founder/CEO and angel investor. Founder & CEO of RentBetter (self-management property platform; founded 2016; raised $1.9M Series A). Ex-ANZ Bank Wealth Strategist. Ex-BCG, Capgemini, Blackdot, IBM Management Consultant. Sector-agnostic with explicit PropTech experience.',
+  basic_info = 'Jeremy Goldschmidt is a Sydney-based PropTech founder, CEO and angel investor. He is the **Founder and CEO of RentBetter** — a Sydney-headquartered self-management property platform he founded in 2016 that helps landlords find tenants and manage properties at a fraction of the cost of traditional agents. RentBetter raised $1.9M Series A from Australian high-net-worth individuals and industry partners.
+
+His RentBetter board includes Tony Breuer (30+ years investment-banking experience at Gresham) and Ata Gokyildirim (Israeli startup growth executive — Sedric, Difftone).
+
+Prior to founding RentBetter he worked as:
+- **Wealth Strategist, ANZ Bank**
+- **Management Consultant** at **Boston Consulting Group**, **Capgemini**, **Blackdot** and **IBM**
+
+His angel posture per CSV directory is "All — experience with PropTech." He is a regular contributor to Your Money & Your Life and has appeared on multiple raising-capital and property-investing podcasts.',
+  why_work_with_us = 'For Australian PropTech, FinTech and SaaS-marketplace founders, Jeremy combines RentBetter operating credentials, BCG/IBM strategy depth and ANZ Bank wealth-management background. Particularly useful for founders selling into Australian property and finance verticals.',
+  sector_focus = ARRAY['PropTech','FinTech','SaaS','Marketplace','Consumer','B2B'],
+  stage_focus = ARRAY['Pre-seed','Seed','Series A'],
+  website = 'https://rentbetter.com.au',
+  linkedin_url = 'https://www.linkedin.com/in/jeremy-goldschmidt-6406ba2/',
+  contact_email = 'jeremy.g@rentbetter.com.au',
+  location = 'Sydney, NSW',
+  country = 'Australia',
+  currently_investing = true,
+  portfolio_companies = ARRAY['RentBetter (Founder & CEO; founded 2016; $1.9M Series A)'],
+  meta_title = 'Jeremy Goldschmidt — RentBetter founder | Sydney PropTech Angel',
+  meta_description = 'Sydney founder/CEO RentBetter (PropTech, $1.9M Series A). Ex-ANZ Wealth Strategist, BCG, Capgemini, Blackdot, IBM consultant.',
+  details = jsonb_build_object(
+    'founder_of', ARRAY['RentBetter (2016 founder & CEO; $1.9M Series A; Sydney PropTech)'],
+    'prior_roles', ARRAY[
+      'Wealth Strategist, ANZ Bank',
+      'Management Consultant, Boston Consulting Group',
+      'Management Consultant, Capgemini',
+      'Management Consultant, Blackdot',
+      'Management Consultant, IBM'
+    ],
+    'rentbetter_board', ARRAY[
+      'Tony Breuer (30+ years investment banking, Gresham)',
+      'Ata Gokyildirim (Israeli startup growth executive — Sedric, Difftone)'
+    ],
+    'investment_thesis','Sector-agnostic with PropTech bias from RentBetter operator background.',
+    'check_size_note','Undisclosed in CSV',
+    'sources', jsonb_build_object(
+      'rentbetter','https://rentbetter.com.au/',
+      'linkedin','https://www.linkedin.com/in/jeremy-goldschmidt-6406ba2/',
+      'tracxn_rentbetter','https://tracxn.com/d/companies/rentbetter/__OZy-IdWrv0ExbmT-6wzPMO0Z3ZoJ8IPd5dTp_UdMbQc',
+      'smartcompany_press','https://www.smartcompany.com.au/startupsmart/news/rentbetter-property-management-tech/',
+      'proptech_news','https://proptechnews.com.au/self-management-rental-platform-scores-1-9m-series-a-to-help-aussies-manage-their-own-property/',
+      'ymyl','https://www.ymyl.com.au/author/jeremy-goldshmidt/',
+      'nudge_group_interview','https://thenudgegroup.com/blog/interviews/startup-stories-jeremy-goldschmidt-founder-ceo-of-rentbetter'
+    ),
+    'corrections','CSV LinkedIn URL truncated ("...goldschmidt-6..."). Resolved to full URL. CSV portfolio empty — populated with founder company. CSV email truncated.'
+  ),
+  updated_at = now()
+WHERE name = 'Jeremy Goldschmidt';
+
+UPDATE investors SET
+  description = 'Sydney-based serial entrepreneur and angel investor. Founder of Inspiring Rare Birds (women''s entrepreneurship movement, since 2014). Founder & MD of Job Capital ($40M+ turnover in 5 years). Top 30 Australian female entrepreneurs since 2013. YPO member. Up to $50K cheques across technology, e-gaming and consumer. CSV portfolio: GGWP.',
+  basic_info = 'Jo Burston is one of Australia''s most successful female entrepreneurs and a Sydney-based angel investor. Her operating track record includes:
+- **Job Capital** (founded 2006) — recruitment business that grew from $0 to $40+ million turnover in 5 years. She is Founder and Managing Director.
+- **Inspiring Rare Birds** (since 2014) — global movement and platform challenging the view of what is possible for women in entrepreneurship and leadership. She is Founder and CEO. Inspiring Rare Birds also acts as a gateway to funding and investment for startups, with access to a diverse pool of angel and VC investors.
+
+She has been on the list of Australia''s top 30 female entrepreneurs every year since 2013, is a YPO (Young Presidents'' Organization) member, and is a regular speaker at Startup Grind Sydney.
+
+Her angel cheques (up to $50K) skew to technology, e-gaming and consumer-tech. CSV-listed portfolio includes **GGWP** (gaming-community moderation/AI-driven safety).',
+  why_work_with_us = 'For Australian female-founded technology, e-gaming and consumer founders, Jo offers high-leverage relationships through Inspiring Rare Birds — its angel/VC investor network plus YPO and Top-30-Female-Entrepreneurs visibility provide unusually deep warm-intro density. Best treated as both a cheque and a community-distribution play.',
+  sector_focus = ARRAY['Technology','E-Gaming','Consumer','Female Founders','SaaS','Recruitment'],
+  stage_focus = ARRAY['Pre-seed','Seed'],
+  check_size_min = 0,
+  check_size_max = 50000,
+  website = 'https://joburston.com',
+  linkedin_url = 'https://www.linkedin.com/in/joburston/',
+  contact_email = 'jo.burston@inspiringrarebirds.com',
+  location = 'Sydney, NSW',
+  country = 'Australia',
+  currently_investing = true,
+  portfolio_companies = ARRAY['Inspiring Rare Birds (Founder & CEO since 2014)','Job Capital (Founder & MD; $40M+ turnover in 5 years)','GGWP'],
+  meta_title = 'Jo Burston — Inspiring Rare Birds founder | Sydney Female-Founder Angel',
+  meta_description = 'Sydney serial founder. Founder Inspiring Rare Birds (women''s entrepreneurship). Founder Job Capital ($40M+ turnover). YPO. Up to $50K. GGWP portfolio.',
+  details = jsonb_build_object(
+    'founder_of', ARRAY[
+      'Job Capital (2006 founder & MD; $0 → $40M+ turnover in 5 years)',
+      'Inspiring Rare Birds (2014 founder & CEO; women''s entrepreneurship movement)'
+    ],
+    'recognition', ARRAY[
+      'Top 30 Australian Female Entrepreneurs (every year since 2013)',
+      'YPO (Young Presidents'' Organization) member'
+    ],
+    'investment_thesis','Female-led technology, e-gaming and consumer-tech founders with Inspiring Rare Birds community-distribution overlay.',
+    'check_size_note','Up to $50K',
+    'sources', jsonb_build_object(
+      'website','https://joburston.com/',
+      'linkedin','https://au.linkedin.com/in/joburston',
+      'crunchbase','https://www.crunchbase.com/person/jo-burston-2',
+      'inspiring_rare_birds','https://www.inspiringrarebirds.com/blog/author/jo-burston/',
+      'startup_grind','https://www.startupgrind.com/events/details/startup-grind-sydney-presents-jo-burston-inspiring-rare-birds-job-capital/',
+      'ypo_profile','https://www.ypo.org/2021/04/leading-an-entrepreneurial-movement-jo-burston-challenges-the-view-of-whats-possible-for-women/',
+      'startup_daily','https://www.startupdaily.net/advice/jo-burston-rare-birds-just-business-global-movement/'
+    ),
+    'corrections','CSV portfolio "GGWP" retained verbatim. Added Inspiring Rare Birds and Job Capital as founder companies. CSV email truncated ("jo.burston@inspiringareb..."). Resolved to jo.burston@inspiringrarebirds.com.'
+  ),
+  updated_at = now()
+WHERE name = 'Jo Burston';
+
+UPDATE investors SET
+  description = 'Brisbane-based serial entrepreneur and angel investor. Owner of Little Tokyo Two (Brisbane co-working space). 18+ years entrepreneurial experience. Sector mandate "Anything except deep tech". CSV-listed portfolio: Sharesies (NZ retail-investing platform), Zeroco (impact-tech). $25k cheques.',
+  basic_info = 'Jock Fairweather is a Brisbane-based serial entrepreneur and angel investor with 18+ years of entrepreneurial experience across multiple industries. He is the owner of **Little Tokyo Two** — a well-known Brisbane co-working space that doubles as a Queensland startup-community hub.
+
+His angel cheques skew to early-stage AU/NZ technology, with explicit exclusion of deep-tech (per CSV directory). Notable CSV-listed portfolio:
+- **Sharesies** — NZ-headquartered retail-investing platform (Australian active).
+- **Zeroco** — impact-tech.
+
+He runs the **Iceberg Nurturing Software** project alongside his angel and operator activity, and has been a regular SmartCompany columnist on early-stage entrepreneurship.',
+  why_work_with_us = 'For Brisbane and Queensland founders building in consumer, marketplace, fintech, edtech or impact-tech (excluding deep tech), Jock combines Little Tokyo Two community visibility with 18+ years of operator pattern recognition.',
+  sector_focus = ARRAY['Consumer','SaaS','Marketplace','FinTech','EdTech','Impact','Co-working / PropTech'],
+  stage_focus = ARRAY['Pre-seed','Seed'],
+  check_size_min = 25000,
+  check_size_max = 25000,
+  linkedin_url = 'https://www.linkedin.com/in/jockfairweather/',
+  contact_email = 'jockfairweather@gmail.com',
+  location = 'Brisbane, QLD',
+  country = 'Australia',
+  currently_investing = true,
+  portfolio_companies = ARRAY['Little Tokyo Two (owner; Brisbane co-working)','Iceberg Nurturing Software','Sharesies','Zeroco'],
+  meta_title = 'Jock Fairweather — Little Tokyo Two | Brisbane Generalist Angel',
+  meta_description = 'Brisbane owner of Little Tokyo Two co-working. 18+ years entrepreneurship. Portfolio: Sharesies, Zeroco. $25k. Anything except deep tech.',
+  details = jsonb_build_object(
+    'experience_years','18+ years entrepreneurship',
+    'current_roles', ARRAY[
+      'Owner, Little Tokyo Two (Brisbane co-working space)',
+      'Iceberg Nurturing Software',
+      'SmartCompany columnist'
+    ],
+    'investment_thesis','Anything except deep tech. Bias to consumer, marketplace, fintech, edtech and impact-tech. Brisbane / Queensland community focus.',
+    'check_size_note','$25k',
+    'sources', jsonb_build_object(
+      'linkedin','https://www.linkedin.com/in/jockfairweather/',
+      'openvc','https://www.openvc.app/fund/Jock%20Fairweather',
+      'clay_earth','https://clay.earth/profile/jock-fairweather',
+      'smartcompany_author','https://www.smartcompany.com.au/author/jock-fairweather/',
+      'australian_angel_list_pdf','https://www.scribd.com/document/767032518/Angels-Australia'
+    ),
+    'corrections','CSV portfolio truncated ("Sharesies (A), Zeroco (A..."). Resolved (A) annotations as part of standard portfolio listing. CSV sector_focus "Anything except deep tec..." resolved to "Anything except deep tech".'
+  ),
+  updated_at = now()
+WHERE name = 'Jock Fairweather';
+
+UPDATE investors SET
+  description = 'Sydney-based technical operator-angel and Inodes director. UNSW Founders mentor. 20+ year track record helping start-ups, scale-ups and mature businesses as Board Advisor, Non-Executive Director and Mentor. Diverse $10k–$50k portfolio: StorReduce, Josef Legal, Atolio, Bright OS, Thanks.dev, Onqlave, Section, Rookout, VirtualPlatform, Uliaa, Bloody Good Tests.',
+  basic_info = 'John Ferlito is a Sydney-based technical operator-angel and infrastructure-engineering veteran. He is **Director at Inodes** (Australian managed-hosting and infrastructure consultancy) and a **Mentor at UNSW Founders** — UNSW''s startup-and-scale-up program.
+
+He has 20+ years of track record helping start-ups, scale-ups and mature businesses as **Board Advisor, Non-Executive Director and Mentor**, with a particular bias toward technical infrastructure and developer-tools companies.
+
+His verified angel-investment portfolio is unusually diverse for a $10k–$50k cheque size:
+- **StorReduce** — cloud storage deduplication (acquired by Pure Storage 2018)
+- **Josef Legal** — legal-tech automation
+- **Atolio** — enterprise search (invested 2022)
+- **Bright OS**, **Thanks.dev**, **Onqlave**
+- **Section**, **Rookout**
+- **VirtualPlatform**, **Uliaa**, **Bloody Good Tests**
+
+He is a long-standing open-source contributor (github.com/johnf) and active across the Australian developer-tools community.',
+  why_work_with_us = 'For Australian developer-tools, infrastructure, legal-tech, observability and B2B-SaaS founders, John offers technical-operator credibility from Inodes plus UNSW Founders mentor visibility plus a 11+-name verified angel portfolio across the developer-tools stack.',
+  sector_focus = ARRAY['Developer Tools','Infrastructure','Cloud Storage','LegalTech','Enterprise Search','B2B SaaS','Open Source'],
+  stage_focus = ARRAY['Pre-seed','Seed','Series A'],
+  website = 'https://inodes.org',
+  linkedin_url = 'https://linkedin.com/in/johnf',
+  contact_email = 'johnf@inodes.org',
+  location = 'Sydney, NSW',
+  country = 'Australia',
+  currently_investing = true,
+  leads_deals = true,
+  portfolio_companies = ARRAY['Inodes (Director)','UNSW Founders (Mentor)','StorReduce','Josef Legal','Atolio','Bright OS','Thanks.dev','Onqlave','Section','Rookout','VirtualPlatform','Uliaa','Bloody Good Tests'],
+  meta_title = 'John Ferlito — Inodes / UNSW Founders Mentor | Sydney DevTools Angel',
+  meta_description = 'Sydney Director Inodes. UNSW Founders Mentor. 20+ yr advisor. Portfolio: StorReduce, Josef Legal, Atolio, Section, Rookout. $10k–$50k.',
+  details = jsonb_build_object(
+    'current_roles', ARRAY[
+      'Director, Inodes (Australian managed-hosting / infrastructure consultancy)',
+      'Mentor, UNSW Founders'
+    ],
+    'experience_years','20+ years',
+    'verified_portfolio', ARRAY['StorReduce','Josef Legal','Atolio','Bright OS','Thanks.dev','Onqlave','Section','Rookout','VirtualPlatform','Uliaa','Bloody Good Tests'],
+    'investment_thesis','Developer-tools, infrastructure, legal-tech and B2B SaaS where his Inodes operating-engineering background is value-add.',
+    'check_size_note','$10k–$50k',
+    'sources', jsonb_build_object(
+      'inodes_about','https://inodes.org/about-me/',
+      'linkedin','https://www.linkedin.com/in/johnf/',
+      'crunchbase','https://www.crunchbase.com/person/john-ferlito',
+      'github','https://github.com/johnf',
+      'twitter_x','https://x.com/johnf',
+      'dealroom','https://app.dealroom.co/investors/john_ferlito_1',
+      'unsw_founders_zoominfo','https://www.zoominfo.com/p/John-Ferlito/43824335'
+    ),
+    'corrections','CSV portfolio truncated ("StorReduce, Josef, Atolio,..."). Expanded with verified Dealroom positions: Bright OS, Thanks.dev, Onqlave, Section, Rookout, VirtualPlatform, Uliaa, Bloody Good Tests. Josef resolved to Josef Legal.'
+  ),
+  updated_at = now()
+WHERE name = 'John Ferlito';
+
+COMMIT;


### PR DESCRIPTION
## Summary

Continues the angel-investor enrichment series with **20 records** in 4 atomic migrations.

### Highlights

- **#99 Harry Uffindell** — Auckland ex-Airbnb ANZ, 50–1000x outlier thesis, Treinta $4M→$100M
- **#101 Hugh Bickerstaff** — Investible CIO, **100+ investments** since 2016, Canva early angel
- **#104 Ilan Israelstam** — **BetaShares Co-Founder** ($40B+ AUM, 1M+ clients)
- **#106 Irene Zhen** — Canberra deep-tech; **Quantum Brilliance** (ANU spinoff)
- **#110 James J. Tennant** — BOKA Group / Balmoral / **Gilmour Space** Senior Partner / ASPI Fellow
- **#113 Jason Serda** — **Utiliti Group MP**, $250k cheques, **45+ investments / 11+ exits since 2008**
- **#116 Jo Burston** — **Inspiring Rare Birds** founder; Job Capital ($40M+ turnover)
- **#118 John Ferlito** — Inodes Director, 11+ verified devtools portfolio (StorReduce, Josef Legal, Atolio, Section, Rookout)

### Cross-references

- **#100 Henry Innis** (Mutinex) and **#112 Jason Chuck** both share **ReciMe** in their portfolios
- **#114 Jayden Basha** is at **Investible** alongside CIO **#101 Hugh Bickerstaff**

**Series state:** pilot (3) + 01a–01d (20) + 02a–02s (95) = **118 of 267** angels enriched.

## Files

- `20260422131900_enrich_angel_investors_batch_02p.sql` (99-103)
- `20260422132000_enrich_angel_investors_batch_02q.sql` (104-108)
- `20260422132100_enrich_angel_investors_batch_02r.sql` (109-113)
- `20260422132200_enrich_angel_investors_batch_02s.sql` (114-118)

https://claude.ai/code/session_017Zvz2r5Y2U8bP3eY4cwAFe

---
_Generated by [Claude Code](https://claude.ai/code/session_01XsHLVbJ1rAJ3oafzHY6j2N)_