### PR TITLE
Enrich VCs batch 04a-04d (records 61-80)

### DIFF
--- a/supabase/migrations/20260422141200_enrich_vcs_batch_04a.sql
+++ b/supabase/migrations/20260422141200_enrich_vcs_batch_04a.sql
@@ -1,0 +1,96 @@
+-- Enrich VCs — batch 04a (records 61-65: INP Capital → January Capital)
+
+BEGIN;
+
+UPDATE investors SET
+  basic_info = 'INP Capital is a **global venture capital firm** investing from **early-stage through to pre-IPO** stages. Headquartered in Canada with an Australian office in **North Sydney (L32, 101 Miller St)**.
+
+The fund has **22+ portfolio companies including 3 unicorns**, demonstrating strong cross-border deal-flow and exit performance.',
+  why_work_with_us = 'For Australian and global technology founders pursuing growth-stage capital from a multi-stage fund — INP Capital offers Canadian-rooted multi-continent VC reach with active Australian deal-flow participation. Especially valuable for founders pursuing US/Canadian market expansion or pre-IPO rounds.',
+  meta_title = 'INP Capital — Global VC | Canada/AU | Early-Stage to Pre-IPO | 3 Unicorns',
+  meta_description = 'Global VC. Canada HQ + AU office (North Sydney). Early-stage to pre-IPO. 22+ portfolio incl. 3 unicorns.',
+  details = jsonb_build_object(
+    'organisation_type','Global venture capital firm',
+    'investment_thesis','Technology — early-stage through to pre-IPO; multi-continent.',
+    'global_offices', ARRAY['Canada (HQ)','North Sydney NSW (AU office)'],
+    'portfolio_size','22+ companies including 3 unicorns'
+  ),
+  updated_at = now()
+WHERE name = 'INP Capital';
+
+UPDATE investors SET
+  basic_info = 'Intervalley Ventures is an **Australian ESVCLP fund** focused on **early-stage Australian technology companies with bridges to the Japanese market**.
+
+The firm operates an **AI^Human LP fund** model with **80%+ of capital deployed in Australia** and a focus on cross-border AU-Japan opportunities.',
+  why_work_with_us = 'For Australian early-stage technology founders pursuing **Japanese market expansion** or with Japan-relevant business models — Intervalley Ventures offers ESVCLP-structured AU-Japan bridge capital. Especially valuable for founders with Japanese co-founders, customers, or supply-chain partners.',
+  meta_title = 'Intervalley Ventures — AU ESVCLP | Australia–Japan Bridge | AI^Human LP',
+  meta_description = 'Australian ESVCLP fund. Early-stage AU tech with Japan bridge. AI^Human LP model. 80%+ capital in AU.',
+  details = jsonb_build_object(
+    'organisation_type','ESVCLP fund',
+    'investment_thesis','Early-stage AU tech with bridge to Japanese market.',
+    'fund_model','AI^Human LP fund',
+    'capital_allocation','80%+ in Australia'
+  ),
+  updated_at = now()
+WHERE name = 'Intervalley Ventures';
+
+UPDATE investors SET
+  basic_info = 'Investible is an **early-stage Asia-Pacific venture capital firm** with offices in **Sydney (Level 3, 180 George St) and Singapore**. Founded by **Trevor Folsom** (covered separately as legendary Sydney mega-angel) and **Creel Price**.
+
+The firm is **ESVCLP-registered** with **Fund 3 registered July 2025**. **53+ investments** to date.
+
+Investible''s history traces back to Blueprint Management Group (1998-2008; nine-figure exit) — Trevor and Creel''s prior business — and the firm now operates as one of the most-active early-stage VCs in the ANZ-SE-Asia corridor.
+
+Stage focus: **Pre-Seed to Series A**.',
+  why_work_with_us = 'For Australian and Asia-Pacific technology founders at pre-seed through Series A — Investible combines Trevor Folsom''s legendary 100+ direct angel-investment track record (incl. seed-stage Canva, Ipsy) with structured ESVCLP-fund deployment, Singapore SE Asia reach, and 53+ portfolio depth.',
+  meta_title = 'Investible — Trevor Folsom''s Asia-Pacific VC | ESVCLP | 53+ Investments',
+  meta_description = 'Sydney/Singapore Asia-Pacific early-stage VC. Trevor Folsom + Creel Price. ESVCLP Fund 3 (Jul 2025). 53+ investments.',
+  details = jsonb_build_object(
+    'organisation_type','ESVCLP-registered VC',
+    'co_founders', ARRAY['Trevor Folsom (legendary Sydney mega-angel; 100+ direct investments incl. Canva seed)','Creel Price'],
+    'global_offices', ARRAY['Sydney (HQ)','Singapore'],
+    'fund_3','Registered July 2025',
+    'portfolio_size','53+ investments',
+    'investment_thesis','Asia-Pacific technology — Pre-Seed to Series A.'
+  ),
+  updated_at = now()
+WHERE name = 'Investible';
+
+UPDATE investors SET
+  basic_info = 'IP Group ANZ runs the **Climate Catalyst Fund** — a **growth-stage climate-tech venture capital fund** targeting **AU$150M**, **launched March 2026** with the **Clean Energy Finance Corporation (CEFC)**.
+
+The fund focuses on **hard-to-abate industry decarbonisation** — a critical category for global climate transition (steel, cement, aviation, shipping, heavy industry).
+
+Notable investment: **MGA Thermal** (March 2026) — Australian thermal energy storage scale-up.',
+  why_work_with_us = 'For Australian and global climate-tech founders building **hard-to-abate industry decarbonisation** solutions — IP Group ANZ''s CEFC-backed Climate Catalyst Fund offers AU$150M growth-capital pool dedicated specifically to industrial decarbonisation. Especially valuable for capital-intensive industrial-tech ventures (steel, cement, aviation, heavy industry).',
+  meta_title = 'IP Group ANZ — Climate Catalyst Fund | AU$150M | CEFC-backed | Industrial Decarbonisation',
+  meta_description = 'AU$150M Climate Catalyst Fund (Mar 2026). CEFC-backed. Hard-to-abate industrial decarbonisation. MGA Thermal portfolio.',
+  details = jsonb_build_object(
+    'fund_size','AU$150M target',
+    'launched','March 2026',
+    'lp_anchor','Clean Energy Finance Corporation (CEFC)',
+    'investment_thesis','Hard-to-abate industry decarbonisation — growth stage.',
+    'highlight_investments', jsonb_build_array(
+      jsonb_build_object('company','MGA Thermal','context','Australian thermal energy storage; March 2026')
+    )
+  ),
+  updated_at = now()
+WHERE name = 'IP Group ANZ';
+
+UPDATE investors SET
+  basic_info = 'January Capital is an **Asia-Pacific thematic early-stage venture capital firm** with **growth credit** capability.
+
+The firm targets technology investments across **Australia, New Zealand and Southeast Asia** with a thematic-investment approach — taking concentrated positions around specific market themes.
+
+New website launched January 2025 — signalling renewed market positioning.',
+  why_work_with_us = 'For Asia-Pacific technology founders pursuing thematic-aligned early-stage capital with growth-credit follow-on capacity — January Capital offers a regional APAC VC cheque with both equity and credit instruments. Especially valuable for founders building category-defining APAC tech platforms.',
+  meta_title = 'January Capital — APAC Thematic Early-Stage VC | Equity + Growth Credit',
+  meta_description = 'APAC thematic early-stage VC with growth credit. AU, NZ, SE Asia. New website launched Jan 2025.',
+  details = jsonb_build_object(
+    'investment_thesis','Asia-Pacific thematic technology — early-stage equity + growth credit.',
+    'regions', ARRAY['Australia','New Zealand','Southeast Asia']
+  ),
+  updated_at = now()
+WHERE name = 'January Capital';
+
+COMMIT;

