### PR TITLE
Enrich VCs batch 02a-02d (records 21-40)

### DIFF
--- a/supabase/migrations/20260422140400_enrich_vcs_batch_02a.sql
+++ b/supabase/migrations/20260422140400_enrich_vcs_batch_02a.sql
@@ -1,0 +1,182 @@
+-- Enrich VCs — batch 02a (records 21-25: Billfolda Ventures → Boson Ventures)
+
+BEGIN;
+
+UPDATE investors SET
+  basic_info = 'Billfolda Ventures (BVC) is a **Sydney-based ESVCFLP** sector-agnostic pre-seed/seed venture capital fund founded in **2024** with **AU$10.5M committed capital** from members of the successful **Billfolda Angels Investment Syndicate** (active since 2019).
+
+The fund has applied for **Early Stage Venture Capital Limited Partnership status** and targets **AU$25M maximum committed capital**. Plans **15-20 investments** in Australian pre-seed, seed, start-up and early-expansion businesses with additional capital reserved for follow-on investment.
+
+Investment range: **AU$200k–$2M** at **Angel, Pre-seed, Seed and Series A** stages. Sector mandate: **Sustainable Tech, AI, FinTech, HealthTech, Cyber, CleanTech and DefenceTech**.
+
+**Track record:** Billfolda Angels Syndicate has invested actively since 2019 in **9 companies** — 5 of which have offered exit opportunities, with most subsequent rounds at higher valuations.',
+  why_work_with_us = 'For Australian pre-seed and seed-stage founders across Sustainable Tech, AI, FinTech, HealthTech, Cyber, CleanTech and DefenceTech — Billfolda Ventures offers a $200k–$2M cheque from an ESVCLP-aligned vehicle with proven angel-syndicate track record (9 investments since 2019, 5 exit opportunities). Especially valuable for sector-aligned founders looking for structured early-stage capital with follow-on capacity.',
+  meta_title = 'Billfolda Ventures — Sydney ESVCFLP Pre-Seed/Seed VC | $200k–$2M | $10.5M Fund',
+  meta_description = 'Sydney ESVCFLP since 2024. AU$10.5M fund (max $25M). Sustainable Tech, AI, FinTech, HealthTech, Cyber, Defence. $200k–$2M.',
+  details = jsonb_build_object(
+    'organisation_type','ESVCFLP (Early Stage Venture Capital Fund Limited Partnership; pending registration)',
+    'founded',2024,
+    'committed_capital','AU$10.5M',
+    'max_capital','AU$25M',
+    'investment_thesis','Sector-agnostic — Sustainable Tech, AI, FinTech, HealthTech, Cyber, CleanTech, DefenceTech.',
+    'check_size_note','AU$200k–$2M',
+    'plan','15-20 Australian pre-seed/seed investments + follow-on',
+    'parent_syndicate','Billfolda Angels Investment Syndicate (active since 2019; 9 investments)',
+    'sources', jsonb_build_object(
+      'website','https://billfolda.vc/',
+      'fund_structure','https://billfolda.vc/fund-structure/'
+    )
+  ),
+  updated_at = now()
+WHERE name = 'Billfolda Ventures';
+
+UPDATE investors SET
+  basic_info = 'Black Nova VC is a **Sydney-based early-stage B2B SaaS specialist venture capital fund** founded in **2020 by Matthew Browne and Darcy Naunton**. Headquartered in Surry Hills.
+
+The firm''s thesis is **mission-critical, workflow-led B2B SaaS in regulated industries** — at **Pre-Seed, Seed and Series A** stages. Cheque size: up to **AU$1M**.
+
+**Fund II closed exceeding AU$35M target (December 2025)** — making Black Nova one of the most-active and best-capitalised pure-play B2B SaaS funds in the ANZ market.
+
+Portfolio includes some of Australia''s most exciting B2B SaaS companies:
+- **Kismet** (workflow automation)
+- **Operata** (contact-centre observability)
+- **Offerfit** (AI marketing)
+- **Cipherstash** (encryption-as-a-service)
+- **GovConnex** (government engagement SaaS)
+- **Pathzero** (carbon accounting)
+- **Notiv** (meeting intelligence)
+- **Functionly** (org-design SaaS)
+- **RightPaw** (pet-care marketplace)
+
+Several Australian individual angels are LPs in Black Nova VC (covered separately in this directory).',
+  why_work_with_us = 'For Australian B2B SaaS founders building **mission-critical, workflow-led software in regulated industries** — Black Nova VC is the most credentialed sector-pure B2B SaaS specialist VC in the ANZ market. Fund II''s AU$35M+ close plus the Matthew Browne / Darcy Naunton operator track record signal both capital depth and sector pattern recognition.',
+  meta_title = 'Black Nova VC — Sydney B2B SaaS Specialist | Fund II AU$35M+ | up to $1M',
+  meta_description = 'Sydney B2B SaaS VC since 2020. Mission-critical workflow software. Fund II AU$35M+. Kismet, Operata, Cipherstash.',
+  details = jsonb_build_object(
+    'founded',2020,
+    'founders', ARRAY['Matthew Browne','Darcy Naunton'],
+    'investment_thesis','Mission-critical, workflow-led B2B SaaS in regulated industries.',
+    'check_size_note','Up to AU$1M',
+    'fund_ii','Closed exceeding AU$35M target (Dec 2025)',
+    'highlight_investments', jsonb_build_array(
+      jsonb_build_object('company','Cipherstash','context','Australian encryption-as-a-service'),
+      jsonb_build_object('company','Operata','context','Contact-centre observability'),
+      jsonb_build_object('company','Pathzero','context','Carbon accounting'),
+      jsonb_build_object('company','GovConnex','context','Government engagement SaaS')
+    ),
+    'sources', jsonb_build_object(
+      'website','https://www.blacknova.vc/'
+    )
+  ),
+  updated_at = now()
+WHERE name = 'Black Nova VC';
+
+UPDATE investors SET
+  basic_info = 'Black Sheep Capital is a **Brisbane-based early-stage angel/micro-VC** founded in **2013 by Dan Gavel**. Focused on scalable technology companies at **Pre-Seed through Series B** stages — typical deals **AU$1M–$5M**.
+
+Portfolio reflects deep operator-aligned consumer/B2B software pattern recognition, with **52 investments** across diverse sectors — primarily technology and healthcare:
+- **Amber Electric** (Australian energy retail)
+- **Go1** (corporate learning unicorn)
+- **Ignition** (Australian client engagement SaaS)
+- **Valiant Finance** (SME finance marketplace)
+- **Notiv** (meeting intelligence)
+- **Sendle** (delivery)
+- **Practice Ignition** / **Ignition** (acquired)
+
+The fund manager has executed **more than 50 investments** across diverse sectors.',
+  why_work_with_us = 'For Australian — and especially Brisbane/Queensland-based — early-stage technology and healthcare founders pursuing pre-seed through Series B rounds — Black Sheep Capital combines 12+ years of operating history with a high-quality 50+ investment portfolio (Amber, Go1, Ignition, Valiant). Especially valuable for founders looking for hands-on early-stage support from a pure-play tech-sector specialist.',
+  meta_title = 'Black Sheep Capital — Brisbane Early-Stage Tech VC since 2013 | 52+ Investments',
+  meta_description = 'Brisbane micro-VC since 2013. Technology, healthcare. Pre-Seed to Series B. 52+ investments. Amber, Go1, Ignition.',
+  details = jsonb_build_object(
+    'founded',2013,
+    'founder','Dan Gavel',
+    'investment_thesis','Scalable technology — pre-seed through Series B.',
+    'check_size_note','AU$1M–$5M typical',
+    'portfolio_size','52+ investments',
+    'highlight_investments', jsonb_build_array(
+      jsonb_build_object('company','Go1','context','Australian corporate learning unicorn'),
+      jsonb_build_object('company','Amber Electric','context','Australian energy retail'),
+      jsonb_build_object('company','Ignition','context','Acquired')
+    ),
+    'sources', jsonb_build_object(
+      'website','https://blacksheepcapital.com.au/'
+    )
+  ),
+  updated_at = now()
+WHERE name = 'Black Sheep Capital';
+
+UPDATE investors SET
+  basic_info = 'Blackbird Ventures is **one of Australia''s largest and most prominent venture capital funds** — and arguably the most active backer of globally-ambitious ANZ founders. Founded **2012 by Niki Scevak, Rick Baker and Bill Bartee**.
+
+The firm invests in the **most ambitious founders from Australia and New Zealand building technology companies that can become global leaders** — across **Pre-Seed through Growth** stages, with cheques from **AU$100k to AU$50M**.
+
+Blackbird''s portfolio reads as a who''s-who of ANZ tech success stories:
+- **Canva** (one of Australia''s most successful tech companies; design unicorn — Niki Scevak led seed)
+- **SafetyCulture** (workplace safety SaaS unicorn)
+- **Culture Amp** (employee experience SaaS unicorn)
+- **Zoox** (autonomous vehicles — acquired by Amazon for ~US$1.2B)
+- Plus an extensive portfolio of breakout ANZ companies
+
+Blackbird also operates the **First Believers** programme — Australia''s most prominent accelerator-angel programme that has bootstrapped many of Australia''s most active emerging angel investors (covered extensively in this directory).',
+  why_work_with_us = 'For Australian and New Zealand technology founders building globally-ambitious companies — Blackbird Ventures is the most-active and best-known VC partner for ANZ tech ambition. Their unicorn-rich portfolio (Canva, SafetyCulture, Culture Amp, Zoox), $100k–$50M cheque flexibility and First Believers angel-network make them a top-of-funnel choice for founders pursuing global category leadership.',
+  meta_title = 'Blackbird Ventures — Australia''s Largest VC | Canva, SafetyCulture, Zoox',
+  meta_description = 'Sydney/Melbourne/Auckland VC since 2012. ANZ founders building global tech. Pre-Seed to Growth. $100k–$50M.',
+  details = jsonb_build_object(
+    'founded',2012,
+    'founders', ARRAY['Niki Scevak','Rick Baker','Bill Bartee'],
+    'investment_thesis','Ambitious ANZ founders building global tech leaders — Pre-Seed through Growth.',
+    'check_size_note','AU$100k–$50M',
+    'highlight_investments', jsonb_build_array(
+      jsonb_build_object('company','Canva','context','Design unicorn — one of Australia''s most successful tech companies'),
+      jsonb_build_object('company','SafetyCulture','context','Workplace safety SaaS unicorn'),
+      jsonb_build_object('company','Culture Amp','context','Employee experience SaaS unicorn'),
+      jsonb_build_object('company','Zoox','context','Autonomous vehicles — acquired by Amazon ~US$1.2B')
+    ),
+    'programmes', ARRAY['First Believers (premier accelerator-angel programme)'],
+    'sources', jsonb_build_object(
+      'website','https://www.blackbird.vc/'
+    )
+  ),
+  updated_at = now()
+WHERE name = 'Blackbird Ventures';
+
+UPDATE investors SET
+  basic_info = 'Boson Ventures is a **Sydney-based early-stage venture capital firm** founded in **2021 by Alan Jones and Victor Ma**.
+
+The firm operates two distinct fund vehicles:
+- **Boson Newton Fund** — DeepTech, biotech, medtech, cleantech
+- **Boson Eoarchean Fund** — B2B SaaS, FinTech
+
+Boson''s differentiator is its **unique global perspective with extensive networks in China and the United States** — specifically positioned to help portfolio scale through Chinese manufacturing and US capital markets. Given that much of high-tech downstream manufacturing is concentrated in China, Boson''s connections provide invaluable support for scaling deep-tech.
+
+The team comprises ex-founders, former corporate executives and veteran investors. Stage focus: **Pre-Seed and Seed**.
+
+Portfolio includes:
+- **GreenDynamics** (Australian climate-tech)
+- **Osara Health** (digital therapeutics)
+- **Hello Clever** (FinTech)
+- **Fiable** (FinTech)
+- **Kite Magnetics** (deep-tech magnets — also Breakthrough Victoria portfolio)',
+  why_work_with_us = 'For Australian and New Zealand deep-tech, biotech, medtech, cleantech, B2B SaaS and FinTech founders pursuing **China-supply-chain or US-market expansion** — Boson Ventures combines two specialist sub-funds with rare ANZ-China-US connectivity. Especially valuable for hardware-and-deep-tech founders needing structured Chinese manufacturing partnerships.',
+  meta_title = 'Boson Ventures — Sydney Deep-Tech / B2B SaaS VC | China + US Connectivity',
+  meta_description = 'Sydney VC since 2021. Newton Fund (deep-tech) + Eoarchean Fund (B2B SaaS). China/US scaling network.',
+  details = jsonb_build_object(
+    'founded',2021,
+    'founders', ARRAY['Alan Jones','Victor Ma'],
+    'funds', jsonb_build_array(
+      jsonb_build_object('name','Boson Newton Fund','focus','DeepTech, biotech, medtech, cleantech'),
+      jsonb_build_object('name','Boson Eoarchean Fund','focus','B2B SaaS, FinTech')
+    ),
+    'investment_thesis','ANZ early-stage with China and US scaling-network leverage.',
+    'highlight_investments', jsonb_build_array(
+      jsonb_build_object('company','Kite Magnetics','context','Deep-tech magnets'),
+      jsonb_build_object('company','GreenDynamics','context','Climate-tech')
+    ),
+    'sources', jsonb_build_object(
+      'website','https://www.boson.vc/'
+    )
+  ),
+  updated_at = now()
+WHERE name = 'Boson Ventures';
+
+COMMIT;

