### PR TITLE
Enrich VCs batch 06a-06d (records 101-120)

### DIFF
--- a/supabase/migrations/20260422142000_enrich_vcs_batch_06a.sql
+++ b/supabase/migrations/20260422142000_enrich_vcs_batch_06a.sql
@@ -1,0 +1,83 @@
+-- Enrich VCs — batch 06a (records 101-105: QIC Ventures → ReGen Ventures)
+
+BEGIN;
+
+UPDATE investors SET
+  basic_info = 'QIC Ventures is the **venture-investment arm of Queensland Investment Corporation (QIC)** — Queensland''s state-owned institutional investment manager.
+
+The firm operates two key vehicles:
+- **Enterprise Acceleration Fund** — AU$24M; AU$500k–$2.5M per company; QLD-focused
+- **Queensland Venture Capital Development Fund (QVCDF)** — AU$130M
+
+**Track record:** **AU$114.8M invested in 65 Queensland businesses**.
+
+Sector focus: Technology — with implicit emphasis on B2B SaaS, space, clean energy, cybersecurity, defence, agrifood and health categories aligned with Queensland''s economic strengths. Stage focus: **Seed to Growth**.',
+  why_work_with_us = 'For Queensland-based founders across B2B SaaS, space, clean energy, cybersecurity, defence, agrifood and health categories — QIC Ventures is **Queensland''s most-capitalised state-government VC** with two distinct vehicles totalling AU$154M+ deployable capital and AU$114.8M deployed across 65 QLD businesses. Especially valuable for QLD-based founders pursuing structured Government-aligned commercialisation.',
+  meta_title = 'QIC Ventures — QLD Government VC | $24M Enterprise Acceleration + $130M QVCDF',
+  meta_description = 'Brisbane QLD Government VC. AU$24M EAF ($500k–$2.5M) + AU$130M QVCDF. AU$114.8M deployed in 65 QLD businesses.',
+  details = jsonb_build_object(
+    'parent','Queensland Investment Corporation (QIC)',
+    'funds', jsonb_build_array(
+      jsonb_build_object('name','Enterprise Acceleration Fund','size','AU$24M','check','AU$500k–$2.5M','focus','QLD'),
+      jsonb_build_object('name','Queensland Venture Capital Development Fund (QVCDF)','size','AU$130M')
+    ),
+    'track_record','AU$114.8M invested in 65 QLD businesses',
+    'investment_thesis','Technology — QLD-focused; B2B SaaS, space, clean energy, cybersecurity, defence, agrifood, health.'
+  ),
+  updated_at = now()
+WHERE name = 'QIC Ventures';
+
+UPDATE investors SET
+  basic_info = 'Qualgro VC is a **Singapore-based venture capital firm** focused on **B2B SaaS, data and AI** at **Series A and Series B** stages. The firm invests across Southeast Asia, Australia and New Zealand.',
+  why_work_with_us = 'For Australian and New Zealand B2B SaaS, data and AI founders pursuing **regional Asia-Pacific expansion** at Series A through Series B — Qualgro VC offers a Singapore-based regional growth-capital cheque with structured SE Asia + ANZ deal-flow.',
+  meta_title = 'Qualgro VC — Singapore B2B SaaS / Data / AI VC | Series A/B | SE Asia + ANZ',
+  meta_description = 'Singapore B2B SaaS, data and AI VC. Series A/B. SE Asia, Australia, New Zealand.',
+  details = jsonb_build_object(
+    'investment_thesis','B2B SaaS, data and AI — Series A and Series B; SE Asia + ANZ.'
+  ),
+  updated_at = now()
+WHERE name = 'Qualgro VC';
+
+UPDATE investors SET
+  basic_info = 'Rampersand is an **ANZ inception-to-seed venture capital firm** that backs founders from the earliest stage using a **community-powered model**. Investment focus: pre-seed and seed Australian and New Zealand technology founders.
+
+**Nicole Kleid Small** (covered in this directory as Melbourne angel; Start Small Ventures founder) was previously **Investment Director at Rampersand for 4 years** — a notable connection across the ANZ early-stage angel/VC community.',
+  why_work_with_us = 'For Australian and New Zealand pre-seed and seed-stage technology founders — Rampersand offers one of the most-established ANZ inception-to-seed VCs with a community-powered model and notable alumni network.',
+  meta_title = 'Rampersand — ANZ Inception-to-Seed VC | Community-Powered',
+  meta_description = 'ANZ inception-to-seed VC. Community-powered. AU/NZ pre-seed/seed.',
+  details = jsonb_build_object(
+    'investment_thesis','Inception-to-seed ANZ — community-powered model.',
+    'related_individuals', ARRAY['Nicole Kleid Small (former Investment Director, 4 years)']
+  ),
+  updated_at = now()
+WHERE name = 'Rampersand';
+
+UPDATE investors SET
+  basic_info = 'REACH ANZ is a **PropTech accelerator and investment fund** focused on **Australia and New Zealand real-estate technology**.
+
+Investment is **by application only** — meaning founders apply through a structured intake process for both accelerator participation and investment consideration.',
+  why_work_with_us = 'For Australian and New Zealand PropTech / real-estate-technology founders — REACH ANZ offers a sector-pure accelerator + investment pathway with structured by-application intake. Especially valuable for proptech founders pursuing structured industry-aligned commercialisation.',
+  meta_title = 'REACH ANZ — Australian PropTech Accelerator + Investment Fund',
+  meta_description = 'PropTech accelerator + investment fund. ANZ real-estate technology. By application only.',
+  details = jsonb_build_object(
+    'organisation_type','PropTech accelerator + investment fund',
+    'investment_thesis','ANZ PropTech / real-estate technology.',
+    'application_process','By application only.'
+  ),
+  updated_at = now()
+WHERE name = 'REACH ANZ';
+
+UPDATE investors SET
+  basic_info = 'ReGen Ventures is an **early-stage cleantech and regenerative-economy venture capital firm**.
+
+The firm invests in technology supporting the transition to a regenerative economy — covering circular-economy, sustainable-agriculture, climate-tech and adjacent categories.',
+  why_work_with_us = 'For Australian cleantech and regenerative-economy founders at the early stage — ReGen Ventures offers a sector-pure regenerative-economy thesis covering circular-economy, sustainable-agriculture and climate-aligned categories.',
+  meta_title = 'ReGen Ventures — Australian Early-Stage Cleantech / Regenerative Economy VC',
+  meta_description = 'Australian early-stage cleantech and regenerative-economy VC.',
+  details = jsonb_build_object(
+    'investment_thesis','Cleantech and regenerative economy — early stage.'
+  ),
+  updated_at = now()
+WHERE name = 'ReGen Ventures';
+
+COMMIT;