--- a/supabase/migrations/20260422141300_enrich_vcs_batch_04b.sql
+++ b/supabase/migrations/20260422141300_enrich_vcs_batch_04b.sql
@@ -1,0 +1,97 @@
+-- Enrich VCs — batch 04b (records 66-70: Jekara Group → King River Capital)
+
+BEGIN;
+
+UPDATE investors SET
+  basic_info = 'Jekara Group is an **Australian clean-energy / cleantech venture capital firm** investing across the **clean-energy value chain** — generation, distribution, storage and consumption.
+
+Stage focus: **ideation through Series A** — meaning Jekara backs founders from earliest concept through to early commercial-traction rounds. Sector mandate: **Clean Energy / CleanTech**.',
+  why_work_with_us = 'For Australian clean-energy and cleantech founders at any early stage — from ideation through Series A — Jekara Group offers a sector-pure clean-energy VC cheque covering the entire value chain (generation, distribution, storage, consumption). Especially valuable for capital-intensive clean-energy founders pursuing structured early-commercialisation pathways.',
+  meta_title = 'Jekara Group — Australian Clean-Energy / CleanTech VC | Ideation to Series A',
+  meta_description = 'Australian clean-energy / cleantech VC. Generation, distribution, storage, consumption. Ideation to Series A.',
+  details = jsonb_build_object(
+    'investment_thesis','Clean energy / cleantech across generation, distribution, storage, consumption.',
+    'stages','Ideation through Series A'
+  ),
+  updated_at = now()
+WHERE name = 'Jekara Group';
+
+UPDATE investors SET
+  basic_info = 'Jelix Ventures is a **Bondi Junction, NSW-based ANZ early-stage venture capital firm** investing in **Australia and New Zealand** technology founders at **Pre-Seed, Seed and Series A** stages.
+
+The firm is **ESVCLP-registered** and operates a sector-agnostic technology mandate.
+
+Portfolio includes notable Australian breakout names:
+- **PropHero** (Australian proptech)
+- **Gelomics** (biotech)
+- **Syenta**
+- **SafeStack** (NZ cybersecurity)',
+  why_work_with_us = 'For Australian and New Zealand pre-seed, seed and Series A technology founders — Jelix Ventures offers an ESVCLP-structured sector-agnostic cheque with a high-quality ANZ portfolio (PropHero proptech, SafeStack cybersecurity, Gelomics biotech). Especially valuable for early-stage tech founders looking for trans-Tasman ANZ deal-flow.',
+  meta_title = 'Jelix Ventures — Bondi Junction ANZ Early-Stage VC | ESVCLP',
+  meta_description = 'ANZ early-stage VC. Bondi Junction NSW. ESVCLP. PropHero, Gelomics, Syenta, SafeStack portfolio.',
+  details = jsonb_build_object(
+    'organisation_type','ESVCLP-registered ANZ early-stage VC',
+    'investment_thesis','Sector-agnostic ANZ technology — pre-seed, seed, Series A.'
+  ),
+  updated_at = now()
+WHERE name = 'Jelix Ventures';
+
+UPDATE investors SET
+  basic_info = 'Jungle Ventures is a **Singapore-based venture capital firm** with **US$1B+ AUM**. The firm is **focused exclusively on SE Asia and India** and is **NOT ANZ-focused**.
+
+Stage focus: Series A and Series B technology investments across South-East Asia and India.',
+  why_work_with_us = 'For Australian founders pursuing **SE Asia or India market expansion** — Jungle Ventures is a major regional VC partner. **Note**: Jungle does not invest in ANZ directly, so engagement is best for AU founders explicitly building SE Asia/India operations.',
+  meta_title = 'Jungle Ventures — Singapore SE Asia / India VC | $1B+ AUM | NOT ANZ-Focused',
+  meta_description = 'Singapore VC. $1B+ AUM. SE Asia + India focus only. Series A/B. Not ANZ-focused.',
+  details = jsonb_build_object(
+    'aum','US$1B+',
+    'investment_thesis','Technology — SE Asia and India only (not ANZ-focused).',
+    'note','For AU founders, only relevant if explicitly expanding to SE Asia or India.'
+  ),
+  updated_at = now()
+WHERE name = 'Jungle Ventures';
+
+UPDATE investors SET
+  basic_info = 'KIN Group is a **Melbourne-based privately-held investment group** with a **100-year vision**.
+
+**IMPORTANT**: KIN Group is **NOT a traditional venture capital fund**. The firm operates as a long-horizon family-office-style investment group rather than running fund cycles or making early-stage VC cheques.',
+  why_work_with_us = 'For Australian founders pursuing exceptionally long-term private capital partnerships — KIN Group offers patient family-office-style capital with a stated 100-year horizon. **Note**: Not a traditional VC; engagement is unconventional and best treated as a referral-led conversation.',
+  meta_title = 'KIN Group — Melbourne 100-Year Vision | NOT a Traditional VC',
+  meta_description = 'Melbourne privately-held investment group. 100-year vision. Not a traditional VC fund.',
+  details = jsonb_build_object(
+    'organisation_type','Privately-held investment group',
+    'is_traditional_vc',false,
+    'investment_thesis','100-year vision long-horizon investment.',
+    'note','Not a traditional VC; long-term family-office-style investing.'
+  ),
+  updated_at = now()
+WHERE name = 'KIN Group';
+
+UPDATE investors SET
+  basic_info = 'King River Capital is a **Sydney-based venture capital firm** founded **2018/2019**, headquartered in Surry Hills (33 Nickson St). The firm manages **AU$1.2B FUM** and focuses on **AI and software** investments at **Seed, Series A and Series B** stages.
+
+**Fund V** (March 2025) is targeting **US$100M** for AI/software-focused investments.
+
+Track record: **49+ investments**.
+
+Notable recent investments include:
+- **Relevance AI** (Series B, May 2025)
+- **Safewill** (Series B, November 2024)',
+  why_work_with_us = 'For Australian and global AI and software founders at seed through Series B — King River Capital offers AU$1.2B FUM scale (one of the largest ANZ tech-VCs by FUM) with active AI/software thesis and recent landmark investments (Relevance AI Series B, Safewill Series B). Especially valuable for founders building AI-native or software-infrastructure products.',
+  meta_title = 'King River Capital — Sydney AI / Software VC | AU$1.2B FUM | Fund V US$100M',
+  meta_description = 'Sydney AI/software VC. AU$1.2B FUM. Fund V US$100M (Mar 2025). 49+ investments. Relevance AI, Safewill.',
+  details = jsonb_build_object(
+    'founded',2018,
+    'fum','AU$1.2B',
+    'fund_v','Targeting US$100M (March 2025)',
+    'investment_thesis','AI and software — Seed, Series A, Series B.',
+    'portfolio_size','49+ investments',
+    'highlight_investments', jsonb_build_array(
+      jsonb_build_object('company','Relevance AI','context','Series B May 2025'),
+      jsonb_build_object('company','Safewill','context','Series B Nov 2024')
+    )
+  ),
+  updated_at = now()
+WHERE name = 'King River Capital';
+
+COMMIT;