--- a/supabase/migrations/20260422140500_enrich_vcs_batch_02b.sql
+++ b/supabase/migrations/20260422140500_enrich_vcs_batch_02b.sql
@@ -1,0 +1,168 @@
+-- Enrich VCs — batch 02b (records 26-30: Brandon Capital Partners → Cardinia Ventures)
+
+BEGIN;
+
+UPDATE investors SET
+  basic_info = 'Brandon Capital Partners is **Australasia''s leading life-science venture capital firm**, headquartered in Melbourne with a strong global presence supported by team members and partnerships across the **United States and United Kingdom**.
+
+Founded **2007**, Brandon has raised **over AU$1B+ across six funds** and completed **60+ investments** in new therapeutic, medical-device and health-tech companies.
+
+**Fund VI (BB6)** had a **A$439M final close in July 2025** — the firm''s largest fund yet, supporting growth of Australian and New Zealand life-sciences startups, scale-ups and Brandon''s expansion into the UK, Europe and US.
+
+The firm operates the **Brandon BioCatalyst** programme (Australasian life-science collaboration; CUREator incubator) and the **Medical Research Commercialisation Fund**.
+
+Active portfolio: **30+ companies** with **17 in clinical trials**. Notable investments:
+- **AdvanCell** (radiopharma — US$112M Series C)
+- **Myricx Bio** (ADC-focused; US$114M Series A)
+- **CatalYm** (German oncology — US$150M Series D)
+- **PolyActiva** (drug delivery)
+- **ENA Respiratory** (clinical-stage drug development)
+- **Currus Biologics** (Peter MacCallum Cancer Centre spin-out — $10M MRCF-led seed)
+- **Azura Ophthalmics**
+- **Certa Therapeutics**
+- **EBR Systems**
+- **George Medicines**',
+  why_work_with_us = 'For Australian and New Zealand life-sciences, biotech, medical-device and pharmaceutical founders — Brandon Capital Partners is the **most credentialed and best-resourced life-science VC in the ANZ market**. With AU$1B+ across 6 funds, A$439M Fund VI, 60+ investments and 17 portfolio companies in clinical trials, Brandon is the go-to fund for capital-intensive life-science ventures pursuing global commercialisation.',
+  meta_title = 'Brandon Capital Partners — Australasia''s Largest Life-Science VC | AU$1B+ FUM',
+  meta_description = 'Melbourne life-science VC since 2007. AU$1B+ across 6 funds. Fund VI A$439M (Jul 2025). 60+ investments.',
+  details = jsonb_build_object(
+    'founded',2007,
+    'fum','AU$1B+ across 6 funds',
+    'investment_thesis','Life sciences — therapeutics, medical devices, health-tech.',
+    'fund_vi','Fund VI (BB6) A$439M final close July 2025',
+    'portfolio_size','30+ active; 60+ total; 17 in clinical trials',
+    'programmes', ARRAY['Brandon BioCatalyst (CUREator incubator; Australasian life-science collaboration)','Medical Research Commercialisation Fund (MRCF)'],
+    'highlight_investments', jsonb_build_array(
+      jsonb_build_object('company','AdvanCell','context','Radiopharma — US$112M Series C'),
+      jsonb_build_object('company','Myricx Bio','context','ADC-focused — US$114M Series A'),
+      jsonb_build_object('company','CatalYm','context','German oncology — US$150M Series D')
+    ),
+    'sources', jsonb_build_object(
+      'website','https://brandoncapital.vc/',
+      'biocatalyst','https://brandonbiocatalyst.com/'
+    )
+  ),
+  updated_at = now()
+WHERE name = 'Brandon Capital Partners';
+
+UPDATE investors SET
+  basic_info = 'Breakthrough Victoria is the **Victorian Government''s private investment company** — established **2021** with a **AU$2B mandate** to invest in **breakthrough technologies and ideas** that will create high-paying Victorian jobs and economic growth.
+
+The firm invests across **all stages from research translation through to growth** in five priority sectors:
+- **Advanced Manufacturing**
+- **Agri-Food**
+- **Clean Economy**
+- **Digital Technologies**
+- **Health & Life Sciences**
+
+Notable portfolio includes:
+- **Kite Magnetics** (deep-tech magnets)
+- **Seer Medical** (medical devices)
+- **RayGen** (solar+storage — also CEFC-backed)
+- **Remagine Labs**
+- **Myostellar**
+- **FytonBio**',
+  why_work_with_us = 'For Victorian-based or Victorian-relevant founders in advanced manufacturing, agri-food, clean economy, digital technologies and health & life sciences — Breakthrough Victoria offers a Government-backed cheque with stages from research translation through to growth. Especially valuable for founders pursuing Victorian state-based commercialisation pathways and capital-intensive deep-tech development.',
+  meta_title = 'Breakthrough Victoria — Victorian Government VC | AU$2B Mandate | All Stages',
+  meta_description = 'Melbourne Victorian Government investment company. AU$2B mandate. Advanced manufacturing, agri-food, clean economy, digital, health.',
+  details = jsonb_build_object(
+    'founded',2021,
+    'organisation_type','Victorian Government private investment company',
+    'mandate','AU$2B',
+    'investment_thesis','Advanced Manufacturing, Agri-Food, Clean Economy, Digital Technologies, Health & Life Sciences.',
+    'stages','Research translation through to growth.',
+    'sources', jsonb_build_object(
+      'website','https://breakthroughvictoria.com/'
+    )
+  ),
+  updated_at = now()
+WHERE name = 'Breakthrough Victoria';
+
+UPDATE investors SET
+  basic_info = 'Breyer Capital is a **global venture capital and private-equity firm** founded **2006 by Jim Breyer** — best known as one of the **earliest investors in Facebook** (Accel''s lead investor when Facebook was still a startup).
+
+The firm is headquartered in **Austin, Texas** and invests **globally** across **AI/ML, healthcare, vertical AI, FinTech and sustainability**.
+
+Stage focus: **Seed, Series A, Series B and Series C**.
+
+Notable historic investments:
+- **Facebook** (early — landmark Accel investment by Jim Breyer)
+- **Etsy**
+- **Legendary Entertainment**
+
+Jim Breyer is widely recognised as one of the most successful and prolific venture capitalists globally.',
+  why_work_with_us = 'For globally-ambitious AI, ML, healthcare, vertical-AI, FinTech and sustainability founders — Breyer Capital offers one of the most credentialed venture cheques in the world. Jim Breyer''s Facebook seed-investor track record signals exceptional pattern recognition for category-defining companies. Best leveraged by ANZ founders pursuing US Series A/B/C with global ambition.',
+  meta_title = 'Breyer Capital — Jim Breyer''s Global VC/PE Firm | AI / Healthcare | Austin TX',
+  meta_description = 'Austin global VC/PE since 2006. Jim Breyer (Facebook early investor). AI/ML, healthcare, vertical AI, FinTech.',
+  details = jsonb_build_object(
+    'founded',2006,
+    'founder','Jim Breyer',
+    'investment_thesis','AI/ML, healthcare, vertical AI, FinTech, sustainability — Seed through Series C.',
+    'highlight_investments', jsonb_build_array(
+      jsonb_build_object('company','Facebook','context','Early — landmark Accel investment by Jim Breyer'),
+      jsonb_build_object('company','Etsy','context','Early-stage'),
+      jsonb_build_object('company','Legendary Entertainment','context','Media/entertainment')
+    ),
+    'sources', jsonb_build_object(
+      'website','https://www.breyercapital.com/'
+    )
+  ),
+  updated_at = now()
+WHERE name = 'Breyer Capital';
+
+UPDATE investors SET
+  basic_info = 'BridgeLane Group is the **private family office of Markus Kahlbetzer**. Activities span **agriculture, real estate, and historically venture capital**.
+
+The firm is **NOT currently active as a VC investor** — Markus has moved focus to **Side Stage Ventures** for his current venture investing activity.
+
+**Historic VC portfolio** (under previous active VC mandate):
+- **Amaysim** (Australian mobile telco — ASX-listed)
+- **Airtasker** (Australian gig-economy marketplace — ASX-listed)
+- **BrickX** (proptech)',
+  why_work_with_us = 'For Australian founders looking for family-office-backed capital, BridgeLane Group is **NOT currently active as a venture investor**. Markus Kahlbetzer''s current venture activity is via **Side Stage Ventures** — founders should approach Side Stage directly for venture investment conversations.',
+  meta_title = 'BridgeLane Group — Markus Kahlbetzer Family Office | NOT Currently VC Active',
+  meta_description = 'Sydney Markus Kahlbetzer family office. Agriculture, real estate, historic VC. Not currently VC active — see Side Stage.',
+  details = jsonb_build_object(
+    'organisation_type','Private family office',
+    'principal','Markus Kahlbetzer',
+    'currently_vc_active',false,
+    'current_venture_vehicle','Side Stage Ventures (Markus''s current venture vehicle)',
+    'historic_portfolio', ARRAY['Amaysim','Airtasker','BrickX']
+  ),
+  updated_at = now()
+WHERE name = 'BridgeLane Group';
+
+UPDATE investors SET
+  basic_info = 'Cardinia Ventures is a **Melbourne-based venture capital firm** investing across **Australia and the United States** in software and hardware companies at **Pre-Seed to Series A** stages.
+
+Sector mandate is broad — software and hardware companies across diverse sectors.
+
+The firm has invested in **at least 6 SaaS companies and 13 enterprise (B2B) companies**, with **3 portfolio acquisitions** to date — most notably **Chronosphere** (acquired by **Palo Alto Networks for US$3.35B in November 2025**).
+
+Portfolio includes:
+- **AdRoll** (digital marketing)
+- **Alariss**
+- **Cadmus** (assessment SaaS)
+- **Chronosphere** (acquired by Palo Alto Networks Nov 2025 — US$3.35B)
+- **Cognian** (smart-building IoT)
+- **Drop Water**
+- **Edrolo** (Australian EdTech)',
+  why_work_with_us = 'For Australian and US-based software and hardware founders at pre-seed through Series A — Cardinia Ventures offers a Melbourne-anchored VC cheque with proven cross-border deal flow and exit performance (Chronosphere/Palo Alto US$3.35B acquisition Nov 2025). Especially valuable for founders pursuing US market entry with Australian roots.',
+  meta_title = 'Cardinia Ventures — Melbourne AU/US Pre-Seed–Series A | Chronosphere ($3.35B exit)',
+  meta_description = 'Melbourne VC. AU/US software & hardware. Pre-Seed–Series A. Chronosphere (Palo Alto $3.35B acquisition).',
+  details = jsonb_build_object(
+    'investment_thesis','Software and hardware companies across Australia and US — Pre-Seed to Series A.',
+    'portfolio_size','15+ companies; 3 acquisitions; 2 seed-stage investments',
+    'highlight_investments', jsonb_build_array(
+      jsonb_build_object('company','Chronosphere','context','Acquired by Palo Alto Networks Nov 2025 for US$3.35B'),
+      jsonb_build_object('company','AdRoll','context','Digital marketing'),
+      jsonb_build_object('company','Edrolo','context','Australian EdTech')
+    ),
+    'sources', jsonb_build_object(
+      'website','https://www.cardiniaventures.com/'
+    )
+  ),
+  updated_at = now()
+WHERE name = 'Cardinia Ventures';
+
+COMMIT;