--- a/supabase/migrations/20260422142100_enrich_vcs_batch_06b.sql
+++ b/supabase/migrations/20260422142100_enrich_vcs_batch_06b.sql
@@ -1,0 +1,100 @@
+-- Enrich VCs — batch 06b (records 106-110: Right Click Capital → SecondQuarter Ventures)
+
+BEGIN;
+
+UPDATE investors SET
+  basic_info = 'Right Click Capital is a **Sydney-based ANZ pre-seed/seed venture capital firm**. The firm also manages the **Sydney Seed Fund** — an additional vehicle providing early-stage capital to NSW founders.
+
+Investment focus: **Pre-Seed and Seed** technology across Australia and New Zealand.
+
+Notable portfolio includes:
+- **black.ai** (AI / computer vision)
+- **Tability** (OKR / goal-tracking SaaS)
+- **Nomad Atomics** (quantum sensors / atomic devices)',
+  why_work_with_us = 'For Australian and New Zealand pre-seed and seed-stage technology founders — Right Click Capital offers two distinct vehicles (Right Click + Sydney Seed Fund) plus a high-quality early-stage portfolio (black.ai, Tability, Nomad Atomics quantum sensors).',
+  meta_title = 'Right Click Capital — Sydney ANZ Pre-Seed/Seed VC | Sydney Seed Fund',
+  meta_description = 'ANZ pre-seed/seed VC. Sydney Seed Fund. black.ai, Tability, Nomad Atomics portfolio.',
+  details = jsonb_build_object(
+    'investment_thesis','ANZ pre-seed/seed technology.',
+    'manages', ARRAY['Sydney Seed Fund']
+  ),
+  updated_at = now()
+WHERE name = 'Right Click Capital';
+
+UPDATE investors SET
+  basic_info = 'Salus Ventures is a **mission-driven venture capital firm at the intersection of enterprise and national security**, based in Australia.
+
+Sector focus spans **Aerospace/Autonomy, AI/ML, Automation/Advanced Manufacturing, Cybersecurity/Enterprise Software, Defence/National Security and Supply Chain**. Stage focus: **Seed**.
+
+Notable portfolio activity:
+- **Biosecurity threat-management platform** (Pre-Seed 2023)
+- **Quantum-control software** (Series B 2024)
+- **Optics/autonomy decision platform** (Seed 2023)',
+  why_work_with_us = 'For Australian dual-use technology founders building products across aerospace/autonomy, AI/ML, advanced manufacturing, cybersecurity, defence, national security and supply chain — Salus Ventures offers a mission-driven, sector-aligned seed cheque with explicit enterprise + national-security thesis.',
+  meta_title = 'Salus Ventures — Australian Defence / National Security / Enterprise VC | Seed',
+  meta_description = 'AU mission-driven VC. Aerospace, AI/ML, Adv Manufacturing, Cybersecurity, Defence, Supply Chain. Seed.',
+  details = jsonb_build_object(
+    'investment_thesis','Enterprise + national-security technology — Seed stage.',
+    'sectors', ARRAY['Aerospace/Autonomy','AI/ML','Advanced Manufacturing','Cybersecurity/Enterprise Software','Defence/National Security','Supply Chain']
+  ),
+  updated_at = now()
+WHERE name = 'Salus Ventures';
+
+UPDATE investors SET
+  basic_info = 'Sapien Ventures is an **Australian venture capital firm** (ABN 1260606938; Authorised Rep of AFSL 238128). The firm focuses on investing in **unicorn-stage companies**.
+
+Limited public information available beyond the directory listing.',
+  why_work_with_us = 'For Australian founders pursuing unicorn-stage capital — Sapien Ventures offers a focused unicorn-stage cheque. Best treated as a referral-led conversation given limited public information.',
+  meta_title = 'Sapien Ventures — Australian Unicorn-Stage VC',
+  meta_description = 'Australian VC. AFSL 238128 authorised rep. Focus on unicorn-stage companies.',
+  details = jsonb_build_object(
+    'organisation_type','VC (Authorised Rep of AFSL 238128)',
+    'abn','1260606938',
+    'investment_thesis','Unicorn-stage companies.',
+    'unverified', ARRAY['Limited public information available.']
+  ),
+  updated_at = now()
+WHERE name = 'Sapien Ventures';
+
+UPDATE investors SET
+  basic_info = 'Scalare Partners is an **Australian early-stage venture capital firm** that also gives **everyday investors access to early-stage startups** — a distinctive retail-investor-aligned approach.
+
+Partners have **built, scaled and sold startups** themselves, bringing operator-aligned investing experience.',
+  why_work_with_us = 'For Australian early-stage founders looking for capital with retail-investor accessibility — Scalare Partners offers a structured pathway combining traditional VC investment with retail-investor co-investment opportunity. Especially valuable for founders pursuing community-powered capital narratives.',
+  meta_title = 'Scalare Partners — Australian Early-Stage VC | Retail-Investor Accessible',
+  meta_description = 'Australian early-stage VC with retail-investor access. Partner-led; built/scaled/sold startups.',
+  details = jsonb_build_object(
+    'investment_thesis','Early-stage Australian technology.',
+    'distinctive','Provides everyday-investor access to early-stage startups.'
+  ),
+  updated_at = now()
+WHERE name = 'Scalare Partners';
+
+UPDATE investors SET
+  basic_info = 'SecondQuarter Ventures is **Australia''s first specialist venture capital secondaries fund**. Sydney-based.
+
+The firm provides **liquidity for founders, employees, and investors in growth-stage technology companies** — meaning SecondQuarter buys equity from existing shareholders rather than participating in primary fundraising rounds.
+
+Notable secondary transactions:
+- **Canva** (Australian design unicorn)
+- **Fleet Space** (Australian satellite networks)
+- **Cover Genius** (insurtech)
+- **Go1** (corporate learning unicorn)
+- **Bare**',
+  why_work_with_us = 'For founders, employees and early investors in Australian growth-stage technology companies looking to **realise partial liquidity** — SecondQuarter Ventures is **Australia''s first specialist secondaries fund**, with notable transactions including Canva, Fleet Space, Cover Genius and Go1. Especially valuable for unicorn-grade ANZ scale-ups managing pre-IPO liquidity.',
+  meta_title = 'SecondQuarter Ventures — Australia''s First VC Secondaries Fund | Canva / Go1 Liquidity',
+  meta_description = 'Sydney Australia''s first VC secondaries fund. Liquidity for growth-tech shareholders. Canva, Fleet Space, Cover Genius, Go1.',
+  details = jsonb_build_object(
+    'distinction','Australia''s first specialist VC secondaries fund',
+    'investment_thesis','Secondary transactions — liquidity for growth-stage tech shareholders.',
+    'highlight_investments', jsonb_build_array(
+      jsonb_build_object('company','Canva','context','Design unicorn'),
+      jsonb_build_object('company','Go1','context','Corporate learning unicorn'),
+      jsonb_build_object('company','Fleet Space','context','Satellite networks'),
+      jsonb_build_object('company','Cover Genius','context','Insurtech')
+    )
+  ),
+  updated_at = now()
+WHERE name = 'SecondQuarter Ventures';
+
+COMMIT;

