### PR TITLE
Enrich angel investors — batches 02t-02w (records 119-138, 20 records)

### DIFF
--- a/supabase/migrations/20260422132300_enrich_angel_investors_batch_02t.sql
+++ b/supabase/migrations/20260422132300_enrich_angel_investors_batch_02t.sql
@@ -1,0 +1,179 @@
+-- Enrich angel investors — batch 02t (records 119-123: John Henderson → Josh Best)
+
+BEGIN;
+
+UPDATE investors SET
+  description = 'Sydney-based General Partner at AirTree Ventures (Australia''s largest VC, $1B+ AUM). 6 years prior in London/NYC: Facebook, COO of Summly (Yahoo $30M exit 2013), Principal at White Star Capital. Ex-BCG. Co-founder of London.ai (Europe''s leading AI practitioner event). Cheque range $100K–$5M.',
+  basic_info = 'John Henderson is a full-time General Partner at AirTree Ventures, focusing on early-stage Australian and NZ technology companies.
+
+His pre-AirTree career: 6 years across London and New York at Facebook, then as COO of Summly (acquired by Yahoo for $30M in 2013), and most recently as Principal at White Star Capital. He started his career at Boston Consulting Group, after a first venture (Bush Campus) that failed.
+
+His personal angel/AirTree investment range is $100K–$5M with a sweet spot of $1.5M. Current AirTree fund $60M+. He co-founded London.ai — Europe''s leading event for AI practitioners.',
+  why_work_with_us = 'For Australian and NZ founders raising $500K–$5M seed/Series A rounds with global ambition, John combines AirTree institutional pathway with cross-Atlantic operator credentials.',
+  sector_focus = ARRAY['SaaS','AI','Marketplace','Consumer','FinTech','HealthTech','Generalist'],
+  stage_focus = ARRAY['Pre-seed','Seed','Series A'],
+  website = 'https://www.airtree.vc',
+  linkedin_url = 'https://www.linkedin.com/in/johnhenderson/',
+  contact_email = 'john@airtree.vc',
+  location = 'Sydney, NSW',
+  country = 'Australia',
+  currently_investing = true,
+  leads_deals = true,
+  portfolio_companies = ARRAY['AirTree Ventures (General Partner)','Summly (ex-COO; Yahoo $30M exit 2013)','White Star Capital (ex-Principal)','Facebook (ex)','London.ai (co-founder)','Boston Consulting Group (ex)'],
+  meta_title = 'John Henderson — AirTree Ventures GP | Sydney Generalist',
+  meta_description = 'Sydney AirTree Ventures GP. Ex-Facebook, COO Summly (Yahoo $30M), White Star Capital. London.ai co-founder. $100K–$5M.',
+  details = jsonb_build_object(
+    'firm','AirTree Ventures',
+    'role','General Partner',
+    'investment_range_aud','$100K–$5M (sweet spot $1.5M)',
+    'fund_size_aud','$60M+',
+    'prior_roles', ARRAY['Facebook','COO Summly (Yahoo $30M exit 2013)','Principal White Star Capital','Boston Consulting Group','Founder Bush Campus'],
+    'co_founder_of', ARRAY['London.ai (Europe leading AI practitioner event)'],
+    'sources', jsonb_build_object(
+      'airtree_team','https://www.airtree.vc/team/john-henderson',
+      'linkedin','https://au.linkedin.com/in/johnhenderson',
+      'crunchbase','https://www.crunchbase.com/person/john-henderson-2',
+      'signal_nfx','https://signal.nfx.com/investors/john-henderson',
+      'inquisitive_vc','https://theinquisitivevc.substack.com/p/john-henderson-airtree'
+    ),
+    'corrections','CSV email "john at airtree dot vc" decoded to john@airtree.vc.'
+  ),
+  updated_at = now()
+WHERE name = 'John Henderson';
+
+UPDATE investors SET
+  description = 'Sydney-based angel investor and Chairman at Atomo Diagnostics. Managing Director at BNP Paribas. Sector focus: Fintech, Health, EdTech, E-commerce. $10k cheques. Notable portfolio: Atomo Diagnostics (rapid blood-based diagnostics), Clipboard.',
+  basic_info = 'John Keith is a Sydney-based angel investor whose primary public role is Chairman of the Board of Directors at Atomo Diagnostics — Australian-listed (ASX:AT1) developer of integrated rapid diagnostic test devices including Galileo lateral flow blood-based diagnostics for HIV, hepatitis and other applications.
+
+He is also Managing Director at BNP Paribas. His angel cheques ($10k) skew to fintech, health, edtech and e-commerce ventures.',
+  why_work_with_us = 'For Australian healthtech, fintech, edtech and e-commerce founders raising small seed cheques, John offers BNP Paribas institutional context plus board-level diagnostics-industry exposure via Atomo.',
+  sector_focus = ARRAY['FinTech','HealthTech','EdTech','E-commerce','Diagnostics','MedTech'],
+  stage_focus = ARRAY['Pre-seed','Seed'],
+  check_size_min = 10000,
+  check_size_max = 10000,
+  linkedin_url = 'https://www.linkedin.com/in/john-keith-3030241b/',
+  contact_email = 'john.keith@mac.com',
+  location = 'Sydney, NSW',
+  country = 'Australia',
+  currently_investing = true,
+  portfolio_companies = ARRAY['Atomo Diagnostics (Chairman)','BNP Paribas (Managing Director)','Clipboard'],
+  meta_title = 'John Keith — Atomo Diagnostics Chairman | Sydney Angel',
+  meta_description = 'Sydney Chairman Atomo Diagnostics. MD BNP Paribas. $10k cheques. Fintech, health, edtech, e-commerce.',
+  details = jsonb_build_object(
+    'current_roles', ARRAY['Chairman, Atomo Diagnostics','Managing Director, BNP Paribas'],
+    'check_size_note','$10k',
+    'sources', jsonb_build_object(
+      'atomo_governance','https://atomodiagnostics.com/governance/',
+      'atomo_board','https://atomodiagnostics.com/board-of-directors/',
+      'linkedin','https://www.linkedin.com/in/john-keith-3030241b/'
+    ),
+    'corrections','CSV portfolio truncated. Two retained as verified.'
+  ),
+  updated_at = now()
+WHERE name = 'John Keith';
+
+UPDATE investors SET
+  description = 'Sydney-based Macquarie Group executive and institutional-cheque-size investor. Sector focus: B2B SaaS, enterprise software. $5M–$25M cheques (institutional scale, not personal angel).',
+  basic_info = 'Jonathan Lay is a Sydney-based investor at Macquarie Group with a B2B SaaS and enterprise-software focus. His CSV-listed cheque band of $5M–$25M places him in institutional Series-B and growth-equity territory rather than personal-angel cheques.
+
+Founders should approach Jonathan as a Macquarie Group institutional contact rather than a typical small-cheque angel — his cheque scale is appropriate for late-Series A through Series B rounds.',
+  why_work_with_us = 'For Australian B2B SaaS and enterprise-software founders raising Series A+ rounds with institutional cheque participation, Jonathan offers Macquarie Group-level capital and institutional pathway.',
+  sector_focus = ARRAY['B2B SaaS','Enterprise Software','SaaS','FinTech'],
+  stage_focus = ARRAY['Series A','Series B','Growth'],
+  check_size_min = 5000000,
+  check_size_max = 25000000,
+  contact_email = 'jonathan.lay@macquarie.com',
+  location = 'Sydney, NSW',
+  country = 'Australia',
+  currently_investing = true,
+  leads_deals = true,
+  portfolio_companies = ARRAY['Macquarie Group'],
+  meta_title = 'Jonathan Lay — Macquarie Group | Sydney B2B SaaS Institutional',
+  meta_description = 'Sydney Macquarie Group institutional investor. B2B SaaS, enterprise software. $5M–$25M cheques.',
+  details = jsonb_build_object(
+    'firm','Macquarie Group',
+    'check_size_note','$5M–$25M (institutional Series A+)',
+    'unverified', ARRAY[
+      'Beyond CSV directory listing, individual investor track record and specific portfolio companies could not be uniquely corroborated from public-source search.'
+    ],
+    'sources', jsonb_build_object(
+      'australian_angel_list_pdf','https://www.scribd.com/document/767032518/Angels-Australia'
+    ),
+    'corrections','CSV email truncated ("jonathan.lay@macquarie...."). Resolved to jonathan.lay@macquarie.com. CSV LinkedIn empty.'
+  ),
+  updated_at = now()
+WHERE name = 'Jonathan Lay';
+
+UPDATE investors SET
+  description = 'Byron Bay-based founder, operator and sustainability-focused angel investor. Founder of Planet Earth Ventures (consultancy and angel platform supporting eco-conscious businesses). Ex-Director/Owner of Colorific for 13 years (consumer-products business; sold 25M+ products, $300M+ revenue; acquired 2022). EnergyLab Angel Network member. Startmate First Believer Cohort 5. Blackbird Giants Mentor.',
+  basic_info = 'Jonny Levi is a Byron Bay-based business owner-operator turned consultant, mentor and angel investor focused on businesses supporting the planet.
+
+His operating story: 13 years at Colorific (consumer products), 10 of those as Director and Owner. The business sold 25M+ products with $300M+ revenue under his tenure and was acquired in 2022 by one of the largest privately-owned global toy companies.
+
+He now runs **Planet Earth Ventures** — a consultancy and angel platform offering Mastermind Groups, 1:1 Advisory and curated Tools & Resources for eco-conscious businesses.
+
+His angel-network affiliations:
+- **EnergyLab Angel Network** (Mentor + Member; see record #80)
+- **Startmate First Believer Cohort 5**
+- **Blackbird Giants Mentor**
+- **Pause Awards Judge**',
+  why_work_with_us = 'For Australian sustainability, climate-tech, consumer-goods and eco-conscious founders, Jonny offers a small first cheque alongside Planet Earth Ventures advisory plus EnergyLab/Startmate/Blackbird mentor-network reach.',
+  sector_focus = ARRAY['Sustainability','Climate','Consumer','Consumer Goods','EcoTech','Impact'],
+  stage_focus = ARRAY['Pre-seed','Seed'],
+  check_size_min = 0,
+  check_size_max = 15000,
+  website = 'https://www.planetearthventures.co',
+  linkedin_url = 'https://www.linkedin.com/in/jonnylevi/',
+  contact_email = 'jonny@planetearthventures.co',
+  location = 'Byron Bay, NSW',
+  country = 'Australia',
+  currently_investing = true,
+  portfolio_companies = ARRAY['Planet Earth Ventures (Founder)','Colorific (ex-Director/Owner; sold 2022)','EnergyLab Angel Network (Mentor)','Startmate First Believer Cohort 5','Blackbird Giants Mentor','Lucent Globe (Chief Commercial and Sustainability Officer)'],
+  meta_title = 'Jonny Levi — Planet Earth Ventures | Byron Bay Sustainability Angel',
+  meta_description = 'Byron Bay founder Planet Earth Ventures. Ex-Colorific (13 years, $300M+, sold 2022). EnergyLab + Startmate + Blackbird mentor. Up to $15k.',
+  details = jsonb_build_object(
+    'founder_of', ARRAY['Planet Earth Ventures (consultancy + angel platform)'],
+    'prior_roles', ARRAY['Director/Owner Colorific (13 years; $300M+ revenue; sold 2022)'],
+    'angel_network_affiliations', ARRAY['EnergyLab Angel Network','Startmate First Believer Cohort 5','Blackbird Giants Mentor','Pause Awards Judge'],
+    'check_size_note','Up to $15k',
+    'sources', jsonb_build_object(
+      'planet_earth_ventures','https://www.planetearthventures.co/',
+      'linkedin','https://www.linkedin.com/in/jonnylevi/',
+      'pause_awards','https://pauseawards.com/judges/jonny-levi/',
+      'balance_grind','https://balancethegrind.co/interviews/jonny-levi-founder-at-planet-earth-ventures/'
+    ),
+    'corrections','CSV email truncated ("jonny@planetearthventur..."). Resolved to jonny@planetearthventures.co.'
+  ),
+  updated_at = now()
+WHERE name = 'Jonny Levi';
+
+UPDATE investors SET
+  description = 'Sydney-based generalist angel investor. CSV-listed portfolio includes Canva (early/historical), Kelly Partners and additional truncated companies. Limited public investor profile.',
+  basic_info = 'Josh Best is a Sydney-based angel investor listed in the Australian angel directory with a generalist mandate. CSV-listed portfolio names include **Canva** and **Kelly Partners** — two of Australia''s most-cited tech and accounting/professional-services scale-ups respectively. Beyond the directory entry, detailed individual investor track record could not be uniquely corroborated from public-source search.
+
+Founders should expect to validate the connection directly through warm introduction or referral.',
+  why_work_with_us = 'For Australian early-stage founders looking for a generalist Sydney angel cheque with apparent Canva and Kelly Partners track record. Best treated as a referral-led conversation given limited public profile.',
+  sector_focus = ARRAY['SaaS','Consumer','Marketplace','FinTech','Generalist','Accounting Tech','Design'],
+  stage_focus = ARRAY['Pre-seed','Seed'],
+  linkedin_url = 'https://www.linkedin.com/in/joshuabest/',
+  location = 'Sydney, NSW',
+  country = 'Australia',
+  currently_investing = true,
+  portfolio_companies = ARRAY['Canva','Kelly Partners'],
+  meta_title = 'Josh Best — Sydney Generalist Angel | Canva, Kelly Partners',
+  meta_description = 'Sydney generalist angel investor. CSV portfolio: Canva, Kelly Partners.',
+  details = jsonb_build_object(
+    'unverified', ARRAY[
+      'Could not uniquely match the directory listing to a single public investor profile.',
+      'CSV portfolio entries verified as real Australian companies but cap-table participation not independently corroborated.'
+    ],
+    'sources', jsonb_build_object(
+      'linkedin_csv','https://www.linkedin.com/in/joshuabest/',
+      'australian_angel_list_pdf','https://www.scribd.com/document/767032518/Angels-Australia'
+    ),
+    'corrections','CSV portfolio truncated. Common-name caveat applies.'
+  ),
+  updated_at = now()
+WHERE name = 'Josh Best';
+
+COMMIT;

--- a/supabase/migrations/20260422132400_enrich_angel_investors_batch_02u.sql
+++ b/supabase/migrations/20260422132400_enrich_angel_investors_batch_02u.sql
@@ -1,0 +1,176 @@
+-- Enrich angel investors — batch 02u (records 124-128: Josh Masters → Justin Dry)
+
+BEGIN;
+
+UPDATE investors SET
+  description = 'Sydney-based wine importer (Vino Cammino) turned startup advisor and climate-tech angel investor. Particular interest in companies solving the climate crisis. CSV-listed portfolio: Carbonaught (enhanced rock weathering carbon removal), Zoshon and others. $10k–$50k cheques.',
+  basic_info = 'Josh Masters is a Sydney/Darlinghurst-based wine importer and startup advisor/investor. He runs **Vino Cammino Pty Ltd** as his primary operating business and invests in and advises a small number of Australian-based technology businesses with particular interest in companies solving the climate crisis.
+
+His CSV-listed portfolio includes **Carbonaught** (enhanced rock-weathering carbon-removal company; backed by Antler Australia early), Zoshon and additional truncated names.',
+  why_work_with_us = 'For Australian climate-tech and consumer-tech founders looking for a small-to-mid cheque from an investor with consumer-products operating context (Vino Cammino) plus climate-tech thesis alignment.',
+  sector_focus = ARRAY['Climate','Climate Tech','Carbon Removal','Consumer','SaaS','Wine/FoodTech'],
+  stage_focus = ARRAY['Pre-seed','Seed'],
+  check_size_min = 10000,
+  check_size_max = 50000,
+  linkedin_url = 'https://www.linkedin.com/in/josh-masters/',
+  contact_email = 'masters.jd@gmail.com',
+  location = 'Sydney, NSW',
+  country = 'Australia',
+  currently_investing = true,
+  portfolio_companies = ARRAY['Vino Cammino (operating)','Carbonaught','Zoshon'],
+  meta_title = 'Josh Masters — Vino Cammino | Sydney Climate-Tech Angel',
+  meta_description = 'Sydney wine importer + startup advisor + climate-tech angel. Carbonaught, Zoshon. $10k–$50k.',
+  details = jsonb_build_object(
+    'operating_role','Wine Importer, Vino Cammino Pty Ltd',
+    'investment_thesis','Climate-tech and consumer-tech with bias toward climate-crisis solutions.',
+    'check_size_note','$10k–$50k',
+    'sources', jsonb_build_object(
+      'linkedin','https://au.linkedin.com/in/josh-masters',
+      'climate_salad_investors','https://www.climatesalad.com/resources/climate-tech-investor-list'
+    ),
+    'corrections','CSV portfolio truncated. Two retained as listed.'
+  ),
+  updated_at = now()
+WHERE name = 'Josh Masters';
+
+UPDATE investors SET
+  description = 'Sydney-based management consultant (ex-Kearney) and climate-and-impact angel investor. TEDxDarlinghurst organiser. 10+ years strategy/operations consulting. Cleantech, SaaS and Impact focus. $10k–$25k cheques.',
+  basic_info = 'Juan Bejjani is a Sydney-based management consultant (ex-Kearney) with 10+ years of experience providing strategy/operations advice to organisations. He runs **TEDxDarlinghurst** to bring the TED CountDown format to Sydney and help Australia accelerate solutions to the climate crisis.
+
+He helps early-stage entrepreneurs with market research, strategy, operations and sales. His direct cleantech operating role: he developed corporate strategy, structured the business plan and raised the seed round for a cleantech CEO, including business development of government grants, strategic partners and product pipeline.
+
+His CSV cheque size $10k–$25k. Sector focus: Cleantech, SaaS, Impact.',
+  why_work_with_us = 'For Australian cleantech, climate-tech, SaaS and impact-led founders, Juan offers Kearney-level strategy advisory plus TEDxDarlinghurst climate-community visibility on a small first cheque.',
+  sector_focus = ARRAY['Clean Tech','SaaS','Impact','Climate','Sustainability','Strategy Consulting'],
+  stage_focus = ARRAY['Pre-seed','Seed'],
+  check_size_min = 10000,
+  check_size_max = 25000,
+  linkedin_url = 'https://www.linkedin.com/in/juanbejjani/',
+  location = 'Sydney, NSW',
+  country = 'Australia',
+  currently_investing = true,
+  portfolio_companies = ARRAY['TEDxDarlinghurst (Organiser)','Kearney (ex-Management Consultant)'],
+  meta_title = 'Juan Bejjani — Sydney Cleantech/Impact Angel | TEDx Darlinghurst',
+  meta_description = 'Sydney management consultant (ex-Kearney). TEDxDarlinghurst organiser. Cleantech/SaaS/Impact angel. $10k–$25k.',
+  details = jsonb_build_object(
+    'current_roles', ARRAY['Management Consultant (ex-Kearney)','TEDxDarlinghurst Organiser','Entrepreneur Mentor','Angel Investor'],
+    'experience_years','10+ years strategy/operations consulting',
+    'check_size_note','$10k–$25k',
+    'sources', jsonb_build_object(
+      'linkedin','https://www.linkedin.com/in/juanbejjani/'
+    ),
+    'corrections','CSV LinkedIn URL had typo (juanbeijjani). Resolved to juanbejjani.'
+  ),
+  updated_at = now()
+WHERE name = 'Juan Bejjani';
+
+UPDATE investors SET
+  description = 'Melbourne-based Managing Director of Valyrian Private Wealth (specialist HNW + family-office wealth and lending advisor). 20+ years across HSBC, RBS, CBA, Alpha Fund Managers, Bank of America Merrill Lynch and ANZ. CPA. Pre-seed to Series B sector-agnostic angel investing. $25k–$100k cheques.',
+  basic_info = 'Julien Brodie CPA is a Melbourne-based wealth-management Managing Director and angel investor. He is **Managing Director of Valyrian Private Wealth** — a specialist provider of wealth advice and lending solutions for high-net-worth individuals and family offices.
+
+His pre-Valyrian career spans 20 years across institutions including **HSBC, RBS, CBA, Alpha Fund Managers, Bank of America Merrill Lynch and ANZ**. He holds a CPA qualification.
+
+His angel posture per CSV is generalist pre-seed to Series B with $25k–$100k cheques.',
+  why_work_with_us = 'For Australian founders raising structured rounds from pre-seed through Series B, Julien offers Valyrian Private Wealth HNW network reach plus 20-year multi-bank wealth-management institutional context.',
+  sector_focus = ARRAY['FinTech','SaaS','Wealth Management','Generalist','Consumer','B2B'],
+  stage_focus = ARRAY['Pre-seed','Seed','Series A','Series B'],
+  check_size_min = 25000,
+  check_size_max = 100000,
+  website = 'https://vpwealth.com.au',
+  linkedin_url = 'https://www.linkedin.com/in/julienbrodie/',
+  contact_email = 'julien@vpwealth.com.au',
+  location = 'Melbourne, VIC',
+  country = 'Australia',
+  currently_investing = true,
+  portfolio_companies = ARRAY['Valyrian Private Wealth (Managing Director)','HSBC (ex)','RBS (ex)','CBA (ex)','Alpha Fund Managers (ex)','Bank of America Merrill Lynch (ex)','ANZ (ex)'],
+  meta_title = 'Julien Brodie — Valyrian Private Wealth MD | Melbourne Generalist Angel',
+  meta_description = 'Melbourne MD Valyrian Private Wealth. 20+ years HSBC/RBS/CBA/BAML. CPA. Pre-seed to Series B. $25k–$100k.',
+  details = jsonb_build_object(
+    'firm','Valyrian Private Wealth (HNW + family-office wealth advisor)',
+    'role','Managing Director',
+    'experience_years','20+ years across major banking and asset-management institutions',
+    'credentials', ARRAY['CPA'],
+    'sources', jsonb_build_object(
+      'linkedin','https://www.linkedin.com/in/julienbrodie/',
+      'valyrian_team','https://vpwealth.com.au/team/',
+      'valyrian_about','https://vpwealth.com.au/about/'
+    ),
+    'corrections','CSV portfolio empty — populated with verified institutional employer affiliations.'
+  ),
+  updated_at = now()
+WHERE name = 'Julien Brodie';
+
+UPDATE investors SET
+  description = 'Sydney-based serial founder and angel investor. Founder & CEO of Snug.com (rental platform). Founded Stayz online holiday rental marketplace 1999, sold to Stayz/Fairfax 2011 for $29M. Ex-HomeAway senior management. Sydney Angels member. 12+ angel investments across marketplace, SaaS, fintech, property, IoT and labour.',
+  basic_info = 'Justin Butterworth is a Sydney-based serial founder, NED, active angel investor and Australian property-tech innovator.
+
+His operating story: self-funded and launched Australia''s first online holiday-rental e-commerce marketplace in 1999, sold to **Stayz/Fairfax in 2011 for $29M**. Then held senior management positions at **HomeAway.com (NASDAQ: AWAY)** for 2 years post-acquisition.
+
+He sold his house and took 16 months off to build **Snug.com (Snug Technologies)** — an online platform that streamlines the rental process for renters and property managers — where he is Founder & Chief Executive Officer.
+
+His angel-investment activity is via **Sydney Angels** and personal direct investments. He has 12+ investments across marketplace, platform, SaaS, fintech, property, IoT and labour categories. CSV-listed portfolio includes **Snug.com** (his own founder company), **Jayride** (airport-transfer marketplace, ASX-listed) and **Instacart**.',
+  why_work_with_us = 'For Australian marketplace, platform, SaaS, fintech, property and IoT founders, Justin offers an exit-tested marketplace operator''s pattern recognition plus Sydney Angels community visibility.',
+  sector_focus = ARRAY['Marketplace','Platform','SaaS','FinTech','PropTech','IoT','Labour','Social Impact'],
+  stage_focus = ARRAY['Pre-seed','Seed','Series A'],
+  website = 'https://snug.com',
+  linkedin_url = 'https://linkedin.com/in/justin-butterworth/',
+  location = 'Sydney, NSW',
+  country = 'Australia',
+  currently_investing = true,
+  leads_deals = true,
+  portfolio_companies = ARRAY['Snug.com (Founder & CEO)','Stayz (founder; Fairfax exit 2011, $29M)','HomeAway/Vrbo (ex-senior management)','Sydney Angels','Jayride','Instacart'],
+  meta_title = 'Justin Butterworth — Snug.com / ex-Stayz | Sydney Marketplace Angel',
+  meta_description = 'Sydney founder Snug.com. Founded Stayz (Fairfax $29M exit 2011). Ex-HomeAway. Sydney Angels. 12+ marketplace/SaaS investments.',
+  details = jsonb_build_object(
+    'founder_of', ARRAY['Snug.com (Snug Technologies; current)','Stayz (1999 founder; Fairfax exit 2011, $29M)'],
+    'exits', jsonb_build_array(
+      jsonb_build_object('company','Stayz','category','Online holiday rental marketplace','acquirer','Stayz/Fairfax','year',2011,'value_aud','$29M')
+    ),
+    'prior_roles', ARRAY['HomeAway.com / NASDAQ: AWAY (senior management)','Sydney Angels member'],
+    'angel_portfolio_count','12+ marketplace/platform/SaaS/fintech investments',
+    'sources', jsonb_build_object(
+      'linkedin','https://www.linkedin.com/in/justin-butterworth/',
+      'rocketreach','https://rocketreach.co/justin-butterworth-email_135949869',
+      'smartcompany','https://www.smartcompany.com.au/property/why-entrepreneur-justin-butterworth-sold-his-house-and-took-16-months-off-to-fix-australias-broken-rental-market/',
+      'startcon','https://www.startcon.com/events/startup-sessions-with-justin-butterworth/'
+    ),
+    'corrections','CSV portfolio truncated. Snug.com is his founder company; retained. Jayride and Instacart kept as listed (cap-table participation per CSV).'
+  ),
+  updated_at = now()
+WHERE name = 'Justin Butterworth';
+
+UPDATE investors SET
+  description = 'Melbourne-based Co-Founder & Joint CEO of Vinomofo (online wine retailer; AU/NZ/Singapore). Spotify Young Entrepreneur of the Year (Australian Startup Awards). Top 50 People in E-Commerce 2016-2020 (Internet Retailing). Angel investor for 3-4 years personally and via Blackbird Venture''s Startmate program. Notable investments: Oddup, Clover (fintech robo-advice).',
+  basic_info = 'Justin Dry is a Melbourne-based serial entrepreneur and Co-Founder/Joint CEO of **Vinomofo** — Australia''s most successful online wine retailer. Vinomofo was launched in April 2011 from a garage in Adelaide and now operates across Australia, NZ and Singapore. The company was started with co-founder Andre Eikmeier under the motto "no bowties and bullshit."
+
+He has been awarded **Spotify Young Entrepreneur of the Year** at the Australian Startup Awards and named one of the Top 50 People in E-Commerce 2016, 2017, 2018, 2019 and 2020 by Internet Retailing.
+
+His angel investing has been done over 3-4 years both personally and through **Blackbird Venture''s Startmate program**, looking for disruptive businesses. Notable investments: **Oddup** (data/research) and **Clover** (fintech robo-advice).',
+  why_work_with_us = 'For Australian consumer, e-commerce, marketplace and fintech founders, Justin offers Vinomofo''s consumer-internet operating credibility plus Blackbird/Startmate co-investment exposure.',
+  sector_focus = ARRAY['Consumer','E-commerce','FinTech','Marketplace','Wine/FoodTech','Disruptive Tech'],
+  stage_focus = ARRAY['Pre-seed','Seed'],
+  linkedin_url = 'https://www.linkedin.com/in/justindry/',
+  location = 'Melbourne, VIC',
+  country = 'Australia',
+  currently_investing = true,
+  portfolio_companies = ARRAY['Vinomofo (Co-Founder & Joint CEO; founded 2011)','Oddup','Clover (fintech robo-advice)','Startmate (mentor + co-investor via Blackbird Venture)'],
+  meta_title = 'Justin Dry — Vinomofo Co-Founder | Melbourne Consumer Angel',
+  meta_description = 'Melbourne Co-Founder/Joint CEO Vinomofo. Spotify Young Entrepreneur of the Year. Oddup, Clover. Startmate co-investor.',
+  details = jsonb_build_object(
+    'founder_of', ARRAY['Vinomofo (Co-Founder, Joint CEO; founded April 2011 with Andre Eikmeier)'],
+    'recognition', ARRAY['Spotify Young Entrepreneur of the Year (Australian Startup Awards)','Top 50 People in E-Commerce 2016/2017/2018/2019/2020 (Internet Retailing)'],
+    'angel_portfolio_count','2 verified investments via personal and Blackbird/Startmate co-investment',
+    'verified_investments', ARRAY['Oddup','Clover (fintech robo-advice)'],
+    'sources', jsonb_build_object(
+      'crunchbase','https://www.crunchbase.com/person/justin-dry',
+      'pitchbook','https://pitchbook.com/profiles/investor/119877-85',
+      'wellfound','https://wellfound.com/p/justin-dry',
+      'smartcompany_clover','https://www.smartcompany.com.au/startupsmart/news/vinomofo-justin-dry-backs-fintech-robo-advice-startup-clover/',
+      'lawson_media','https://lawson.media/episodes/the-road-to-vino-with-justin-dry-ceo-of-vinomofo'
+    ),
+    'corrections','CSV portfolio empty — populated with Vinomofo (founder company), Oddup and Clover (verified angel investments).'
+  ),
+  updated_at = now()
+WHERE name = 'Justin Dry';
+
+COMMIT;

--- a/supabase/migrations/20260422132500_enrich_angel_investors_batch_02v.sql
+++ b/supabase/migrations/20260422132500_enrich_angel_investors_batch_02v.sql
@@ -1,0 +1,204 @@
+-- Enrich angel investors — batch 02v (records 129-133: Justus Hammer → Kenny Wong)
+
+BEGIN;
+
+UPDATE investors SET
+  description = 'Sydney-based serial entrepreneur and prolific angel investor. CEO and Co-founder of Mad Paws (pet-care marketplace). Founded Spreets in 2011 (Yahoo!7 $40M exit, 10 months). Founding investor and advisor at VICE Golf and Airtasker. Founder of Sellable (real-estate-tech). 45+ angel investments. Born Munich; M.IT Macquarie University.',
+  basic_info = 'Justus Hammer is a Sydney-based serial founder and one of the most prolific Australian angel investors. He is CEO and Co-founder of **Mad Paws** — Australia''s leading pet-services marketplace.
+
+His operating story is unusually condensed: he founded **Spreets** in 2011 and grew it to be Australia''s leading group-buying company with 1.5M+ members and 100+ employees in less than 12 months, exiting to Yahoo!7 for ~$40M just 10 months after founding. He is a founding investor and advisor at **VICE Golf** (golf D2C brand) and **Airtasker** (marketplace, ASX-listed).
+
+His latest venture is **Sellable** — Australian real-estate-tech aiming to make residential property buying easier.
+
+Born in Munich, Germany; played professional basketball before completing a Masters in Economics. Holds a Master of Information Technology from Macquarie University. 45+ angel investments over the past several years.',
+  why_work_with_us = 'For Australian marketplace, consumer, retail and real-estate-tech founders, Justus combines exit-tested founder credentials (Spreets 10-month $40M exit) with active marketplace operator role at Mad Paws and 45+ portfolio pattern recognition.',
+  sector_focus = ARRAY['Marketplace','Retail','Tech','Real Estate','Consumer','SaaS','PropTech'],
+  stage_focus = ARRAY['Pre-seed','Seed','Series A'],
+  check_size_min = 50000,
+  check_size_max = 50000,
+  linkedin_url = 'https://linkedin.com/in/justus-hammer-6a871b8',
+  contact_email = 'justus.hammer@gmail.com',
+  location = 'Sydney, NSW',
+  country = 'Australia',
+  currently_investing = true,
+  leads_deals = true,
+  portfolio_companies = ARRAY['Mad Paws (CEO, Co-founder)','Spreets (founder; Yahoo!7 $40M exit 2011)','VICE Golf (founding investor + advisor)','Airtasker (early investor + advisor)','Sellable (founder)'],
+  meta_title = 'Justus Hammer — Mad Paws CEO / ex-Spreets | Sydney Marketplace Angel',
+  meta_description = 'Sydney CEO/Co-founder Mad Paws. Founded Spreets (Yahoo!7 $40M exit 10 months). Airtasker, VICE Golf early investor. 45+ investments. $50k.',
+  details = jsonb_build_object(
+    'founder_of', ARRAY['Mad Paws (current; CEO + Co-founder)','Spreets (2011 founder; Yahoo!7 $40M exit, 10 months)','Sellable (real-estate-tech)'],
+    'exits', jsonb_build_array(
+      jsonb_build_object('company','Spreets','category','Group buying','members','1.5M+','employees','100+','acquirer','Yahoo!7','year',2011,'value_aud','~$40M','time_to_exit','10 months')
+    ),
+    'highlight_investments', ARRAY['VICE Golf (founding investor + advisor)','Airtasker (early investor + advisor)'],
+    'angel_portfolio_count','45+ over recent years',
+    'background','Born Munich; ex-professional basketball; Masters in Economics; Master of Information Technology, Macquarie University',
+    'check_size_note','$50k',
+    'sources', jsonb_build_object(
+      'linkedin','https://au.linkedin.com/in/justus-hammer-6a871b8',
+      'crunchbase','https://www.crunchbase.com/person/justus-hammer',
+      'pitchbook','https://pitchbook.com/profiles/investor/160885-99',
+      'theorg_mad_paws','https://theorg.com/org/mad-paws/org-chart/justus-hammer',
+      'b2b_expo','https://b2bexpo.com.au/speakers/justus-hammer/'
+    ),
+    'corrections','CSV portfolio truncated ("Airtasker, Vice Golf, Spre..."). Three retained verbatim. Added Mad Paws (current) and Sellable (latest founder venture).'
+  ),
+  updated_at = now()
+WHERE name = 'Justus Hammer';
+
+UPDATE investors SET
+  description = 'Melbourne-based serial entrepreneur and angel investor. CEO at DARE Venture Group. Founder/owner of KDR Private Office. 15+ years entrepreneurship, investment strategy, marketing and branding. Ex-Managing Partner K&K Ventures, ex-Principal Rainmaking ($5B+ equity value across 1389 ventures). Consumer Technology, Health focus. $50k–$150k cheques. Portfolio: WalkSafe, DryGo, LandEx.',
+  basic_info = 'Kane Daniel Ricca is a Melbourne-based serial entrepreneur with 15+ years experience in entrepreneurship, investment strategy, marketing and branding. He is currently CEO of **DARE Venture Group** and operates **KDR Private Office** as his investment vehicle.
+
+His operating background includes:
+- Founded and exited a marketing agency after 10 years, with clients including **Harrods, Qatar Airways, FIFA, Mercedes Benz, Formula 1, AVIVA** and Her Majesty''s Palace and Fortress.
+- **Managing Partner at K&K Ventures**.
+- **Principal at Rainmaking** — corporate venture studio that created $5B+ equity value across 1389 ventures.
+
+His CSV cheque size is $50k–$150k. Sector focus is Consumer Technology and Health. Notable CSV-listed portfolio: **WalkSafe** (consumer safety app), **DryGo** and **LandEx**.',
+  why_work_with_us = 'For Australian consumer-tech, health and brand-led founders, Kane combines exit-tested marketing-agency operator credentials, K&K Ventures + Rainmaking corporate-venture-studio scale exposure, and DARE Venture Group + KDR Private Office cheque capacity.',
+  sector_focus = ARRAY['Consumer Technology','Health','Marketing','Branding','SaaS','Consumer'],
+  stage_focus = ARRAY['Pre-seed','Seed','Series A'],
+  website = 'https://www.kdr.vision',
+  linkedin_url = 'https://www.linkedin.com/in/kanedanielricca/',
+  location = 'Melbourne, VIC',
+  country = 'Australia',
+  currently_investing = true,
+  leads_deals = true,
+  portfolio_companies = ARRAY['DARE Venture Group (CEO)','KDR Private Office','K&K Ventures (ex-Managing Partner)','Rainmaking (ex-Principal)','WalkSafe','DryGo','LandEx'],
+  meta_title = 'Kane Daniel Ricca — DARE Venture Group / KDR Private Office | Melbourne Angel',
+  meta_description = 'Melbourne CEO DARE Venture Group. Ex-K&K Ventures MP, Rainmaking Principal ($5B+, 1389 ventures). $50k–$150k.',
+  details = jsonb_build_object(
+    'current_roles', ARRAY['CEO, DARE Venture Group','Founder/Owner, KDR Private Office'],
+    'prior_roles', ARRAY['Managing Partner, K&K Ventures','Principal, Rainmaking ($5B+ value, 1389 ventures)','Founder/exited marketing agency (10 years; Harrods, Qatar Airways, FIFA, Mercedes Benz, Formula 1, AVIVA clients)'],
+    'experience_years','15+ years',
+    'check_size_note','$50k–$150k',
+    'sources', jsonb_build_object(
+      'kdr','https://www.kdr.vision/',
+      'linkedin','https://www.linkedin.com/in/kanedanielricca/',
+      'pitchbook','https://pitchbook.com/profiles/person/380589-49P',
+      'helpbnk','https://helpbnk.com/@kanedanielricca'
+    ),
+    'corrections','CSV portfolio truncated ("WalkSafe, DryGo, LandEx..."). Three retained as listed.'
+  ),
+  updated_at = now()
+WHERE name = 'Kane Daniel Ricca';
+
+UPDATE investors SET
+  description = 'Melbourne-based Co-Founder & Managing Partner of Protagonist Capital (pre-revenue and early-revenue Australian startup fund). Co-founder of Character + Distinction (Melbourne PR agency). VP Brand & Communications at Culture Amp. Mentor + Investor at Startmate since March 2018. $25k cheques into enterprise software, consumer SaaS. Notable: Milkdrop, Who Gives a Crap.',
+  basic_info = 'Kate Dinon is a Melbourne-based Co-Founder & Managing Partner of **Protagonist Capital** — an Australian pre-revenue and early-revenue startup fund focused on consumer and B2B SaaS. The fund emerged from her Melbourne PR/comms agency **Character + Distinction**, which she co-founded.
+
+Her primary day role is VP Brand & Communications at **Culture Amp** (one of Australia''s largest tech employers and a Blackbird Ventures portfolio company).
+
+She has been a **Mentor + Investor at Startmate since March 2018**, and her CSV-listed portfolio includes **Milkdrop** and **Who Gives a Crap** (toilet-paper subscription with 50% donation to clean-water charities; one of Australia''s most-cited social-impact consumer brands).
+
+CSV cheque size: $25k.',
+  why_work_with_us = 'For Australian consumer and B2B SaaS founders looking for an angel cheque alongside hands-on PR and brand-comms operator support, Kate is one of the more distinctive cheques on the Melbourne scene — Protagonist Capital fund-level + Character + Distinction agency advisory + Culture Amp + Startmate networks.',
+  sector_focus = ARRAY['Consumer','B2B SaaS','Enterprise Software','PR/Comms','Social Impact','Sustainability'],
+  stage_focus = ARRAY['Pre-seed','Seed'],
+  check_size_min = 25000,
+  check_size_max = 25000,
+  linkedin_url = 'https://www.linkedin.com/in/katedinon/',
+  contact_email = 'kate@protagonistcapital.com',
+  location = 'Melbourne, VIC',
+  country = 'Australia',
+  currently_investing = true,
+  portfolio_companies = ARRAY['Protagonist Capital (Co-Founder & Managing Partner)','Character + Distinction (Co-Founder; Melbourne PR agency)','Culture Amp (VP Brand & Communications)','Startmate (Mentor + Investor since March 2018)','Milkdrop','Who Gives a Crap'],
+  meta_title = 'Kate Dinon — Protagonist Capital MP | Melbourne Consumer + B2B SaaS Angel',
+  meta_description = 'Melbourne Co-Founder/MP Protagonist Capital. Co-founder Character + Distinction PR. VP Brand Culture Amp. Startmate Mentor. $25k.',
+  details = jsonb_build_object(
+    'firm','Protagonist Capital (pre-revenue + early-revenue startup fund; consumer + B2B SaaS)',
+    'role','Co-Founder & Managing Partner',
+    'co_founder_of', ARRAY['Character + Distinction (Melbourne PR/comms agency)'],
+    'current_roles', ARRAY['VP Brand & Communications, Culture Amp','Mentor + Investor, Startmate (since March 2018)'],
+    'verified_portfolio', ARRAY['Milkdrop','Who Gives a Crap'],
+    'check_size_note','$25k',
+    'sources', jsonb_build_object(
+      'linkedin','https://www.linkedin.com/in/katedinon/',
+      'smartcompany_seed_fund','https://www.smartcompany.com.au/startupsmart/news/kate-dinon-pr-agency-seed-fund-startup-investment/',
+      'character_distinction','https://www.ofcharacter.com',
+      'theorg_culture_amp','https://theorg.com/org/culture-amp/org-chart/kate-dinon',
+      'crunchbase','https://www.crunchbase.com/person/kate-dinon-5337'
+    ),
+    'corrections','CSV portfolio truncated ("Milkdrop, Who Gives a Cr..."). Two retained verbatim.'
+  ),
+  updated_at = now()
+WHERE name = 'Kate Dinon';
+
+UPDATE investors SET
+  description = 'Sydney-based serial entrepreneur and prolific angel investor. 50+ company portfolio incl. Cloudflare, Zoom, Afterpay, Airtasker, Zip, Slack, Monash IVF, Alibaba, Treasury Wines, Fastly, Oatly. Founded Le Black Book at age 21. CEO Her Fashion Box. Retail tech, e-commerce focus. $50K cheques.',
+  basic_info = 'Kath Purkis is a Sydney-based entrepreneur and prolific angel investor. She founded her first online retail company **Le Black Book** at age 21, and has been CEO of **Her Fashion Box**.
+
+Her angel portfolio is unusually broad and high-profile — **50+ companies invested in across Australia and overseas**. Notable holdings include **Cloudflare, Zoom, Afterpay, Airtasker, Zip, Slack, Monash IVF, Alibaba, Treasury Wines, Fastly** and **Oatly**.
+
+She brings 15+ years of entrepreneurial experience plus deep expertise in China manufacturing, scalable e-commerce solutions, customised software solutions, scaling globally and brand building. Sector focus: Retail technology, e-commerce, fintech, software, agriculture, food & beverage, sustainability and communications.',
+  why_work_with_us = 'For Australian retail-tech, e-commerce, consumer and fashion founders, Kath offers one of the broadest 50+ company angel portfolios in the country plus deep China-manufacturing and scalable-e-commerce operator credentials.',
+  sector_focus = ARRAY['Retail Tech','E-commerce','Fashion','Consumer','SaaS','FinTech','AgTech','FoodTech','Sustainability'],
+  stage_focus = ARRAY['Seed','Series A','Series B'],
+  check_size_min = 50000,
+  check_size_max = 50000,
+  website = 'https://www.kathpurkis.com',
+  linkedin_url = 'https://au.linkedin.com/in/kathpurkis',
+  contact_email = 'kp@kathpurkis.com',
+  location = 'Sydney, NSW',
+  country = 'Australia',
+  currently_investing = true,
+  leads_deals = true,
+  portfolio_companies = ARRAY['Le Black Book (founder; age 21)','Her Fashion Box (CEO)','Cloudflare','Zoom','Afterpay','Airtasker','Zip','Slack','Monash IVF','Alibaba','Treasury Wines','Fastly','Oatly'],
+  meta_title = 'Kath Purkis — Le Black Book founder | Sydney Retail Tech Angel',
+  meta_description = 'Sydney 50+ portfolio. Cloudflare, Zoom, Afterpay, Airtasker, Slack, Alibaba, Oatly. Founded Le Black Book at 21. $50K.',
+  details = jsonb_build_object(
+    'founder_of', ARRAY['Le Black Book (online retail; founded at age 21)'],
+    'current_roles', ARRAY['CEO, Her Fashion Box'],
+    'angel_portfolio_count','50+ companies in Australia and overseas',
+    'highlight_investments', ARRAY['Cloudflare','Zoom','Afterpay','Airtasker','Zip','Slack','Monash IVF','Alibaba','Treasury Wines','Fastly','Oatly'],
+    'experience_years','15+ years entrepreneurship',
+    'expertise', ARRAY['China manufacturing','Scalable e-commerce solutions','Customised software solutions','Scaling globally','Brand building'],
+    'check_size_note','$50K',
+    'sources', jsonb_build_object(
+      'website','https://www.kathpurkis.com',
+      'about','https://www.kathpurkis.com/about-kath-purkis',
+      'crunchbase','https://www.crunchbase.com/person/kath-purkis',
+      'angellist','https://angel.co/kath-purkis',
+      'clarity','https://clarity.fm/kathpurkis',
+      'medium','https://medium.com/@kathpurkis/about',
+      'f6s','https://www.f6s.com/kathpurkis'
+    ),
+    'corrections','CSV portfolio empty — populated with 11 verified portfolio names from public sources plus founder/CEO companies.'
+  ),
+  updated_at = now()
+WHERE name = 'Kath Purkis';
+
+UPDATE investors SET
+  description = 'Sydney-based deep-tech-and-healthtech-focused angel investor. CSV-listed portfolio includes Quantum Brilliance (ANU diamond-quantum-computer spinoff) and Baymax. Sector focus: Healthtech, Deeptech, B2B.',
+  basic_info = 'Kenny Wong is a Sydney-based angel investor with a stated sector focus on **HealthTech, DeepTech and B2B** per the Australian angel directory. CSV-listed portfolio:
+- **Quantum Brilliance** — Australian-German diamond-quantum-computing spinoff from ANU; ~$77.7M raised.
+- **Baymax** — could not be uniquely corroborated.
+
+The directory listing has not been uniquely corroborated to a single LinkedIn or Crunchbase profile from public-source search alone (multiple "Kenny Wong" individuals exist). Founders should validate the connection via the listed email when they make contact.',
+  why_work_with_us = 'For Australian deep-tech, healthtech and B2B founders, Kenny''s Quantum Brilliance position signals appetite for ambitious technical bets.',
+  sector_focus = ARRAY['HealthTech','DeepTech','B2B','Quantum','MedTech','SaaS'],
+  stage_focus = ARRAY['Seed','Series A'],
+  linkedin_url = 'https://au.linkedin.com/in/kennyvhkwong',
+  contact_email = 'kenny.ho.wong@gmail.com',
+  location = 'Sydney, NSW',
+  country = 'Australia',
+  currently_investing = true,
+  portfolio_companies = ARRAY['Quantum Brilliance','Baymax'],
+  meta_title = 'Kenny Wong — Sydney Healthtech/Deeptech Angel | Quantum Brilliance',
+  meta_description = 'Sydney-based deep-tech and healthtech angel. CSV portfolio: Quantum Brilliance, Baymax.',
+  details = jsonb_build_object(
+    'unverified', ARRAY[
+      'Could not uniquely match the directory listing to a single public investor profile (multiple Kenny Wong individuals).',
+      'Baymax could not be uniquely corroborated.'
+    ],
+    'sources', jsonb_build_object(
+      'linkedin_csv','https://au.linkedin.com/in/kennyvhkwong',
+      'quantum_brilliance_crunchbase','https://www.crunchbase.com/organization/quantum-brilliance'
+    ),
+    'corrections','CSV portfolio retained as listed. Common-name caveat noted.'
+  ),
+  updated_at = now()
+WHERE name = 'Kenny Wong';
+
+COMMIT;

--- a/supabase/migrations/20260422132600_enrich_angel_investors_batch_02w.sql
+++ b/supabase/migrations/20260422132600_enrich_angel_investors_batch_02w.sql
@@ -1,0 +1,235 @@
+-- Enrich angel investors — batch 02w (records 134-138: Kevin O'Hara → Landon Kahn)
+
+BEGIN;
+
+UPDATE investors SET
+  description = 'Sydney-based 3x exited founder turned VC and angel investor. Co-Founder & CEO of Trivian Capital and Sentor Investments (Sydney boutique principal investment firm focused on growth-stage ASEAN). Venture Partner at Primal Capital (UK), SDGx (Singapore), Newzone Ventures (Portugal). MBA + INSEAD + Harvard Business School postgrad. $50k–$250k cheques.',
+  basic_info = 'Kevin O''Hara is a Sydney-based 3x exited founder turned Angel and Venture Capitalist with one of the most internationally-distributed VC affiliation networks in the Australian scene.
+
+His operating background: founded and exited 3 successful Australian startups to private equity. Then completed an MBA with a major in Digital Transformation, plus postgraduate studies at both **INSEAD** and **Harvard Business School**.
+
+His current investment roles:
+- **Co-Founder & CEO of Trivian Capital**
+- **Sentor Investments** (Sydney boutique principal investment firm, founded 2015) — venture capital, private equity, digital assets, pre-IPO and listed equity across Australia, Israel, Asia, Europe and US. Particular focus on growth-capital opportunities in ASEAN.
+- **Investment Committee Member + Venture Partner, Primal Capital (UK)**
+- **Venture Partner, SDGx (Singapore)**
+- **Investment Committee Member, Newzone Ventures (Portugal)**
+
+CSV-listed portfolio: **Internet 2.0** (cybersecurity), **Immersve** and additional truncated names. CSV cheque size $50k–$250k.',
+  why_work_with_us = 'For Australian founders with international scale ambitions across ASEAN, UK, Singapore or Portugal, Kevin offers an unusually globally-distributed cheque-and-syndication footprint plus 3x exited-founder operator credentials.',
+  sector_focus = ARRAY['SaaS','Cybersecurity','FinTech','Crypto','DeepTech','Generalist','Cross-border'],
+  stage_focus = ARRAY['Seed','Series A','Series B','Growth'],
+  check_size_min = 50000,
+  check_size_max = 250000,
+  linkedin_url = 'https://www.linkedin.com/in/kevino23/',
+  contact_email = 'kevin@sentorinvestments.com.au',
+  location = 'Sydney, NSW',
+  country = 'Australia',
+  currently_investing = true,
+  leads_deals = true,
+  portfolio_companies = ARRAY['Trivian Capital (Co-Founder & CEO)','Sentor Investments (founded 2015)','Primal Capital UK (Venture Partner + IC Member)','SDGx Singapore (Venture Partner)','Newzone Ventures Portugal (IC Member)','Internet 2.0','Immersve'],
+  meta_title = 'Kevin O''Hara — Trivian / Sentor / Primal | Sydney Globally-Networked Angel',
+  meta_description = 'Sydney 3x exited founder. CEO Trivian Capital + Sentor Investments. VP Primal Capital UK, SDGx Singapore, Newzone Portugal. $50k–$250k.',
+  details = jsonb_build_object(
+    'founder_history','3 prior Australian startup exits to private equity',
+    'current_roles', ARRAY[
+      'Co-Founder & CEO, Trivian Capital',
+      'Sentor Investments (Sydney; founded 2015)',
+      'IC Member + Venture Partner, Primal Capital (UK)',
+      'Venture Partner, SDGx (Singapore)',
+      'IC Member, Newzone Ventures (Portugal)'
+    ],
+    'education', ARRAY['MBA (Digital Transformation major)','INSEAD postgraduate','Harvard Business School postgraduate'],
+    'check_size_note','$50k–$250k',
+    'sources', jsonb_build_object(
+      'sentor_crunchbase','https://www.crunchbase.com/organization/sentor-investments-4e2c',
+      'sentor_cb_insights','https://www.cbinsights.com/investor/sentor-investments',
+      'trivian','https://www.triviancapital.com/team',
+      'linkedin','https://au.linkedin.com/in/kevino23',
+      'wellfound','https://wellfound.com/p/kevin-sentorinvestments-com-au'
+    ),
+    'corrections','CSV portfolio truncated. Two retained verbatim plus expanded firm affiliations. CSV email truncated ("kevin@sentorinvestments..."). Resolved.'
+  ),
+  updated_at = now()
+WHERE name = 'Kevin O''Hara';
+
+UPDATE investors SET
+  description = 'Sydney-based serial entrepreneur and angel investor. Founder of Modibodi (period-and-leakage underwear; sold to Essity 2022 for ~AU$140M after 10 years CEO). OAM. Now investing and advising female-owned, social-impact-led businesses incl. Laronix, PeopleBench, Clean Slate Clinic, Human Health, Revibe, E-Leviate, Matched, Everty. $50k–$150k cheques.',
+  basic_info = 'Kristy Chong OAM is a Sydney-based serial entrepreneur and angel investor with one of the most-cited Australian female-founder exit stories. She is the founder of **Modibodi** — the period-and-leakage underwear brand she built into a category-defining business and sold to global health company **Essity** in 2022 for ~AU$140M after 10 years as CEO.
+
+She is now dedicating her time to investing in and advising **female-owned, social-impact-led businesses**. Verified portfolio:
+- **Laronix** (AI-powered voice-loss tech)
+- **PeopleBench** (HR/people analytics for schools)
+- **Clean Slate Clinic** (digital alcohol-treatment)
+- **Human Health**
+- **Revibe**
+- **E-Leviate**
+- **Matched**
+- **Everty** (EV charging digital tech)
+- **SBE Growth Advisory**
+
+She is openly biased toward female-founded businesses and has stated "I have a conscious bias" — she actively wants to see more female entrepreneurs.',
+  why_work_with_us = 'For Australian female-founded sustainability, health, social-impact and consumer brands, Kristy offers one of the highest-leverage cheques in the country — combining Modibodi''s $140M exit operator credentials, OAM-level public profile and an explicit female-founder bias.',
+  sector_focus = ARRAY['Sustainability','Health','Female Founders','Social Impact','Consumer','HealthTech','EnergyTech'],
+  stage_focus = ARRAY['Seed','Series A'],
+  check_size_min = 50000,
+  check_size_max = 150000,
+  linkedin_url = 'https://www.linkedin.com/in/kristy-chong-oam-3b21357/',
+  location = 'Sydney, NSW',
+  country = 'Australia',
+  currently_investing = true,
+  leads_deals = true,
+  portfolio_companies = ARRAY['Modibodi (Founder, ex-CEO; Essity exit 2022, AU$140M)','Laronix','PeopleBench','Clean Slate Clinic','Human Health','Revibe','E-Leviate','Matched','Everty','SBE Growth Advisory'],
+  meta_title = 'Kristy Chong OAM — Modibodi founder | Sydney Female-Founder Angel',
+  meta_description = 'Sydney founder Modibodi (Essity $140M exit 2022). OAM. Female-founded social-impact angel. Laronix, PeopleBench, Clean Slate Clinic, Everty. $50k–$150k.',
+  details = jsonb_build_object(
+    'founder_of', ARRAY['Modibodi (Founder, ex-CEO 10 years; Essity exit 2022, ~AU$140M)'],
+    'recognition', ARRAY['OAM (Order of Australia Medal)'],
+    'exits', jsonb_build_array(
+      jsonb_build_object('company','Modibodi','category','Period-and-leakage underwear','acquirer','Essity (global health)','year',2022,'value_aud','~$140M','tenure','10 years CEO')
+    ),
+    'investment_thesis','Female-owned, social-impact-led businesses with sustainability and health focus. Conscious female-founder bias.',
+    'verified_portfolio', ARRAY['Laronix','PeopleBench','Clean Slate Clinic','Human Health','Revibe','E-Leviate','Matched','Everty','SBE Growth Advisory'],
+    'check_size_note','$50k–$150k',
+    'sources', jsonb_build_object(
+      'linkedin','https://www.linkedin.com/in/kristy-chong-oam-3b21357/',
+      'sydney_uni','https://www.sydney.edu.au/news-opinion/news/2023/10/09/breaking-with-taboo.html',
+      'smartcompany_modibodi','https://www.smartcompany.com.au/entrepreneurs/kristy-chong-unmentionable-modibodi/',
+      'theorg_clean_slate','https://theorg.com/org/clean-slate-clinic/org-chart/kristy-chong-oam',
+      'allbright','https://www.allbrightcollective.com/edit/articles/heres-how-modibodis-kristy-chong-disrupted-an-entire-market-category',
+      'giant_leap','https://www.giantleap.com.au/blog-posts/a-founders-guide-to-educating-the-market-and-scaling-towards-exit---with-modibodis-kristy-chong'
+    ),
+    'corrections','CSV portfolio truncated ("Laronix, PeopleBench, Ev..."). Expanded with verified investments from public sources.'
+  ),
+  updated_at = now()
+WHERE name = 'Kristy Chong';
+
+UPDATE investors SET
+  description = 'Sydney-based Co-Founder and Partner at Flying Fox Ventures (early-stage AU/NZ syndicate, ~$5M/yr deployment). Founder of Eleanor Venture (predecessor early-stage VC). 20+ years in technology capital raising and M&A across AU, Asia, US. LLB(Hons), BA(Int Studies), AGSM Change Mgmt, Harvard leadership. 55+ portfolio incl. Josef, Fresh Equities, Jig Space, Goterra, Mr Yum, Heaps Normal, Butter Insurance. $150K cheques.',
+  basic_info = 'Kylie Frazer is a Sydney-based Co-Founder and Partner at **Flying Fox Ventures** — the early-stage Australian and NZ syndicate she co-founded with Rachael Neumann (separately listed as record #83) targeting ~$5M/year deployment across early-stage AU/NZ technology businesses.
+
+Before Flying Fox, she founded **Eleanor Venture** — an early-stage VC firm that made it easy for private investors to build their own diversified technology portfolios, with portfolio companies including Fresh Equities, Jig Space and Goterra.
+
+Combined Flying Fox + Eleanor Venture portfolio runs to **55+ companies** with ~$30M deployed. Notable holdings: **Josef, Fresh Equities, Jig Space, Goterra, Mr Yum, Heaps Normal, Butter Insurance** and many more.
+
+In 2024 Flying Fox tapped investors for a new $20M fund.
+
+She brings 20+ years of experience in technology capital raising and M&A across Australia, Asia and the United States. Education: **LLB (Hons) and BA (International Studies)**, postgraduate Change Management at AGSM, leadership studies at Harvard Business School. CSV cheque size $150K.',
+  why_work_with_us = 'For Australian and NZ early-stage founders, Kylie is among the most institutionally rigorous angel-syndicate operators — Flying Fox combines fund-style discipline with syndicate accessibility and her 20+ years of capital-raising/M&A pattern recognition.',
+  sector_focus = ARRAY['SaaS','Marketplace','FinTech','LegalTech','EdTech','Consumer','HealthTech','Climate'],
+  stage_focus = ARRAY['Pre-seed','Seed','Series A'],
+  check_size_min = 150000,
+  check_size_max = 150000,
+  website = 'https://www.flyingfox.vc',
+  linkedin_url = 'https://www.linkedin.com/in/kylie-frazer-6331407a/',
+  location = 'Sydney, NSW',
+  country = 'Australia',
+  currently_investing = true,
+  leads_deals = true,
+  portfolio_companies = ARRAY['Flying Fox Ventures (Co-Founder & Partner, with Rachael Neumann #83)','Eleanor Venture (Founder)','Josef','Fresh Equities','Jig Space','Goterra','Mr Yum','Heaps Normal','Butter Insurance'],
+  meta_title = 'Kylie Frazer — Flying Fox Ventures Co-Founder | Sydney Syndicate Angel',
+  meta_description = 'Sydney Co-Founder Flying Fox Ventures (~$5M/yr). Founder Eleanor Venture. 55+ portfolio. Josef, Goterra, Mr Yum, Heaps Normal. $150K.',
+  details = jsonb_build_object(
+    'firms', ARRAY[
+      'Flying Fox Ventures (Co-Founder & Partner; with Rachael Neumann #83)',
+      'Eleanor Venture (Founder)'
+    ],
+    'experience_years','20+ years technology capital raising and M&A (AU/Asia/US)',
+    'education', ARRAY['LLB (Hons), University of Sydney','BA (International Studies)','Postgraduate Change Management, AGSM','Leadership studies, Harvard Business School'],
+    'portfolio_count','55+ companies, ~$30M deployed',
+    'highlight_investments', ARRAY['Josef','Fresh Equities','Jig Space','Goterra','Mr Yum','Heaps Normal','Butter Insurance'],
+    'check_size_note','$150K',
+    'sources', jsonb_build_object(
+      'linkedin','https://au.linkedin.com/in/kylie-frazer-6331407a',
+      'crunchbase','https://www.crunchbase.com/person/kylie-frazer',
+      'flying_fox','https://www.flyingfox.vc/',
+      'business_news_au_20m','https://www.businessnewsaustralia.com/articles/-we-feel-really-confident---early-stage-vc-firm-flying-fox-ventures-taps-investors-for-new--20m-fund.html',
+      'on_impact','https://onimpact.com.au/flying-fox-ventures-its-not-vc-its-a-master-class-in-angel-investing/',
+      'pioneera_take_5','https://pioneera.com/content/blog/take-5-kylie-frazer'
+    ),
+    'corrections','CSV portfolio truncated ("Josef, Fresh Equities, Jig..."). Expanded with verified Flying Fox/Eleanor portfolio from public sources.'
+  ),
+  updated_at = now()
+WHERE name = 'Kylie Frazer';
+
+UPDATE investors SET
+  description = 'Sydney-based serial consumer-brand entrepreneur and angel investor. Co-Founder of Yes To Inc (one of largest US natural-beauty brands) and Yoobi (school supplies). Co-founder of Cheeky Home (tableware with meal donation). Ex-Chairman Bellabox (Feb 2013-Jan 2019). Advisor + Investor RangeMe (2015-2017). Chairman district8.',
+  basic_info = 'Lance Kalish is a Sydney-based serial entrepreneur and consumer-products angel investor. He is best known as Co-Founder of:
+- **Yes To Inc** (with Ido Leffler) — one of the largest natural-beauty brands in the United States.
+- **Yoobi** — school-supplies social-enterprise that provides supplies to underprivileged children.
+- **Cheeky Home** — colourful tableware brand with meal-donation model.
+
+His angel portfolio centre-of-mass is consumer goods. Notable positions:
+- **Bellabox** (Australian beauty subscription) — Series A investor January 2013; Chairman February 2013 – January 2019.
+- **RangeMe** (B2B retail-product discovery; acquired by Emerge Commerce) — Advisor + Investor January 2015 – July 2017.
+- **district8** — Chairman.',
+  why_work_with_us = 'For Australian and global consumer-goods, beauty, household and social-enterprise founders, Lance offers exit-tested consumer-brand operating credentials (Yes To Inc, Yoobi, Cheeky Home) plus 6+ years of Bellabox chairmanship.',
+  sector_focus = ARRAY['Consumer','Consumer Goods','Beauty','Household','Social Enterprise','Retail Tech'],
+  stage_focus = ARRAY['Seed','Series A'],
+  linkedin_url = 'https://www.linkedin.com/in/lance-kalish-1555b/',
+  contact_email = 'lance.kalish@gmail.com',
+  location = 'Sydney, NSW',
+  country = 'Australia',
+  currently_investing = true,
+  leads_deals = true,
+  portfolio_companies = ARRAY['Yes To Inc (Co-Founder)','Yoobi (Co-Founder, Chairman, CFO)','Cheeky Home (Co-Founder)','Bellabox (ex-Chairman 2013-2019)','RangeMe (Advisor + Investor 2015-2017)','district8 (Chairman)'],
+  meta_title = 'Lance Kalish — Yes To Inc / Yoobi / Bellabox | Sydney Consumer Angel',
+  meta_description = 'Sydney consumer-brand serial founder. Co-Founder Yes To Inc, Yoobi, Cheeky Home. Ex-Chairman Bellabox. RangeMe advisor.',
+  details = jsonb_build_object(
+    'co_founder_of', ARRAY['Yes To Inc (US natural-beauty brand)','Yoobi (school supplies social enterprise)','Cheeky Home (colourful tableware with meal donation)'],
+    'past_chairman_roles', ARRAY['Bellabox (Feb 2013 - Jan 2019)','district8'],
+    'past_advisor_roles', ARRAY['RangeMe (Advisor + Investor; Jan 2015 - Jul 2017)'],
+    'investment_thesis','Consumer goods, beauty, household, retail-tech and social-enterprise.',
+    'sources', jsonb_build_object(
+      'linkedin','https://www.linkedin.com/in/lance-kalish-1555b/',
+      'crunchbase','https://www.crunchbase.com/person/lance-kalish',
+      'pitchbook','https://pitchbook.com/profiles/investor/224336-08',
+      'theorg_yoobi','https://theorg.com/org/yoobi/org-chart/lance-kalish',
+      'smartcompany_yes_to','https://www.smartcompany.com.au/entrepreneurs/ido-leffler-australia-successful-entrepreneurs-adam-schwab/',
+      'wikipedia_ido_leffler','https://en.wikipedia.org/wiki/Ido_Leffler'
+    ),
+    'corrections','CSV portfolio truncated ("Bellabox, RangeMe, Beac..."). Two verified retained; trailing item could not be uniquely identified. Added Yes To Inc, Yoobi, Cheeky Home, district8 from verified founder/chairman roles.'
+  ),
+  updated_at = now()
+WHERE name = 'Lance Kalish';
+
+UPDATE investors SET
+  description = 'Sydney-based climate-tech and impact angel investor. NetZero & Energy Transition Consultant and Business Advisor. 13 angel investments to date. $5k–$20k cheques. Active in Australian climate-tech investor community.',
+  basic_info = 'Landon Kahn is a Sydney-based **NetZero & Energy Transition Consultant**, business advisor and angel investor with an explicit Climatetech and Impact thesis.
+
+Per the CSV directory, he has made **13 angel investments to date** with cheque sizes of $5k–$20k. He is active in the Australian climate-tech investor community and has a regular public profile via LinkedIn on solar, EV and renewable-energy themes.
+
+Beyond the directory entry and his consulting/advisor practice, individual portfolio details could not be uniquely corroborated from public-source search.',
+  why_work_with_us = 'For Australian climate-tech, energy-transition and impact-led founders, Landon offers a small first cheque ($5k–$20k) plus NetZero/energy-transition consulting expertise.',
+  sector_focus = ARRAY['Climate Tech','Impact','Energy Transition','NetZero','Renewables','Solar','EV'],
+  stage_focus = ARRAY['Pre-seed','Seed'],
+  check_size_min = 5000,
+  check_size_max = 20000,
+  linkedin_url = 'https://www.linkedin.com/in/landonkahn',
+  contact_email = 'hello@landonkahn.com.au',
+  location = 'Sydney, NSW',
+  country = 'Australia',
+  currently_investing = true,
+  portfolio_companies = ARRAY['NetZero & Energy Transition consulting practice','13 climate-tech angel investments to date'],
+  meta_title = 'Landon Kahn — Sydney Climate-Tech Angel | $5k–$20k',
+  meta_description = 'Sydney NetZero & Energy Transition Consultant. Climate Tech and Impact angel. 13 investments. $5k–$20k.',
+  details = jsonb_build_object(
+    'professional_role','NetZero & Energy Transition Consultant + Business Advisor',
+    'investment_count','13 (per CSV)',
+    'investment_thesis','Climate Tech and Impact early-stage Australian businesses.',
+    'check_size_note','$5k–$20k',
+    'unverified', ARRAY[
+      'Beyond CSV directory listing, individual portfolio companies could not be uniquely corroborated from public-source search.'
+    ],
+    'sources', jsonb_build_object(
+      'linkedin','https://www.linkedin.com/in/landonkahn',
+      'climate_salad_investors','https://www.climatesalad.com/climate-tech-angel-investors-australia',
+      'climate_angels','https://www.climateangels.vc',
+      'flashlabs','https://www.flashlabs.ai/people/Landon-Kahn-b9d2da9965ac41417cb164036d742440/'
+    ),
+    'corrections','CSV portfolio "13 investments so far" — interpreted as count rather than literal portfolio names.'
+  ),
+  updated_at = now()
+WHERE name = 'Landon Kahn';
+
+COMMIT;


### PR DESCRIPTION
## Summary

20 records in 4 atomic migrations.

### Highlights

- **#119 John Henderson** — AirTree Ventures GP, ex-Facebook + Summly COO ($30M Yahoo exit)
- **#127 Justin Butterworth** — Snug.com founder; Stayz $29M Fairfax exit 2011
- **#129 Justus Hammer** — Mad Paws CEO; Spreets $40M Yahoo!7 10-month exit; 45+ investments
- **#131 Kate Dinon** — Protagonist Capital MP, Culture Amp VP, Startmate Mentor since 2018
- **#132 Kath Purkis** — 50+ portfolio incl. Cloudflare, Zoom, Afterpay, Slack, Alibaba, Oatly
- **#134 Kevin O'Hara** — Globally distributed: Trivian + Sentor + Primal UK + SDGx Singapore + Newzone Portugal
- **#135 Kristy Chong OAM** — Modibodi founder ($140M Essity exit 2022); explicit female-founder bias
- **#136 Kylie Frazer** — Flying Fox Ventures Co-Founder (with #83 Rachael Neumann); 55+ portfolio
- **#137 Lance Kalish** — Yes To Inc Co-Founder + Yoobi + ex-Bellabox Chairman

### Cross-references

- **#136 Kylie Frazer** ↔ **#83 Rachael Neumann** (Flying Fox Ventures co-founders)
- **#135 Kristy Chong** ↔ **#66 Danin Kahn** (both Everty investors)

**Series state:** pilot (3) + 01a–01d (20) + 02a–02w (115) = **138 of 267** (52% complete)

## Files

- `20260422132300_enrich_angel_investors_batch_02t.sql` (119-123)
- `20260422132400_enrich_angel_investors_batch_02u.sql` (124-128)
- `20260422132500_enrich_angel_investors_batch_02v.sql` (129-133)
- `20260422132600_enrich_angel_investors_batch_02w.sql` (134-138)

https://claude.ai/code/session_017Zvz2r5Y2U8bP3eY4cwAFe

---
_Generated by [Claude Code](https://claude.ai/code/session_01XsHLVbJ1rAJ3oafzHY6j2N)_