--- a/supabase/migrations/20260422140600_enrich_vcs_batch_02c.sql
+++ b/supabase/migrations/20260422140600_enrich_vcs_batch_02c.sql
@@ -1,0 +1,148 @@
+-- Enrich VCs — batch 02c (records 31-35: Carthona Capital → Common Sense Ventures)
+
+BEGIN;
+
+UPDATE investors SET
+  basic_info = 'Carthona Capital is a **Sydney-based thematic early-stage venture capital firm** founded in **2014**. Headquartered in The Rocks, Sydney.
+
+The firm invests in **highly thematic technology** — taking strong sector views and concentrating capital around specific market themes. Now on its **third fund** with **AU$360M FUM**.
+
+Stage focus: **Pre-Seed, Seed and Series A** with strong follow-on capability into Series B/C from balance-sheet capital. Cheque size: from **AU$1M+**.
+
+Carthona is a **UNPRI signatory** — meaning the firm is committed to UN Principles for Responsible Investment.',
+  why_work_with_us = 'For Australian and New Zealand technology founders building category-defining companies aligned with strong sector themes — Carthona Capital offers AU$360M FUM scale, three-fund operating depth (since 2014), and UN PRI-aligned responsible investment positioning. Especially valuable for founders pursuing thematic / sector-specific category leadership with strong follow-on support.',
+  meta_title = 'Carthona Capital — Sydney Thematic Tech VC | AU$360M FUM | from $1M',
+  meta_description = 'Sydney thematic early-stage VC since 2014. AU$360M FUM. Pre-Seed to Series A. UNPRI signatory.',
+  details = jsonb_build_object(
+    'founded',2014,
+    'fum','AU$360M',
+    'investment_thesis','Highly thematic technology — Pre-Seed, Seed and Series A with strong follow-on.',
+    'check_size_note','From AU$1M',
+    'fund_count','3 funds',
+    'esg','UNPRI signatory',
+    'sources', jsonb_build_object(
+      'website','https://carthona.com/'
+    )
+  ),
+  updated_at = now()
+WHERE name = 'Carthona Capital';
+
+UPDATE investors SET
+  basic_info = 'Clean Energy Finance Corporation (CEFC) is **Australia''s specialist climate investor** — established by the **Australian Government in 2012** with a total investment mandate of **AU$32.5B**.
+
+The CEFC operates multiple sub-funds and programmes:
+- **Clean Energy Innovation Fund** — AU$200M dedicated venture-capital pool for early-stage clean-energy companies
+- **Rewiring the Nation Fund** — AU$19B dedicated to grid transformation
+- Plus broader debt, equity and fund-of-funds mandates
+
+The CEFC invests across **all stages from VC innovation through to large-scale infrastructure** — minimum cheque typically **AU$3M+**.
+
+Sector focus: **clean energy, climate tech, energy transition, decarbonisation**.
+
+Notable portfolio includes:
+- **RayGen** (solar+storage)
+- **Hysata** (next-generation electrolyser — green hydrogen)
+- **Australian Ethical Growth Fund** (LP position)
+- **IP Group Climate Catalyst Fund** (LP position)',
+  why_work_with_us = 'For Australian clean-energy, climate-tech, energy-transition and decarbonisation founders — CEFC is the **largest single climate-aligned investor in Australia** with AU$32.5B mandate. Especially valuable for capital-intensive infrastructure-aligned ventures (Hysata, RayGen examples), grid-transformation projects, and founders pursuing structured Government-backed climate capital.',
+  meta_title = 'Clean Energy Finance Corporation (CEFC) — Australian Government Climate VC | AU$32.5B',
+  meta_description = 'Australian Government climate investor since 2012. AU$32.5B mandate. $200M Innovation Fund. $19B Rewiring the Nation.',
+  details = jsonb_build_object(
+    'organisation_type','Australian Government specialist climate investor',
+    'founded',2012,
+    'mandate','AU$32.5B',
+    'investment_thesis','Clean energy, climate tech, energy transition, decarbonisation — all stages.',
+    'sub_funds', jsonb_build_array(
+      jsonb_build_object('name','Clean Energy Innovation Fund','size','AU$200M','focus','Early-stage VC'),
+      jsonb_build_object('name','Rewiring the Nation Fund','size','AU$19B','focus','Grid transformation')
+    ),
+    'check_size_note','From AU$3M',
+    'sources', jsonb_build_object(
+      'website','https://www.cefc.com.au/'
+    )
+  ),
+  updated_at = now()
+WHERE name = 'Clean Energy Finance Corporation (CEFC)';
+
+UPDATE investors SET
+  basic_info = 'Climate Tech Partners is a **Sydney-based Series A climate-tech venture capital firm**. **Fund I reached AU$50M+ first close in June 2025**, anchored by:
+- **Clean Energy Finance Corporation (CEFC)** — AU$15M
+- **Australian Ethical** — AU$15M
+
+The firm also operates a **separate AU$15M Sustainable Aviation Fuel (SAF) vehicle** in partnership with **Qantas and Airbus** — a globally-significant SAF-aligned investment platform.
+
+Sector focus: **climate tech — energy, transport, logistics, mining and sustainable aviation fuel**.
+
+Stage focus: **Series A**. Cheque size: **AU$1M–$5M**.
+
+Notable portfolio includes:
+- **Hullbot** (marine robotics — AU$16M Series A)',
+  why_work_with_us = 'For Australian climate-tech founders at Series A across energy, transport, logistics, mining or sustainable aviation fuel — Climate Tech Partners offers a **CEFC + Australian Ethical-anchored Series A cheque ($1M–$5M)** plus the unique Qantas/Airbus SAF vehicle. Especially valuable for SAF-adjacent founders or founders pursuing structured Australian climate-aligned institutional capital.',
+  meta_title = 'Climate Tech Partners — Sydney Series A Climate VC | $50M+ Fund I | CEFC/Australian Ethical-anchored',
+  meta_description = 'Sydney Series A climate VC. Fund I AU$50M+ first close. CEFC + Australian Ethical anchored. SAF vehicle with Qantas/Airbus.',
+  details = jsonb_build_object(
+    'investment_thesis','Climate tech — energy, transport, logistics, mining, sustainable aviation fuel.',
+    'check_size_note','AU$1M–$5M',
+    'fund_i','AU$50M+ first close (June 2025)',
+    'fund_i_anchors', jsonb_build_array(
+      jsonb_build_object('lp','CEFC','amount','AU$15M'),
+      jsonb_build_object('lp','Australian Ethical','amount','AU$15M')
+    ),
+    'saf_vehicle','AU$15M separate vehicle in partnership with Qantas and Airbus',
+    'highlight_investments', jsonb_build_array(
+      jsonb_build_object('company','Hullbot','context','Marine robotics — AU$16M Series A')
+    )
+  ),
+  updated_at = now()
+WHERE name = 'Climate Tech Partners';
+
+UPDATE investors SET
+  basic_info = 'Clinton Capital Partners is a **Sydney-based VC advisory and investment firm** founded in **2015**. The firm operates a distinctive **success-fee capital-raising model** alongside proprietary investments — raising capital via a **5,000+ active investor network**.
+
+Track record: **90+ transactions over 10+ years**.
+
+Investment thesis is **sector-agnostic** at **Seed, Series A and Series B** stages. Notable Australian-startup transactions include:
+- **Alex Bank** (Australian neobank)
+- **OpusXenta** (cemetery software SaaS)
+- **Lumitron** (truncated)
+- **PaidRight** (payroll compliance)
+- **MyEmergencyDr** (telehealth)
+- **WithYouWithMe** (Australian veteran-skills platform)
+- **AgriWebb** (agritech)',
+  why_work_with_us = 'For Australian seed, Series A and Series B founders — Clinton Capital Partners offers a unique combination of **success-fee capital-raising advisory** plus direct proprietary investing. Their 5,000+ active investor network makes them especially valuable for founders looking to coordinate large syndicate-style rounds with structured-process capital-raising support.',
+  meta_title = 'Clinton Capital Partners — Sydney VC Advisory & Investment | 5,000+ Investor Network',
+  meta_description = 'Sydney VC advisory + investment since 2015. 5,000+ investor network. 90+ transactions. Sector-agnostic. Alex Bank, AgriWebb.',
+  details = jsonb_build_object(
+    'organisation_type','VC advisory and investment firm',
+    'founded',2015,
+    'model','Success-fee capital-raising via 5,000+ active investor network + proprietary investments',
+    'investment_thesis','Sector-agnostic — Seed, Series A, Series B.',
+    'transactions','90+ over 10 years',
+    'highlight_investments', jsonb_build_array(
+      jsonb_build_object('company','Alex Bank','context','Australian neobank'),
+      jsonb_build_object('company','AgriWebb','context','Australian agritech'),
+      jsonb_build_object('company','WithYouWithMe','context','Australian veteran-skills platform')
+    )
+  ),
+  updated_at = now()
+WHERE name = 'Clinton Capital Partners';
+
+UPDATE investors SET
+  basic_info = 'Common Sense Ventures is an **Australian family office** investing at **Seed and Series A** stages across multiple sectors — **AgTech, Food, Sustainability, eCommerce/DTC and B2B SaaS**.
+
+The firm was **founded by past entrepreneurs** — bringing operator-aligned investing perspective.
+
+Cheque size: **AU$100k–$1M**.',
+  why_work_with_us = 'For Australian agtech, food-tech, sustainability, eCommerce/DTC and B2B SaaS founders at seed or Series A — Common Sense Ventures offers a $100k–$1M cheque from a family office with founder-operator perspective. Especially valuable for founders looking for low-ceremony private-capital partners with sector-thesis alignment in agriculture, food and sustainability.',
+  meta_title = 'Common Sense Ventures — Australian Family Office | AgTech / Food / DTC / B2B SaaS | $100k–$1M',
+  meta_description = 'Australian family-office VC. AgTech, Food, Sustainability, eCommerce/DTC, B2B SaaS. Seed–Series A. $100k–$1M.',
+  details = jsonb_build_object(
+    'organisation_type','Australian family office',
+    'investment_thesis','AgTech, Food, Sustainability, eCommerce/DTC, B2B SaaS — Seed and Series A.',
+    'check_size_note','AU$100k–$1M',
+    'partners','Past entrepreneurs (founder-operator perspective)'
+  ),
+  updated_at = now()
+WHERE name = 'Common Sense Ventures';
+
+COMMIT;