--- a/supabase/migrations/20260422142200_enrich_vcs_batch_06c.sql
+++ b/supabase/migrations/20260422142200_enrich_vcs_batch_06c.sql
@@ -1,0 +1,104 @@
+-- Enrich VCs — batch 06c (records 111-115: Seed Space VC → Significant Ventures)
+
+BEGIN;
+
+UPDATE investors SET
+  basic_info = 'Seed Space Venture Capital is an **Australian and Swiss-based early-stage seed FinTech venture capital firm** investing in companies driving a revolution in financial services.
+
+Stage focus: **Seed**.',
+  why_work_with_us = 'For Australian and European fintech founders at seed — Seed Space Venture Capital offers a sector-pure FinTech cheque with cross-continent AU + Switzerland deployment.',
+  meta_title = 'Seed Space Venture Capital — AU + Switzerland Early-Stage Seed FinTech VC',
+  meta_description = 'Australian + Swiss early-stage seed FinTech VC.',
+  details = jsonb_build_object(
+    'investment_thesis','FinTech — seed stage.',
+    'global_offices', ARRAY['Australia','Switzerland']
+  ),
+  updated_at = now()
+WHERE name = 'Seed Space Venture Capital';
+
+UPDATE investors SET
+  basic_info = 'SEEK Investments is the **investment arm of SEEK Limited** — Australia''s largest employment marketplace and a globally significant HR-tech operator. Headquartered in Cremorne, VIC (60 Cremorne St).
+
+The firm is a **thematic long-term growth investor** — operating the **SEEK Growth Fund** with **~AU$2B FUM**.
+
+Sector focus: **HR SaaS, Education, Contingent Labour tech** — categories aligned with SEEK''s core operating thesis. Stage focus: **Growth** (global investment scope).
+
+**Ariel Hersh** (covered separately as **Investment Director at Seek Investments**) is part of **Nullarbor Ventures** founding team — illustrating SEEK''s deep ties into the broader ANZ angel community.',
+  why_work_with_us = 'For HR SaaS, Education and Contingent Labour tech founders at growth stage — SEEK Investments offers ~AU$2B FUM scale plus deep strategic alignment with SEEK Limited''s global HR-tech operating depth. Especially valuable for founders whose products complement or extend SEEK''s core marketplace.',
+  meta_title = 'SEEK Investments — SEEK Growth Fund | ~AU$2B FUM | HR SaaS / EdTech / Contingent Labour',
+  meta_description = 'Investment arm of SEEK Limited. Thematic growth investor. ~AU$2B FUM. HR SaaS, EdTech, Contingent Labour tech.',
+  details = jsonb_build_object(
+    'parent','SEEK Limited',
+    'fund','SEEK Growth Fund',
+    'fum','~AU$2B',
+    'investment_thesis','HR SaaS, Education, Contingent Labour tech — thematic long-term growth.',
+    'related_individuals', ARRAY['Ariel Hersh (Investment Director; Nullarbor Ventures founding team)']
+  ),
+  updated_at = now()
+WHERE name = 'SEEK Investments';
+
+UPDATE investors SET
+  basic_info = 'Shearwater Capital is a **Sydney-based venture capital firm** (Edgecliff, NSW) with **AU$100M Fund II** raised in **2024**.
+
+Distinctive structure: **3 founders as partners investing their own capital** — meaning Shearwater operates with a high alignment of incentives between investors and founders.
+
+Track record: **22 investments**, **6 at AU$100M+ valuation** (i.e. centaur or unicorn-grade outcomes).
+
+Sector focus: Fast-growth technology in Australia and New Zealand. Stage focus: **Seed to Growth**.',
+  why_work_with_us = 'For Australian and New Zealand fast-growth technology founders at seed through growth — Shearwater Capital offers AU$100M Fund II capital from a partner-aligned firm where the 3 founders invest their own capital. The 22-investment portfolio with 6 at $100M+ valuation signals strong pattern recognition for breakout outcomes.',
+  meta_title = 'Shearwater Capital — Sydney Fast-Growth Tech VC | $100M Fund II | 22 investments / 6 at $100M+',
+  meta_description = 'Sydney VC. AU$100M Fund II (2024). 3 partners investing own capital. 22 investments, 6 at $100M+ valuation.',
+  details = jsonb_build_object(
+    'fund_ii','AU$100M (2024)',
+    'partner_alignment','3 founders as partners investing own capital',
+    'track_record','22 investments, 6 at $100M+ valuation',
+    'investment_thesis','Fast-growth technology — AU/NZ; Seed to Growth.'
+  ),
+  updated_at = now()
+WHERE name = 'Shearwater Capital';
+
+UPDATE investors SET
+  basic_info = 'Side Stage Ventures is an **Australian founder-led seed venture capital fund**. **Fund I: AU$15M** raised in **August 2023**.
+
+The firm is led by **Markus Kahlbetzer** (founder of BridgeLane Group — covered separately in this directory; BridgeLane has now moved focus exclusively to Side Stage). Cheque size: **up to AU$500k**. Sector mandate: agnostic with bias to large markets.
+
+Notable portfolio includes some of Australia''s breakout technology successes:
+- **Leonardo AI** (generative AI — exited to Canva)
+- **Braid** (financial-services SaaS)
+- **Superdesign** (design tooling)
+- **Arca** (climate tech — AU$12.2M raise)
+- **TrueState**
+- **MagicBrief** (exited)
+- Plus historic backings of **Go1** and **Airtasker**',
+  why_work_with_us = 'For Australian seed-stage founders building products targeting big markets — Side Stage Ventures offers Markus Kahlbetzer''s deep Australian-tech network plus Fund I AU$15M capacity (Aug 2023). Especially valuable for founders pursuing structured pre-Series A capital with notable scale-up adjacency (Leonardo AI/Canva, Go1, Airtasker historic backings).',
+  meta_title = 'Side Stage Ventures — Markus Kahlbetzer''s Founder-Led Seed VC | $15M Fund I | up to $500k',
+  meta_description = 'AU founder-led seed fund. AU$15M Fund I (Aug 2023). Up to $500k. Leonardo AI (Canva exit), Arca, MagicBrief.',
+  details = jsonb_build_object(
+    'principal','Markus Kahlbetzer (formerly BridgeLane Group)',
+    'fund_i','AU$15M (August 2023)',
+    'check_size_note','Up to AU$500k',
+    'investment_thesis','Sector-agnostic with bias to big markets — seed.',
+    'highlight_investments', jsonb_build_array(
+      jsonb_build_object('company','Leonardo AI','context','Generative AI — exited to Canva'),
+      jsonb_build_object('company','Arca','context','Climate tech — AU$12.2M raise')
+    )
+  ),
+  updated_at = now()
+WHERE name = 'Side Stage Ventures';
+
+UPDATE investors SET
+  basic_info = 'Signal Ventures is a **Melbourne-founded seed venture capital firm** with offices in **Melbourne (AU team) and Singapore**.
+
+**Fund I: AU$10M** raised in **2021**. Cheque size: **AU$150k–$250k**. Sector focus: **early-stage Australian technology** + **blockchain/crypto investment arm** based in Singapore.',
+  why_work_with_us = 'For Australian early-stage technology founders at seed — Signal Ventures offers a focused $150k–$250k cheque with Melbourne base and Singapore blockchain/crypto-arm reach. Especially valuable for founders building tech-or-blockchain products with Asian regional ambition.',
+  meta_title = 'Signal Ventures — Melbourne Seed VC + Singapore Blockchain Arm | $10M Fund (2021)',
+  meta_description = 'Melbourne seed VC. AU$10M fund (2021). Early-stage AU tech. Blockchain/crypto arm in Singapore.',
+  details = jsonb_build_object(
+    'fund_i','AU$10M (2021)',
+    'investment_thesis','Early-stage AU tech + blockchain/crypto (Singapore arm).',
+    'check_size_note','AU$150k–$250k'
+  ),
+  updated_at = now()
+WHERE name = 'Signal Ventures';
+
+COMMIT;