--- a/supabase/migrations/20260422141400_enrich_vcs_batch_04c.sql
+++ b/supabase/migrations/20260422141400_enrich_vcs_batch_04c.sql
@@ -1,0 +1,88 @@
+-- Enrich VCs — batch 04c (records 71-75: Landran Ventures → Mai Capital)
+
+BEGIN;
+
+UPDATE investors SET
+  basic_info = 'Landran Ventures is a **Queensland-based venture capital firm** focused on **healthcare, sports tech, hospitality tech and DTC brands**. The fund has a stated **focus on female-led businesses**.
+
+Stage focus: **Seed to Series A**. Cheque size: **AU$500k–$3M**.',
+  why_work_with_us = 'For Queensland and Australian founders — and especially **female-led founders** — building healthcare, sports-tech, hospitality-tech or DTC consumer brands at seed through Series A — Landran Ventures offers a $500k–$3M cheque with explicit gender-lens / diversity-aligned thesis.',
+  meta_title = 'Landran Ventures — QLD Healthcare / Sports / Hospitality / DTC VC | Female-Led Focus | $500k–$3M',
+  meta_description = 'QLD VC. Healthcare, sports tech, hospitality tech, DTC brands. Female-led focus. Seed to Series A. $500k–$3M.',
+  details = jsonb_build_object(
+    'investment_thesis','Healthcare, Sports Tech, Hospitality Tech, DTC Brands — female-led focus.',
+    'check_size_note','AU$500k–$3M'
+  ),
+  updated_at = now()
+WHERE name = 'Landran Ventures';
+
+UPDATE investors SET
+  basic_info = 'Light Warrior Group is the **Sali family office** — Australian private investment group operating across **public and private markets, property, and operating businesses**.
+
+**IMPORTANT**: Light Warrior Group is a **family office** rather than a traditional venture capital fund. Engagement is best treated as a referral-led conversation.',
+  why_work_with_us = 'For Australian founders pursuing structured family-office-backed capital — Light Warrior Group (the Sali family office) offers diversified multi-asset investing across public, private, property and operating-business positions. **Note**: Not a traditional VC; long-horizon family-office investing approach.',
+  meta_title = 'Light Warrior Group — Sali Family Office | Multi-Asset | NOT Traditional VC',
+  meta_description = 'Sali family office. Public/private markets, property, operating businesses. Not a traditional VC.',
+  details = jsonb_build_object(
+    'organisation_type','Family office',
+    'family','Sali family',
+    'is_traditional_vc',false,
+    'investment_thesis','Multi-asset — public/private markets, property, operating businesses.'
+  ),
+  updated_at = now()
+WHERE name = 'Light Warrior Group';
+
+UPDATE investors SET
+  basic_info = 'Macdoch Ventures is a **Sydney-based venture capital firm** founded **2011** investing in **SaaS, marketplaces and tech infrastructure** at **Pre-Seed, Seed and Series A** stages with **ANZ focus**.
+
+**Sweetspot cheque size: AU$500k.** Cheque size minimum: AU$150k.
+
+The firm has been operating across the ANZ early-stage ecosystem for 14+ years.',
+  why_work_with_us = 'For Australian and New Zealand technology founders building SaaS, marketplaces or tech infrastructure at pre-seed through Series A — Macdoch Ventures offers 14+ years of operating depth with a clear $500k sweetspot cheque and ANZ-focused thesis.',
+  meta_title = 'Macdoch Ventures — Sydney ANZ SaaS / Marketplace / Infra VC since 2011 | $500k Sweetspot',
+  meta_description = 'Sydney VC since 2011. SaaS, marketplaces, tech infrastructure. ANZ. Pre-Seed to Series A. $500k sweetspot.',
+  details = jsonb_build_object(
+    'founded',2011,
+    'investment_thesis','SaaS, marketplaces, tech infrastructure — Pre-Seed to Series A; ANZ focus.',
+    'check_size_note','$500k sweetspot; from $150k'
+  ),
+  updated_at = now()
+WHERE name = 'Macdoch Ventures';
+
+UPDATE investors SET
+  basic_info = 'Macquarie Group operates the **Macquarie Capital Venture Studio** — the venture-investment arm of one of Australia''s largest financial-services groups. The studio has made **53 total investments (36 realised, 17 current)**.
+
+Sector focus: **Cybersecurity, Compliance, RegTech, AI and Food Tech** — categories aligned with Macquarie''s broader institutional and infrastructure-investment thesis.
+
+The studio operates across stages and is **not a traditional fixed-fund-cycle VC** — investments are made on a deal-by-deal basis from Macquarie''s balance sheet and selected vehicles.',
+  why_work_with_us = 'For Australian founders building **cybersecurity, compliance, RegTech, AI or food-tech** products that align with Macquarie Group''s institutional / infrastructure thesis — the Macquarie Capital Venture Studio offers strategic-investor cheques with deep institutional-financial-services network access.',
+  meta_title = 'Macquarie Group — Capital Venture Studio | Cybersecurity / RegTech / AI / Food Tech',
+  meta_description = 'Macquarie Capital Venture Studio. 53 total investments. Cybersecurity, Compliance, RegTech, AI, Food Tech.',
+  details = jsonb_build_object(
+    'organisation_type','Strategic-investor / corporate venture studio',
+    'parent','Macquarie Group',
+    'investment_thesis','Cybersecurity, Compliance, RegTech, AI, Food Tech.',
+    'portfolio_size','53 total (36 realised, 17 current)'
+  ),
+  updated_at = now()
+WHERE name = 'Macquarie Group';
+
+UPDATE investors SET
+  basic_info = 'Mai Capital is a **Melbourne-based boutique fund-management firm** established **2015**. The firm offers **real-estate managed pooled funds, corporate advisory and high-net-worth services** with **AU$298M FUM**.
+
+Sector focus: **Real estate and diversified investments**. Stage focus: **Growth**.
+
+**IMPORTANT**: Mai Capital is **primarily a real-estate-and-diversified-fund manager** — venture-style early-stage investment is not its primary mandate.',
+  why_work_with_us = 'For founders or partners pursuing real-estate-aligned diversified growth-capital partnerships — Mai Capital offers AU$298M FUM scale with corporate-advisory and HNW-services capability. **Note**: Mai is primarily a real-estate / diversified-fund manager rather than a tech-VC; engagement is best treated as a structured-fund or advisory conversation.',
+  meta_title = 'Mai Capital — Melbourne Boutique Fund Manager | $298M FUM | Real-Estate / Diversified',
+  meta_description = 'Melbourne boutique fund manager since 2015. $298M FUM. Real-estate pooled funds, advisory, HNW services.',
+  details = jsonb_build_object(
+    'founded',2015,
+    'fum','AU$298M',
+    'investment_thesis','Real estate and diversified investments — growth stage.',
+    'note','Primarily a real-estate / diversified-fund manager rather than a tech-VC.'
+  ),
+  updated_at = now()
+WHERE name = 'Mai Capital';
+
+COMMIT;