--- a/supabase/migrations/20260422140700_enrich_vcs_batch_02d.sql
+++ b/supabase/migrations/20260422140700_enrich_vcs_batch_02d.sql
@@ -1,0 +1,113 @@
+-- Enrich VCs — batch 02d (records 36-40: CP Ventures → Eaton Square)
+
+BEGIN;
+
+UPDATE investors SET
+  basic_info = 'CP Ventures is a **Sydney-based micro-VC** managing **two funds with AU$16M total** investing **globally** in highly scalable breakthrough technology companies.
+
+Stage focus: **Pre-Seed and Seed**. Cheque size: **AU$500k** standard.
+
+The firm''s thesis is **"highly scalable breakthrough technology"** — meaning concentrated capital around technically ambitious, globally-scalable founders.',
+  why_work_with_us = 'For globally-ambitious founders building **breakthrough technology** at pre-seed and seed — CP Ventures offers a focused $500k cheque from a micro-VC operating two AU$16M funds. Especially valuable for technically ambitious founders pursuing global category leadership at the earliest stage.',
+  meta_title = 'CP Ventures — Sydney Micro-VC | AU$16M Total | Breakthrough Tech | $500k',
+  meta_description = 'Sydney micro-VC. Two funds AU$16M total. Breakthrough technology. Global. Pre-Seed/Seed. $500k.',
+  details = jsonb_build_object(
+    'organisation_type','Micro-VC',
+    'fum','AU$16M across two funds',
+    'investment_thesis','Highly scalable breakthrough technology — global.',
+    'check_size_note','AU$500k standard'
+  ),
+  updated_at = now()
+WHERE name = 'CP Ventures';
+
+UPDATE investors SET
+  basic_info = 'Darcy Naunton is an **individual Partner entry** — Darcy is **Partner & General Partner at Black Nova Venture Capital** (covered separately in this directory).
+
+He co-founded **Black Nova VC** with Matthew Browne in 2020 — the Sydney-based early-stage B2B SaaS specialist that closed Fund II exceeding AU$35M target in December 2025.
+
+For full investment thesis, fund details, portfolio and engagement pathway, see the **Black Nova VC** entry. This individual record represents Darcy as a person rather than a separate fund.',
+  why_work_with_us = 'For Australian B2B SaaS founders building mission-critical, workflow-led software in regulated industries — Darcy Naunton is one of the General Partners at Black Nova VC and a primary point-of-contact for Black Nova investment conversations. Approach via Black Nova VC for fund cheques.',
+  meta_title = 'Darcy Naunton — Black Nova VC General Partner | Sydney B2B SaaS',
+  meta_description = 'Sydney Black Nova VC General Partner. Co-founder. B2B SaaS specialist. Fund II AU$35M+.',
+  details = jsonb_build_object(
+    'role','Individual Partner entry — Partner & General Partner at Black Nova Venture Capital',
+    'see_also','Black Nova VC (primary fund record)',
+    'co_founders', ARRAY['Matthew Browne (Black Nova VC co-founder)'],
+    'note','This entry represents Darcy Naunton as an individual; investment activity is via Black Nova VC.'
+  ),
+  updated_at = now()
+WHERE name = 'Darcy Naunton';
+
+UPDATE investors SET
+  basic_info = 'Devika Ventures is a **Wollongong-based AI-first, operator-led venture capital firm** investing at **Pre-Seed, Seed and Series A** stages.
+
+The firm specifically focuses on **AI-first technology companies** with a strong operator-led pattern recognition. **Cheque size up to AU$1.5M.** Makes **3-6 investments per year**.
+
+**Portfolio value: AU$50M+** across active companies.
+
+Notable portfolio includes:
+- **ClevaQ**
+- **Hopstep**
+- **CONDITN**
+- **Social Kung Fu**
+
+Wollongong-based positioning makes Devika one of the few credentialed regional-NSW-based VCs in the Australian ecosystem.',
+  why_work_with_us = 'For Australian AI-first technology founders at pre-seed through Series A — Devika Ventures offers an operator-led specialist cheque (up to AU$1.5M) with active 3-6 deals/year deal flow. Especially valuable for Wollongong/regional-NSW-based founders or those building AI-native products who want hands-on operator advice.',
+  meta_title = 'Devika Ventures — Wollongong AI-First Operator VC | up to $1.5M | 3-6 deals/year',
+  meta_description = 'Wollongong AI-first operator-led VC. Pre-Seed–Series A. Up to AU$1.5M. 3-6 deals/year. AU$50M+ portfolio.',
+  details = jsonb_build_object(
+    'investment_thesis','AI-first technology — operator-led; pre-seed through Series A.',
+    'check_size_note','Up to AU$1.5M',
+    'pace','3-6 investments per year',
+    'portfolio_value','AU$50M+'
+  ),
+  updated_at = now()
+WHERE name = 'Devika Ventures';
+
+UPDATE investors SET
+  basic_info = 'Dragonfly Enviro Capital is a **Sydney-based environmental impact venture capital firm** founded in **2017 by Nigel Sharp**.
+
+The firm''s **Impact Growth Fund (established 2022)** is targeting **AU$50M**, with **AU$7.5M raised and deployed to date** across **13 portfolio companies**.
+
+Sector focus: **environmental impact — circular economy, cleantech, sustainable agriculture, carbon markets**. Stage focus: **Seed and Series A**.
+
+Notable portfolio includes:
+- **Pacific Bio** (sustainable aquaculture)
+- **Downforce** (carbon-negative concrete additives)
+- **Our Trace** (carbon traceability)
+- **Water** (water-tech)
+- **Carbon Group** (carbon markets)
+- **Red Earth Energy Storage** (battery storage)',
+  why_work_with_us = 'For Australian environmental-impact founders building circular-economy, cleantech, sustainable-agriculture or carbon-market businesses — Dragonfly Enviro Capital offers seed/Series A capital from a sector-pure impact-aligned VC. Especially valuable for founders pursuing measurable environmental-impact business models with structured ESG-aligned capital.',
+  meta_title = 'Dragonfly Enviro Capital — Sydney Environmental Impact VC since 2017 | $50M Fund Target',
+  meta_description = 'Sydney impact VC since 2017. Circular economy, cleantech, sustainable agriculture, carbon markets. AU$7.5M deployed.',
+  details = jsonb_build_object(
+    'founded',2017,
+    'founder','Nigel Sharp',
+    'investment_thesis','Environmental impact — circular economy, cleantech, sustainable agriculture, carbon markets.',
+    'impact_growth_fund','Targeting AU$50M; AU$7.5M raised/deployed to date',
+    'portfolio_size','13 companies'
+  ),
+  updated_at = now()
+WHERE name = 'Dragonfly Enviro Capital';
+
+UPDATE investors SET
+  basic_info = 'Eaton Square is a **cross-border M&A advisory and capital-raising firm** with **100+ senior professionals globally**.
+
+**IMPORTANT:** Eaton Square is **NOT a traditional VC fund** — the firm does **NOT make direct investments**. Eaton Square specialises in **ANZ-to-global cross-border M&A and capital-raising transactions**.
+
+Sector focus: **Technology, SaaS and services M&A** — typically advising founders/sellers on cross-border exit transactions or capital raises.',
+  why_work_with_us = 'For Australian and New Zealand technology, SaaS and services-business founders pursuing **cross-border M&A exit transactions or institutional capital raises** — Eaton Square offers professional advisory services from 100+ senior professionals globally. **Note**: Eaton Square does not make direct VC investments; engagement is for advisory/transaction services rather than venture capital.',
+  meta_title = 'Eaton Square — Cross-Border M&A & Capital Raising Advisory | NOT a VC Fund',
+  meta_description = 'Sydney cross-border M&A and capital-raising advisory. 100+ senior professionals globally. NOT a direct VC investor.',
+  details = jsonb_build_object(
+    'organisation_type','Cross-border M&A and capital-raising advisory firm',
+    'is_direct_investor',false,
+    'investment_thesis','NOT a direct VC — advisory only. Tech, SaaS and services M&A; cross-border ANZ to global.',
+    'team','100+ senior professionals globally',
+    'note','This is an advisory firm, not a venture capital fund. Founders should engage Eaton Square for M&A or capital-raising advisory services.'
+  ),
+  updated_at = now()
+WHERE name = 'Eaton Square';
+
+COMMIT;