--- a/supabase/migrations/20260422142300_enrich_vcs_batch_06d.sql
+++ b/supabase/migrations/20260422142300_enrich_vcs_batch_06d.sql
@@ -1,0 +1,122 @@
+-- Enrich VCs — batch 06d (records 116-120: Significant Ventures → SAVCF)
+
+BEGIN;
+
+UPDATE investors SET
+  basic_info = 'Significant Early Venture Capital (Significant Ventures) is a **Canberra, ACT-based early-stage venture capital firm** (Suite 41, Level 1, 65 Constitution Ave, Campbell, ACT).
+
+The firm manages **AU$28.6M FUM** with **32 investments** to date. Cheque size: **AU$100k–$500k**. Founded by the **Hindmarsh family**.
+
+Sector focus: **Deep tech, critical tech, life sciences, AI, climate tech, advanced manufacturing** — with a notable bias to **university spinouts**. Stage focus: **Seed and Series A**.
+
+Notable portfolio includes:
+- **Wavewise Analytics**
+- **Earthodic**
+- **Visionary Machines**',
+  why_work_with_us = 'For Australian deep-tech, critical-tech, life-sciences, AI, climate-tech and advanced-manufacturing founders — and especially university spinouts — Significant Ventures offers Canberra-anchored capital ($100k–$500k) from a Hindmarsh-family-backed VC with deep university-commercialisation network depth.',
+  meta_title = 'Significant Ventures — Canberra Deep-Tech VC | $28.6M FUM | Hindmarsh Family',
+  meta_description = 'Canberra early-stage VC. AU$28.6M FUM. 32 investments. $100k–$500k. Deep tech, critical tech, life sciences, AI, climate.',
+  details = jsonb_build_object(
+    'family','Hindmarsh family',
+    'fum','AU$28.6M',
+    'portfolio_size','32 investments',
+    'check_size_note','AU$100k–$500k',
+    'investment_thesis','Deep tech, critical tech, life sciences, AI, climate tech, advanced manufacturing — university spinouts emphasis.'
+  ),
+  updated_at = now()
+WHERE name = 'Significant Early Venture Capital (Significant Ventures)';
+
+UPDATE investors SET
+  basic_info = 'Skalata Ventures is a **Melbourne-based pre-seed to seed-stage venture capital firm** known as **Australia''s highest support-to-cheque ratio VC** — meaning the firm provides exceptionally high levels of operating and structural support relative to capital invested.
+
+**Fund III** is **ESVCLP-registered** (registered November 2025). Headquartered at Level 8, 446 Collins St, Melbourne.
+
+Sector mandate is agnostic with **priority focus on women founders, climate, agtech, AI and healthtech**.
+
+Notable portfolio includes:
+- Digital freight forwarder
+- E-commerce personalisation
+- Custom artwork marketplace
+- Cinema ticketing
+- Financial education app
+- Hospitality ordering
+- Smart livestock ear tags
+
+**Tracie Clark** (covered separately as Perth angel; Champion of Investment Diversity 2023) is part of the Skalata team.',
+  why_work_with_us = 'For Australian pre-seed and seed-stage founders — and especially women founders, climate, agtech, AI and healthtech — Skalata Ventures offers Australia''s highest support-to-cheque ratio with structured operating-team engagement. ESVCLP Fund III (Nov 2025) provides additional capital depth.',
+  meta_title = 'Skalata Ventures — Melbourne Pre-Seed/Seed VC | Fund III ESVCLP (Nov 2025) | Highest Support-to-Cheque',
+  meta_description = 'Melbourne pre-seed/seed VC. Fund III ESVCLP (Nov 2025). Sector-agnostic. Women founders, climate, agtech, AI, healthtech priority.',
+  details = jsonb_build_object(
+    'distinction','Australia''s highest support-to-cheque ratio VC',
+    'fund_iii','ESVCLP-registered Nov 2025',
+    'investment_thesis','Sector-agnostic with women-founder, climate, agtech, AI, healthtech priority.',
+    'related_individuals', ARRAY['Tracie Clark (Champion of Investment Diversity 2023)']
+  ),
+  updated_at = now()
+WHERE name = 'Skalata Ventures';
+
+UPDATE investors SET
+  basic_info = 'Skip Capital is the **private investment fund of Scott Farquhar** (Atlassian Co-Founder) and his wife **Kim Jackson**.
+
+The firm invests in **technology and infrastructure** at growth and multi-stage. Notable portfolio includes:
+- **Neara** (utility-grid digital twin SaaS)
+- **Lorikeet** (AI customer support — co-investor)
+
+Skip Capital represents the **Farquhar / Jackson family-office venture activity** — distinct from Mike Cannon-Brookes'' Grok Ventures (the other Atlassian co-founder''s family office, covered separately).',
+  why_work_with_us = 'For Australian and global technology and infrastructure founders pursuing growth-stage capital — Skip Capital offers Scott Farquhar (Atlassian Co-Founder) family-office capital with deep ANZ tech and infrastructure-investment depth (Neara, Lorikeet).',
+  meta_title = 'Skip Capital — Scott Farquhar (Atlassian Co-Founder) Family Office | Tech / Infrastructure',
+  meta_description = 'Scott Farquhar (Atlassian Co-Founder) + Kim Jackson family office. Technology and infrastructure. Growth / multi-stage.',
+  details = jsonb_build_object(
+    'principals', ARRAY['Scott Farquhar (Atlassian Co-Founder)','Kim Jackson'],
+    'investment_thesis','Technology and infrastructure — growth / multi-stage.',
+    'related','Sister-firm context to Grok Ventures (Mike Cannon-Brookes)'
+  ),
+  updated_at = now()
+WHERE name = 'Skip Capital';
+
+UPDATE investors SET
+  basic_info = 'Social Ventures Australia (SVA) is an **Australian social-impact advisory and investment organisation** focused on **social enterprises and impact investment**.
+
+The firm operates as a structured impact-investing platform combining advisory services with investment capital.',
+  why_work_with_us = 'For Australian social-enterprise and impact-aligned founders — Social Ventures Australia offers a structured impact-advisory + investment combination. Especially valuable for founders building businesses with measurable social-impact outcomes.',
+  meta_title = 'Social Ventures Australia (SVA) — Social-Impact Advisory + Investment',
+  meta_description = 'Australian social-impact advisory and investment organisation. Social enterprises and impact investment.',
+  details = jsonb_build_object(
+    'organisation_type','Social-impact advisory + investment organisation',
+    'investment_thesis','Social enterprises and impact investment.'
+  ),
+  updated_at = now()
+WHERE name = 'Social Ventures Australia';
+
+UPDATE investors SET
+  basic_info = 'South Australian Venture Capital Fund (SAVCF) is the **South Australian Government-backed AU$50M venture capital fund**, **managed by Artesian Venture Partners**.
+
+The fund operates two distinct cheque tiers:
+- **Seed** — AU$400k
+- **Series A** — AU$2.5M
+
+**SA company requirement**: Portfolio companies must have **50%+ staff or assets in South Australia** to qualify.
+
+Sector focus: **B2B Software, Space, Clean Energy, Cybersecurity, Defence, Agrifood and Health/MedTech**.
+
+**11 SA businesses** supported to date.
+
+Headquartered in Adelaide (L5, 2 Ebenezer Place). Contact: SAVCF@artesianinvest.com.',
+  why_work_with_us = 'For South Australian founders — and especially companies with 50%+ SA staff/assets — building B2B software, space, clean-energy, cybersecurity, defence, agrifood or health-tech products — SAVCF is the **most-capitalised SA-Government-aligned VC** with structured Seed (AU$400k) and Series A (AU$2.5M) cheque tiers managed by Artesian.',
+  meta_title = 'South Australian Venture Capital Fund (SAVCF) — SA Government VC | AU$50M | Managed by Artesian',
+  meta_description = 'SA Government AU$50M VC. Managed by Artesian. Seed ($400k) + Series A ($2.5M). 50% SA staff/assets required.',
+  details = jsonb_build_object(
+    'organisation_type','SA Government-backed VC fund',
+    'fund_size','AU$50M',
+    'manager','Artesian Venture Partners',
+    'check_tiers', jsonb_build_array(
+      jsonb_build_object('stage','Seed','amount','AU$400k'),
+      jsonb_build_object('stage','Series A','amount','AU$2.5M')
+    ),
+    'eligibility','50%+ staff or assets in South Australia',
+    'investment_thesis','B2B Software, Space, Clean Energy, Cybersecurity, Defence, Agrifood, Health/MedTech.'
+  ),
+  updated_at = now()
+WHERE name = 'South Australian Venture Capital Fund (SAVCF)';
+
+COMMIT;