--- a/supabase/migrations/20260422141500_enrich_vcs_batch_04d.sql
+++ b/supabase/migrations/20260422141500_enrich_vcs_batch_04d.sql
@@ -1,0 +1,102 @@
+-- Enrich VCs — batch 04d (records 76-80: Main Sequence → MassMutual Ventures)
+
+BEGIN;
+
+UPDATE investors SET
+  basic_info = 'Main Sequence is **Australia''s deep-tech venture fund** — backed by **CSIRO** (the Commonwealth Scientific and Industrial Research Organisation, Australia''s national science agency).
+
+The firm invests in startups **commercialising world-class science and technology** — across **Data Infrastructure and Analytics, Farming, Medical Practices, Services for Renewable Energy and Software Development**. Stage focus: **Pre-Seed, Seed and Series A**. Cheque size: **AU$500k–$10M**.
+
+Notable Australian deep-tech portfolio includes:
+- **Gilmour Space** (Australian launch vehicles / orbital rockets)
+- **Morse Micro** (Wi-Fi HaLow chipset semiconductor)
+- **Baraja** (LiDAR for autonomous vehicles)
+- **Q-CTRL** (quantum-computing software / control)',
+  why_work_with_us = 'For Australian deep-tech founders commercialising world-class science — particularly in space, semiconductor, LiDAR, quantum, biotech, agtech, climate-tech and data-infrastructure categories — Main Sequence is **the most credentialed deep-tech VC in Australia**. CSIRO backing plus AU$500k–$10M cheque flexibility plus high-quality portfolio (Gilmour Space, Morse Micro, Baraja, Q-CTRL) make Main Sequence the go-to partner for hard-tech founders.',
+  meta_title = 'Main Sequence — Australia''s Deep-Tech VC | CSIRO-backed | $500k–$10M',
+  meta_description = 'Australia''s deep-tech VC backed by CSIRO. Gilmour Space, Morse Micro, Baraja, Q-CTRL. Pre-Seed to Series A. $500k–$10M.',
+  details = jsonb_build_object(
+    'distinction','Australia''s deep-tech venture fund',
+    'lp_anchor','CSIRO (Commonwealth Scientific and Industrial Research Organisation)',
+    'investment_thesis','Commercialising world-class science — data infra, farming, medical, renewable energy services, software.',
+    'check_size_note','AU$500k–$10M',
+    'highlight_investments', jsonb_build_array(
+      jsonb_build_object('company','Gilmour Space','context','Australian orbital rockets / launch vehicles'),
+      jsonb_build_object('company','Morse Micro','context','Wi-Fi HaLow chipset — semiconductor'),
+      jsonb_build_object('company','Baraja','context','LiDAR for autonomous vehicles'),
+      jsonb_build_object('company','Q-CTRL','context','Quantum-computing software / control')
+    )
+  ),
+  updated_at = now()
+WHERE name = 'Main Sequence';
+
+UPDATE investors SET
+  basic_info = 'Mandalay Venture Partners is a **Queensland-based agri-food tech venture capital firm** founded in **2021**. The firm invests at **Seed to Series A** stages with backing from **QIC (Queensland Investment Corporation) and NRMA**.
+
+The fund has a **Queensland Venture Capital Development Fund (QVCDF) allocation up to AU$20M** — providing structured early-stage capital for agri-food-tech founders in Queensland.',
+  why_work_with_us = 'For Australian — and especially Queensland-based — agri-food tech founders at seed through Series A — Mandalay Venture Partners offers QIC + NRMA-backed capital with up to AU$20M QVCDF allocation. Especially valuable for AgTech founders pursuing structured Queensland-government-aligned commercialisation.',
+  meta_title = 'Mandalay Venture Partners — QLD Agri-Food Tech VC since 2021 | QIC + NRMA-Backed | up to $20M',
+  meta_description = 'QLD agri-food tech VC since 2021. QIC + NRMA investors. QVCDF allocation up to $20M. Seed to Series A.',
+  details = jsonb_build_object(
+    'founded',2021,
+    'investment_thesis','Agri-food tech — Seed to Series A; Queensland focus.',
+    'lp_base', ARRAY['QIC (Queensland Investment Corporation)','NRMA'],
+    'qvcdf_allocation','Up to AU$20M'
+  ),
+  updated_at = now()
+WHERE name = 'Mandalay Venture Partners';
+
+UPDATE investors SET
+  basic_info = 'Marbruck Investments is a **Darlinghurst, Sydney-based open-ended venture capital fund** (137-153 Crown St). The firm has historic ties to the **online casino industry** and operates a relatively secretive investment programme.
+
+Investment focus: **Technology and growth-stage companies** — specific portfolio not publicly disclosed in detail.',
+  why_work_with_us = 'For Australian founders looking for structured private-capital partnerships — Marbruck Investments offers an open-ended fund structure (no fixed term) for technology and growth-stage companies. **Note**: Limited public visibility means engagement is best treated as a referral-led conversation through warm intros.',
+  meta_title = 'Marbruck Investments — Darlinghurst Sydney Open-Ended VC | Tech / Growth',
+  meta_description = 'Darlinghurst Sydney open-ended VC. Technology and growth-stage. Limited public profile.',
+  details = jsonb_build_object(
+    'organisation_type','Open-ended venture capital fund',
+    'investment_thesis','Technology and growth-stage companies.',
+    'note','Open-ended structure; ties to online casino industry; limited public visibility on portfolio.'
+  ),
+  updated_at = now()
+WHERE name = 'Marbruck Investments';
+
+UPDATE investors SET
+  basic_info = 'Marshall Investments is a **Sydney-based growth-capital and venture-debt provider**.
+
+**IMPORTANT**: Marshall Investments is **NOT pure VC** — the firm provides **loans of AU$2M–$20M** for **revenue-generating businesses with revenue >AU$5M per annum**.
+
+This makes Marshall a structured non-dilutive capital alternative to traditional venture equity for late-stage growth founders.',
+  why_work_with_us = 'For Australian late-stage growth founders with **revenue >AU$5M per annum** seeking **non-dilutive growth capital** rather than equity — Marshall Investments offers AU$2M–$20M loan instruments with venture-debt structuring. Especially valuable for capital-efficient SaaS or marketplace founders looking to extend runway without equity dilution.',
+  meta_title = 'Marshall Investments — Sydney Growth Capital + Venture Debt | $2M–$20M | Revenue >$5M',
+  meta_description = 'Sydney growth capital + venture debt provider. Loans $2M–$20M. Revenue >$5M pa. Not pure VC.',
+  details = jsonb_build_object(
+    'organisation_type','Growth capital + venture debt provider',
+    'investment_thesis','Loans for revenue-generating businesses (>$5M pa revenue).',
+    'check_size_note','AU$2M–$20M loans',
+    'note','Non-dilutive venture-debt instrument rather than traditional VC equity.'
+  ),
+  updated_at = now()
+WHERE name = 'Marshall Investments';
+
+UPDATE investors SET
+  basic_info = 'MassMutual Ventures is a **US-based venture capital firm** with offices in **Boston (USA) and Singapore**. The firm invests in Australia and New Zealand from its global Asia-focused fund.
+
+**Fund III: US$300M (2022)** — focused on Asia and Europe.
+
+Sector focus: **Digital health, FinTech, enterprise SaaS and cybersecurity**. Stage focus: **Series A, Series B and Series C**.
+
+Backed by Massachusetts Mutual Life Insurance Company (MassMutual) — one of the largest life-insurance companies in the United States.',
+  why_work_with_us = 'For Australian and New Zealand digital-health, FinTech, enterprise-SaaS and cybersecurity founders at Series A through Series C — MassMutual Ventures offers structured US-institutional VC capital with global Asia-Europe deployment thesis. Especially valuable for ANZ founders pursuing US/global Series-stage capital with insurance-industry strategic LP signalling.',
+  meta_title = 'MassMutual Ventures — US-based VC | Boston/Singapore | $300M Fund III | Series A/B/C',
+  meta_description = 'US-based VC (Boston + Singapore). Fund III $300M (2022, Asia+Europe). Digital health, FinTech, SaaS, cybersecurity.',
+  details = jsonb_build_object(
+    'parent','Massachusetts Mutual Life Insurance Company',
+    'fund_iii','US$300M (2022)',
+    'global_offices', ARRAY['Boston USA','Singapore'],
+    'investment_thesis','Digital health, FinTech, enterprise SaaS, cybersecurity — Series A, B, C.'
+  ),
+  updated_at = now()
+WHERE name = 'MassMutual Ventures';
+
+COMMIT;