### PR DESCRIPTION
## Summary

Adds rich `basic_info`, `why_work_with_us`, `meta_title`, `meta_description` and structured `details` JSONB for **VCs 21-40 of 145** in the production `investors` table. Spans `Billfolda Ventures` → `Eaton Square`.

### Highlight VCs in this batch
- **Blackbird Ventures** — Australia's largest VC; Canva, SafetyCulture, Zoox; First Believers programme
- **Brandon Capital Partners** — Australasia's largest life-science VC (AU$1B+ FUM, Fund VI A$439M Jul 2025, 17 portfolio in clinical trials)
- **Black Nova VC** — Sydney B2B SaaS specialist; Fund II AU$35M+ (Dec 2025)
- **Carthona Capital** — Sydney thematic; AU$360M FUM; UNPRI signatory
- **Clean Energy Finance Corporation (CEFC)** — Australian Government AU$32.5B climate mandate
- **Climate Tech Partners** — Series A climate VC; CEFC + Australian Ethical anchored; SAF vehicle with Qantas/Airbus
- **Breakthrough Victoria** — Victorian Government AU$2B mandate
- **Cardinia Ventures** — Chronosphere/Palo Alto US$3.35B exit (Nov 2025)
- **Boson Ventures** — Sydney deep-tech with China + US connectivity
- **Black Sheep Capital** — Brisbane micro-VC; 52+ investments incl. Go1 (unicorn)
- **Breyer Capital** — Jim Breyer's global VC (Facebook early backer)
- **Devika Ventures** — Wollongong AI-first operator-led VC
- **Dragonfly Enviro Capital** — Sydney environmental impact VC since 2017
- **Clinton Capital Partners** — Sydney VC advisory + investment; 5,000+ investor network