### PR DESCRIPTION
## Summary

Adds rich `basic_info`, `why_work_with_us`, `meta_title`, `meta_description` and structured `details` JSONB for **VCs 101-120 of 145**. Spans `QIC Ventures` → `South Australian Venture Capital Fund (SAVCF)`.

### Highlight VCs in this batch
- **QIC Ventures** — QLD Government VC; AU$24M Enterprise Acceleration + **AU$130M QVCDF**; AU$114.8M deployed in 65 QLD businesses
- **SecondQuarter Ventures** — Australia's first specialist VC secondaries fund; **Canva, Fleet Space, Cover Genius, Go1** liquidity
- **Skip Capital** — **Scott Farquhar (Atlassian Co-Founder)** family office; Neara, Lorikeet
- **SEEK Investments** — SEEK Growth Fund **~AU$2B FUM**; HR SaaS, EdTech, Contingent Labour tech
- **South Australian VCF (SAVCF)** — SA Government **AU$50M**; managed by Artesian; Seed $400k + Series A $2.5M
- **Side Stage Ventures** — Markus Kahlbetzer founder-led seed; AU$15M Fund I; **Leonardo AI (Canva exit)**
- **Skalata Ventures** — Australia's highest support-to-cheque ratio VC; Fund III ESVCLP (Nov 2025)
- **Significant Ventures** — Canberra Hindmarsh family deep-tech; AU$28.6M FUM
- **Shearwater Capital** — Sydney AU$100M Fund II; 22 investments / 6 at $100M+ valuation
- **Salus Ventures** — AU mission-driven defence/national security VC
- **Right Click Capital** — Sydney Seed Fund; black.ai, Tability, Nomad Atomics

### Special flags
- **Sapien Ventures** — flagged limited public information (unicorn-stage focus)

## Migrations applied to production

All 4 migrations applied directly to MES production Supabase (`xhziwveaiuhzdoutpgrh`) via Supabase MCP `apply_migration`:
- `20260422142000_enrich_vcs_batch_06a` (records 101-105)
- `20260422142100_enrich_vcs_batch_06b` (records 106-110)
- `20260422142200_enrich_vcs_batch_06c` (records 111-115)
- `20260422142300_enrich_vcs_batch_06d` (records 116-120)

## VC Series State
**120 of 145 VCs enriched (82.8% complete)**. **25 remaining** — 1-2 more PRs to complete the series.

## Test plan
- [x] All 4 migration files applied to production via Supabase MCP
- [x] Verified count of enriched VCs is 120
- [ ] CI green on this PR

https://claude.ai/code/session_01XsHLVbJ1rAJ3oafzHY6j2N

---
_Generated by [Claude Code](https://claude.ai/code/session_01XsHLVbJ1rAJ3oafzHY6j2N)_