### PR DESCRIPTION
## Summary

Adds rich `basic_info`, `why_work_with_us`, `meta_title`, `meta_description` and structured `details` JSONB for **VCs 61-80 of 145**. Spans `INP Capital` → `MassMutual Ventures`.

### Highlight VCs in this batch
- **Main Sequence** — Australia's deep-tech VC backed by **CSIRO**; Gilmour Space, Morse Micro, Baraja, Q-CTRL portfolio
- **King River Capital** — Sydney AI/software VC; **AU$1.2B FUM**; Fund V US$100M (Mar 2025); Relevance AI, Safewill backer
- **Investible** — Trevor Folsom + Creel Price's Asia-Pacific VC; ESVCLP Fund 3 (Jul 2025); 53+ investments
- **IP Group ANZ** — Climate Catalyst Fund **AU$150M** (Mar 2026, CEFC-backed); hard-to-abate industrial decarbonisation
- **INP Capital** — global Canada/AU VC; 22+ portfolio incl. **3 unicorns**
- **Macquarie Group** — Capital Venture Studio; 53 total investments
- **Mandalay Venture Partners** — QLD agri-food tech; QIC + NRMA-backed
- **MassMutual Ventures** — US Boston/Singapore VC; Fund III US$300M
- **Jelix Ventures** — ANZ ESVCLP; PropHero, Gelomics, SafeStack portfolio
- **Macdoch Ventures** — Sydney ANZ SaaS/marketplace VC since 2011
- **Landran Ventures** — QLD healthcare/sports/hospitality/DTC; female-led focus