### Special flags
- **BridgeLane Group** — flagged NOT currently VC active (Markus Kahlbetzer now via Side Stage Ventures)
- **Eaton Square** — flagged NOT a VC fund (cross-border M&A advisory only)
- **Darcy Naunton** — individual entry; Black Nova VC GP (cross-references primary fund record)

## Migrations applied to production

All 4 migrations applied directly to MES production Supabase (`xhziwveaiuhzdoutpgrh`) via Supabase MCP `apply_migration`:
- `20260422140400_enrich_vcs_batch_02a` (records 21-25)
- `20260422140500_enrich_vcs_batch_02b` (records 26-30)
- `20260422140600_enrich_vcs_batch_02c` (records 31-35)
- `20260422140700_enrich_vcs_batch_02d` (records 36-40)

Verified all 20 rows updated.

## VC Series State
**40 of 145 VCs enriched (27.6% complete)**. 105 remaining over ~5-6 PRs.

## Test plan
- [x] All 4 migration files applied to production via Supabase MCP
- [x] Verified count of enriched VCs is 40
- [ ] CI green on this PR

https://claude.ai/code/session_01XsHLVbJ1rAJ3oafzHY6j2N

---
_Generated by [Claude Code](https://claude.ai/code/session_01XsHLVbJ1rAJ3oafzHY6j2N)_