### Special flags
- **KIN Group** — flagged NOT a traditional VC (100-year vision investment group)
- **Light Warrior Group** — flagged Sali family office (not traditional VC)
- **Mai Capital** — flagged primarily real-estate / diversified-fund manager
- **Marshall Investments** — flagged NOT pure VC (growth capital + venture debt)
- **Jungle Ventures** — flagged SE Asia/India only, NOT ANZ-focused

## Migrations applied to production

All 4 migrations applied directly to MES production Supabase (`xhziwveaiuhzdoutpgrh`) via Supabase MCP `apply_migration`:
- `20260422141200_enrich_vcs_batch_04a` (records 61-65)
- `20260422141300_enrich_vcs_batch_04b` (records 66-70)
- `20260422141400_enrich_vcs_batch_04c` (records 71-75)
- `20260422141500_enrich_vcs_batch_04d` (records 76-80)

## VC Series State
**80 of 145 VCs enriched (55.2% complete)**. 65 remaining over ~3-4 PRs.

## Test plan
- [x] All 4 migration files applied to production via Supabase MCP
- [x] Verified all 80 enriched VCs (count = 80)
- [ ] CI green on this PR

https://claude.ai/code/session_01XsHLVbJ1rAJ3oafzHY6j2N

---
_Generated by [Claude Code](https://claude.ai/code/session_01XsHLVbJ1rAJ3oafzHY6j2N)_