### PR TITLE
Enrich VCs batch 07a-07e (records 121-145) — FINAL VC BATCH (100% complete)

### DIFF
--- a/supabase/migrations/20260422142400_enrich_vcs_batch_07a.sql
+++ b/supabase/migrations/20260422142400_enrich_vcs_batch_07a.sql
@@ -1,0 +1,110 @@
+-- Enrich VCs — batch 07a (records 121-125: Southern Cross Venture Partners → Steamworks Ventures)
+
+BEGIN;
+
+UPDATE investors SET
+  basic_info = 'Southern Cross Venture Partners is a **Sydney-based venture capital firm** established in **2006**. Sector focus: **Technology** with a notable specialisation in **renewable energy** via the **REVC Fund**.
+
+**REVC Fund**: AU$120M renewable-energy fund backed by **ARENA (Australian Renewable Energy Agency) and SoftBank China**. The firm also operates the **IIF Fund**.
+
+**Team**: Bob Christiansen, John Scull, Mark Bonnar, Jonathan Whitehouse — bringing decades of Australian VC operating experience.
+
+Stage focus: **Early Growth stage**.',
+  why_work_with_us = 'For Australian renewable-energy and growth-stage technology founders — Southern Cross Venture Partners offers AU$120M REVC Fund (ARENA + SoftBank China backed) plus 18+ years of operating depth (since 2006). Especially valuable for renewable-energy founders pursuing structured growth-stage capital with cross-border China LP exposure.',
+  meta_title = 'Southern Cross Venture Partners — Sydney Tech / Renewable Energy VC since 2006 | $120M REVC Fund',
+  meta_description = 'Sydney VC since 2006. AU$120M REVC Fund (ARENA + SoftBank China). Tech + renewable energy. Early growth.',
+  details = jsonb_build_object(
+    'founded',2006,
+    'team', ARRAY['Bob Christiansen','John Scull','Mark Bonnar','Jonathan Whitehouse'],
+    'funds', jsonb_build_array(
+      jsonb_build_object('name','REVC Fund','size','AU$120M','backers', ARRAY['ARENA','SoftBank China']),
+      jsonb_build_object('name','IIF Fund','focus','Innovation Investment Fund')
+    ),
+    'investment_thesis','Technology + renewable energy — early growth stage.'
+  ),
+  updated_at = now()
+WHERE name = 'Southern Cross Venture Partners';
+
+UPDATE investors SET
+  basic_info = 'Sprint Ventures is a **multi-city venture capital firm** with offices in **Brisbane (primary), Sydney and Melbourne**. The firm invests at **early and growth stages**.
+
+**Sprint Fund III** focuses on **AI, Health, Aged Care, Climate, Infrastructure and Water** — a thematic sector mix aligned with Australia''s critical-infrastructure and demographic-trend categories. The fund operates in **partnership with QIC (Queensland Investment Corporation)**.',
+  why_work_with_us = 'For Australian founders building AI, health, aged-care, climate, infrastructure or water-tech products — Sprint Ventures offers a multi-city VC presence (Brisbane, Sydney, Melbourne) plus QIC partnership for institutional-grade capital. Especially valuable for QLD-based founders or those pursuing structured Government-aligned thematic capital.',
+  meta_title = 'Sprint Ventures — Brisbane/Sydney/Melbourne VC | Fund III | AI / Health / Climate / Infrastructure',
+  meta_description = 'Brisbane, Sydney, Melbourne VC. Sprint Fund III. AI, Health, Aged Care, Climate, Infrastructure, Water. QIC partnership.',
+  details = jsonb_build_object(
+    'investment_thesis','AI, Health, Aged Care, Climate, Infrastructure, Water.',
+    'fund_iii','Sprint Fund III with QIC partnership',
+    'global_offices', ARRAY['Brisbane (primary)','Sydney','Melbourne']
+  ),
+  updated_at = now()
+WHERE name = 'Sprint Ventures';
+
+UPDATE investors SET
+  basic_info = 'Square Peg Capital is **one of Australia''s most prominent global venture capital firms** investing in **transformative technology companies across Australia, Israel and Southeast Asia**.
+
+Headquartered in Melbourne, Square Peg operates Series A through Growth-stage investments with cheques of **AU$5M–$50M**.
+
+The firm''s portfolio reads as a who''s-who of globally-significant tech companies:
+- **Fiverr** (NYSE: FVRR — global freelancer marketplace)
+- **Stripe (AU)** (Australian ops of global payments giant)
+- **Rokt** (e-commerce / advertising)
+- **Airwallex** (Australian global payments unicorn)
+
+Sector focus: **Capital Markets, E-Learning Providers, Internet Marketplace Platforms and Software Development**. Stage focus: **Series A, Series B and Growth**.',
+  why_work_with_us = 'For Australian, Israeli and Southeast Asian technology founders building globally-transformative companies — Square Peg Capital is one of the most-credentialed global VCs in the ANZ market. AU$5M–$50M cheques + Fiverr/Stripe/Rokt/Airwallex portfolio + multi-continent reach (AU/Israel/SEA) make Square Peg a top-tier Series A through Growth partner.',
+  meta_title = 'Square Peg Capital — Melbourne Global VC | $5M–$50M | Fiverr, Stripe, Rokt, Airwallex',
+  meta_description = 'Melbourne global VC. AU/Israel/SE Asia. Fiverr, Stripe, Rokt, Airwallex. Series A to Growth. $5M–$50M.',
+  details = jsonb_build_object(
+    'investment_thesis','Transformative technology companies — AU, Israel, SE Asia.',
+    'check_size_note','AU$5M–$50M',
+    'global_offices', ARRAY['Melbourne (HQ)','Israel','Southeast Asia'],
+    'highlight_investments', jsonb_build_array(
+      jsonb_build_object('company','Fiverr','context','NYSE: FVRR — global freelancer marketplace'),
+      jsonb_build_object('company','Stripe (AU)','context','Australian ops of global payments giant'),
+      jsonb_build_object('company','Rokt','context','E-commerce / advertising'),
+      jsonb_build_object('company','Airwallex','context','Australian global payments unicorn')
+    )
+  ),
+  updated_at = now()
+WHERE name = 'Square Peg Capital';
+
+UPDATE investors SET
+  basic_info = 'Starfish Ventures is a **Melbourne-based venture capital firm** managing **AU$400M+ across IT, life sciences and cleantech** — three sectors where Starfish has built deep specialisation.
+
+The firm operates **three principal funds**:
+- **Fund I**: AU$138M
+- **Fund II**: AU$185M
+- **Fund III**: (active fund)
+
+Stage focus: **Series A through Series C**.
+
+Notable portfolio includes:
+- **Aktana** (life sciences AI / pharma commercial intelligence)',
+  why_work_with_us = 'For Australian IT, life-sciences and cleantech founders at Series A through Series C — Starfish Ventures offers AU$400M+ FUM across three principal funds plus multi-decade operating depth. Especially valuable for sector-specialist founders (life sciences, cleantech) pursuing structured Series-stage capital.',
+  meta_title = 'Starfish Ventures — Melbourne IT / Life Sciences / Cleantech VC | $400M+ FUM',
+  meta_description = 'Melbourne VC. AU$400M+ across IT, life sciences, cleantech. Fund I $138M, Fund II $185M, Fund III. Series A–C.',
+  details = jsonb_build_object(
+    'fum','AU$400M+',
+    'funds', jsonb_build_array(
+      jsonb_build_object('name','Fund I','size','AU$138M'),
+      jsonb_build_object('name','Fund II','size','AU$185M'),
+      jsonb_build_object('name','Fund III')
+    ),
+    'investment_thesis','IT, life sciences, cleantech — Series A through Series C.'
+  ),
+  updated_at = now()
+WHERE name = 'Starfish Ventures';
+
+UPDATE investors SET
+  basic_info = 'Steamworks Ventures is an **Australian venture capital fund**. Limited public information available — the firm''s website is currently unavailable.',
+  why_work_with_us = 'For Australian founders looking for structured private-capital partnerships — Steamworks Ventures is best treated as a referral-led conversation given limited public visibility.',
+  meta_title = 'Steamworks Ventures — Australian VC Fund | Limited Public Information',
+  meta_description = 'Australian VC fund. Website unavailable. Limited public information.',
+  details = jsonb_build_object(
+    'unverified', ARRAY['Website unavailable; limited public information.']
+  ),
+  updated_at = now()
+WHERE name = 'Steamworks Ventures';
+
+COMMIT;

--- a/supabase/migrations/20260422142500_enrich_vcs_batch_07b.sql
+++ b/supabase/migrations/20260422142500_enrich_vcs_batch_07b.sql
@@ -1,0 +1,103 @@
+-- Enrich VCs — batch 07b (records 126-130: Stoic VC → Taronga Ventures)
+
+BEGIN;
+
+UPDATE investors SET
+  basic_info = 'Stoic VC is a **Sydney-based venture capital firm** at the **intersection of research and commercialisation** — investing when startups have demonstrated proof of concept. Headquartered at 1 Macquarie Place, Sydney.
+
+The firm partners with **Uniseed** (Australia''s longest-running university VC fund — covered separately) for university-spinout deal flow.
+
+Sector focus across three thematic categories:
+- **Human Health**
+- **Advanced Computing**
+- **Physical World** (climate / environment)
+
+Stage focus: **Seed to Series A**. Cheque size: **AU$100k–$1M**.
+
+Notable portfolio includes:
+- **Kinoxis** (drug development)
+- **Neurode** (medical-device / neurology)
+- **BioScout** (agricultural pathogen surveillance)',
+  why_work_with_us = 'For Australian founders building research-and-commercialisation-aligned products in Human Health, Advanced Computing or Physical World (climate/environment) categories — Stoic VC offers a focused $100k–$1M cheque with deep university-spinout partnership network (via Uniseed).',
+  meta_title = 'Stoic VC — Sydney Research / Commercialisation VC | Uniseed Partner | $100k–$1M',
+  meta_description = 'Sydney VC at intersection of research and commercialisation. Uniseed partnership. Seed–Series A. $100k–$1M.',
+  details = jsonb_build_object(
+    'partnership','Uniseed',
+    'investment_thesis','Human Health, Advanced Computing, Physical World — Seed to Series A; proof-of-concept stage.',
+    'check_size_note','AU$100k–$1M'
+  ),
+  updated_at = now()
+WHERE name = 'Stoic VC';
+
+UPDATE investors SET
+  basic_info = 'Strata Vision Fund is an **Australian fund** investing in **high-potential startups bringing innovation to strata/apartment communities** with a **long-term perspective**.
+
+Sector focus: **PropTech — strata and apartment-community innovation**.',
+  why_work_with_us = 'For Australian PropTech founders specifically building products for **strata/apartment-community management, services or technology** — Strata Vision Fund offers a sector-pure focused cheque with long-term-horizon investment perspective.',
+  meta_title = 'Strata Vision Fund — Australian Strata / Apartment-Community PropTech',
+  meta_description = 'Australian PropTech fund. Strata/apartment-community innovation. Long-term perspective.',
+  details = jsonb_build_object(
+    'investment_thesis','PropTech — strata/apartment-community innovation; long-term perspective.'
+  ),
+  updated_at = now()
+WHERE name = 'Strata Vision Fund';
+
+UPDATE investors SET
+  basic_info = 'Tank Stream Ventures is a **Sydney-based early-stage venture capital firm** (Level 10, 17-19 Bridge St). The firm operates an **AU$20M fund (fully deployed)** with **30+ investments** across Pre-Seed, Seed and Series A stages. Cheque size: **AU$200k–$1M**.
+
+The firm is **part of BridgeLane Group** (Markus Kahlbetzer family office — covered separately; though Markus has now moved focus to Side Stage Ventures).
+
+Sector focus: **SaaS, eCommerce, Social Media, Online Marketplaces**.
+
+**Rui Rodrigues** (covered as Sydney angel / 2× F1 World Champion team manager) was a **former Managing Partner** at Tank Stream Ventures.',
+  why_work_with_us = 'For Australian SaaS, eCommerce, social-media and online-marketplace founders at pre-seed through Series A — Tank Stream Ventures offers AU$200k–$1M cheques from a Sydney-based fund with 30+ investments and BridgeLane Group network connections.',
+  meta_title = 'Tank Stream Ventures — Sydney Early-Stage VC | $20M Fund | 30+ Investments | $200k–$1M',
+  meta_description = 'Sydney early-stage VC. AU$20M fund (fully deployed). 30+ investments. SaaS, eCommerce. $200k–$1M.',
+  details = jsonb_build_object(
+    'fund_size','AU$20M (fully deployed)',
+    'parent','Part of BridgeLane Group',
+    'investment_thesis','SaaS, eCommerce, Social Media, Online Marketplaces — Pre-Seed to Series A.',
+    'check_size_note','AU$200k–$1M',
+    'related_individuals', ARRAY['Rui Rodrigues (former Managing Partner)']
+  ),
+  updated_at = now()
+WHERE name = 'Tank Stream Ventures';
+
+UPDATE investors SET
+  basic_info = 'Tarnagulla Ventures is a **Melbourne-based family-owned life-sciences venture capital firm** with a focus on **seed and venture-capital investments**.
+
+The firm specialises in **small-molecule, protein and cell-based therapeutics** and brings medical-technology companies to **Australian and US markets**.
+
+Sector focus: **Life Sciences — therapeutics and medical technology**. Stage focus: **Seed and Venture**.',
+  why_work_with_us = 'For Australian life-sciences founders building small-molecule, protein or cell-based therapeutics — Tarnagulla Ventures offers a Melbourne-based family-owned specialist cheque with explicit AU + US-market commercialisation thesis.',
+  meta_title = 'Tarnagulla Ventures — Melbourne Family-Owned Life-Sciences VC | Therapeutics + MedTech',
+  meta_description = 'Melbourne family-owned life-sciences VC. Small molecule, protein, cell-based therapeutics. AU + US markets.',
+  details = jsonb_build_object(
+    'organisation_type','Family-owned life-sciences VC',
+    'investment_thesis','Life sciences — small-molecule, protein, cell-based therapeutics.'
+  ),
+  updated_at = now()
+WHERE name = 'Tarnagulla Ventures';
+
+UPDATE investors SET
+  basic_info = 'Taronga Ventures is a **global RealTech (real-estate technology) venture capital firm and accelerator** with **global institutional partners**.
+
+Sector focus spans **real estate, built environment, smart cities, ESG and energy transition** — making Taronga one of the most credentialed sector-pure RealTech investors globally.
+
+Notable portfolio includes:
+- **Rebound Technologies** (industrial cooling)
+- **Ailytics** (computer vision for built environment)
+- **Enteligent** (energy management)
+- **Diraq** (quantum-tech for built-environment applications)
+- **OpenSpace** (construction reality-capture)',
+  why_work_with_us = 'For global PropTech / RealTech founders building products for real estate, built environment, smart cities, ESG or energy-transition categories — Taronga Ventures offers a sector-pure global RealTech VC + accelerator pathway with institutional-grade LP base.',
+  meta_title = 'Taronga Ventures — Global RealTech VC | Real Estate / Built Environment / Smart Cities / ESG',
+  meta_description = 'Global RealTech VC + accelerator. Real estate, built environment, smart cities, ESG, energy transition.',
+  details = jsonb_build_object(
+    'organisation_type','VC + accelerator',
+    'investment_thesis','RealTech — real estate, built environment, smart cities, ESG, energy transition.'
+  ),
+  updated_at = now()
+WHERE name = 'Taronga Ventures';
+
+COMMIT;

--- a/supabase/migrations/20260422142600_enrich_vcs_batch_07c.sql
+++ b/supabase/migrations/20260422142600_enrich_vcs_batch_07c.sql
@@ -1,0 +1,95 @@
+-- Enrich VCs — batch 07c (records 131-135: TEN13 → Tin Alley Ventures)
+
+BEGIN;
+
+UPDATE investors SET
+  basic_info = 'TEN13 is a **syndicated investment platform** by **Steve Baxter and Stew Glynn** — two of Australia''s most prominent angel investors and tech operators.
+
+The platform has **invested AU$110M+ since 2019** with cheques of **AU$300k–$2M** at **Pre-Seed to Series A** stages.
+
+TEN13 was the **first mandate under the AU$130M QVCDF (Queensland Venture Capital Development Fund)** — managed by QIC Ventures (covered separately).
+
+Notable portfolio: Appetise (Atrium pre-seed) — plus extensive syndicate participation across the ANZ early-stage ecosystem (e.g. Mr Yum, where Stew Glynn at TEN13 led a round that Tom Richardson and others joined).',
+  why_work_with_us = 'For Australian — and especially Queensland-based — pre-seed through Series A founders — TEN13 offers structured syndicated capital with AU$110M+ deployment track record, $300k–$2M cheques and QVCDF anchor LP. Especially valuable for founders pursuing Steve Baxter / Stew Glynn-network deal flow.',
+  meta_title = 'TEN13 — Steve Baxter + Stew Glynn Syndicate | $110M+ Since 2019 | $300k–$2M',
+  meta_description = 'AU syndicated investment platform. Steve Baxter + Stew Glynn. AU$110M+ since 2019. $300k–$2M. Pre-Seed to Series A.',
+  details = jsonb_build_object(
+    'organisation_type','Syndicated investment platform',
+    'principals', ARRAY['Steve Baxter','Stew Glynn'],
+    'track_record','AU$110M+ invested since 2019',
+    'check_size_note','AU$300k–$2M',
+    'qvcdf_anchor','First mandate under AU$130M QVCDF (managed by QIC Ventures)'
+  ),
+  updated_at = now()
+WHERE name = 'TEN13';
+
+UPDATE investors SET
+  basic_info = 'Tenacious Ventures is an **early-stage Australian venture capital firm** focused **exclusively on agri-food innovation and climate tech** at the intersection of **digitally native agriculture**.
+
+The portfolio is one of the deepest sector-pure agri-food-tech portfolios in Australia:
+- **Agovor**, **Azaneo**, **Cecil**, **Earthodic**, **Geora**, **Goterra**, **Jupiter Ionics**, **Nbryo**, **Phyllome**, **RapidAIM**, **Regrow**, **SwarmFarm Robotics**, **Vow Food**',
+  why_work_with_us = 'For Australian agri-food and climate-tech founders building digitally-native agriculture products — Tenacious Ventures is **the most credentialed sector-pure agri-food-tech VC in Australia** with a deep 13-company portfolio. Especially valuable for founders pursuing structured agri-tech commercialisation.',
+  meta_title = 'Tenacious Ventures — Australia''s Specialist Agri-Food / Climate Tech VC | Digitally Native Agriculture',
+  meta_description = 'AU early-stage VC. Exclusive focus on agri-food innovation + climate tech. Digitally native agriculture.',
+  details = jsonb_build_object(
+    'investment_thesis','Agri-food innovation + climate tech — digitally native agriculture; early stage.'
+  ),
+  updated_at = now()
+WHERE name = 'Tenacious Ventures';
+
+UPDATE investors SET
+  basic_info = 'Teoh Capital is the **family office of David Teoh** — founder of **TPG Telecom** (one of Australia''s largest telecommunications companies). The firm operates as an **Australian PE/VC firm** investing in **software, brands and enduring businesses**.',
+  why_work_with_us = 'For Australian founders pursuing structured family-office-backed capital — Teoh Capital offers David Teoh''s telecommunications-industry-leader operator depth (TPG Telecom founder) plus PE/VC investment capability across software, brands and enduring-businesses categories.',
+  meta_title = 'Teoh Capital — David Teoh (TPG Telecom Founder) Family Office | Software / Brands / Enduring Businesses',
+  meta_description = 'David Teoh (TPG Telecom founder) family office. Australian PE/VC. Software, brands, enduring businesses.',
+  details = jsonb_build_object(
+    'organisation_type','Family office (PE/VC)',
+    'principal','David Teoh (TPG Telecom founder)',
+    'investment_thesis','Software, brands, enduring businesses.'
+  ),
+  updated_at = now()
+WHERE name = 'Teoh Capital';
+
+UPDATE investors SET
+  basic_info = 'Tidal Ventures is an **Australian seed-stage venture capital firm** — **founder-led**. **Tidal Seed Fund III** is currently active.
+
+The firm invests in **technology with global potential**.
+
+Notable portfolio includes:
+- **Search.io** (AI search)
+- **TheLoops** (customer-experience analytics)
+- **Shippit** (Australian e-commerce shipping/logistics)
+- **SecurePII** (data protection)
+- **Vinyl**
+- **Refold** (translation tech)',
+  why_work_with_us = 'For Australian seed-stage founders building technology with global potential — Tidal Ventures offers a founder-led seed cheque with high-quality global-tech portfolio (Search.io, Shippit, TheLoops, Refold) and active Fund III deployment.',
+  meta_title = 'Tidal Ventures — AU Founder-Led Seed VC | Tidal Seed Fund III | Search.io, Shippit',
+  meta_description = 'AU seed-stage VC. Founder-led. Tidal Seed Fund III active. Search.io, Shippit, SecurePII, Vinyl, Refold portfolio.',
+  details = jsonb_build_object(
+    'organisation_type','Founder-led seed VC',
+    'fund_iii','Tidal Seed Fund III (active)',
+    'investment_thesis','Technology with global potential — seed.'
+  ),
+  updated_at = now()
+WHERE name = 'Tidal Ventures';
+
+UPDATE investors SET
+  basic_info = 'Tin Alley Ventures is the **University of Melbourne / Tanarra Capital partnership venture capital firm** with **AU$125M FUM**.
+
+The firm primarily focuses on **University of Melbourne spinouts** in **life sciences and physical sciences**, also extending to broader technology investments. Stage focus: **Seed to Pre-IPO**. Cheque size: **from AU$500k**.
+
+**9 investments** to date (not named publicly).',
+  why_work_with_us = 'For University of Melbourne researchers and spinout-founders — and broader Australian life-sciences and physical-sciences founders — Tin Alley Ventures offers AU$125M FUM partnership-backed capital with explicit university-spinout commercialisation focus.',
+  meta_title = 'Tin Alley Ventures — University of Melbourne / Tanarra Capital Partnership | $125M FUM',
+  meta_description = 'University of Melbourne / Tanarra Capital partnership VC. AU$125M FUM. Seed to Pre-IPO. UoM spinouts focus.',
+  details = jsonb_build_object(
+    'partnership','University of Melbourne + Tanarra Capital',
+    'fum','AU$125M',
+    'investment_thesis','UoM spinouts in life sciences and physical sciences; broader technology — Seed to Pre-IPO.',
+    'check_size_note','From AU$500k',
+    'portfolio_size','9 investments'
+  ),
+  updated_at = now()
+WHERE name = 'Tin Alley Ventures';
+
+COMMIT;

--- a/supabase/migrations/20260422142700_enrich_vcs_batch_07d.sql
+++ b/supabase/migrations/20260422142700_enrich_vcs_batch_07d.sql
@@ -1,0 +1,102 @@
+-- Enrich VCs — batch 07d (records 136-140: Tin Men Capital → UniQuest Extension Fund)
+
+BEGIN;
+
+UPDATE investors SET
+  basic_info = 'Tin Men Capital is a **Singapore-based venture capital firm** (193 Jalan Besar Rd) focused **exclusively on B2B technology in Southeast Asia**.
+
+**IMPORTANT**: Tin Men Capital is **NOT ANZ-focused**.
+
+Stage focus: **Series A and Series B**.
+
+Notable portfolio includes:
+- **Ailytics** (exited)
+- **Hubble** (exited)
+- **Globaltix** (Series B; S$6.5M)
+- **Ai Palette**
+- **Manuva**',
+  why_work_with_us = 'For Australian founders pursuing **Southeast Asia B2B-tech market expansion** — Tin Men Capital is a major Singapore regional B2B-tech VC. **Note**: Tin Men is not ANZ-focused, so engagement is best for AU founders explicitly building SEA B2B-tech operations.',
+  meta_title = 'Tin Men Capital — Singapore B2B Tech SE Asia VC | Series A/B | NOT ANZ-Focused',
+  meta_description = 'Singapore B2B tech VC. SE Asia focus only. Series A/B. Not ANZ-focused.',
+  details = jsonb_build_object(
+    'investment_thesis','B2B technology — SE Asia only (not ANZ-focused).',
+    'note','For AU founders, only relevant if explicitly expanding to SE Asia.'
+  ),
+  updated_at = now()
+WHERE name = 'Tin Men Capital';
+
+UPDATE investors SET
+  basic_info = 'TORUS is a **global early-stage investment community** with **300+ accelerators and VCs in its network**. The team is **behind Cake** (equity-management software with 10,000+ customers — also covered separately as Cake Equity-network).
+
+**20+ startup investments to date** alongside major ANZ VCs including **Blackbird, Airtree and TEN13**.
+
+Stage focus: **early stage**. Sector mandate: agnostic technology.
+
+Note: This entry represents the global TORUS investment community — separately from PB Ventures / TORUS Fund Zero (Gold Coast B2B SaaS syndicate, also covered).',
+  why_work_with_us = 'For global early-stage founders looking for community-network access to 300+ accelerators and VCs — TORUS offers a unique investment-community structure with cross-investment alongside Blackbird, Airtree and TEN13. Especially valuable for cap-table-aware founders given the Cake Equity origin.',
+  meta_title = 'TORUS — Global Early-Stage Investment Community | 300+ VCs | Cake Equity Origin',
+  meta_description = 'Global early-stage investment community. 300+ accelerators/VCs in network. Cake Equity team. 20+ investments alongside Blackbird, Airtree, TEN13.',
+  details = jsonb_build_object(
+    'organisation_type','Global early-stage investment community',
+    'network','300+ accelerators / VCs',
+    'origin','Team behind Cake (equity management; 10,000+ customers)',
+    'co_investors', ARRAY['Blackbird','Airtree','TEN13']
+  ),
+  updated_at = now()
+WHERE name = 'TORUS';
+
+UPDATE investors SET
+  basic_info = 'Touch Ventures is the **investment holding company of Afterpay** (now part of **Block**, formerly Square — acquired Afterpay 2022 for ~US$29B).
+
+The firm provides **growth capital to high-growth scalable businesses benefiting from Afterpay''s ecosystem** — making Touch Ventures a strategic-investor cheque for fintech, e-commerce and consumer-tech companies aligned with the BNPL/payments value chain.
+
+Stage focus: **Growth**.',
+  why_work_with_us = 'For Australian and global high-growth scalable businesses — particularly in fintech, e-commerce, BNPL-adjacent and consumer-tech categories — Touch Ventures offers strategic-investor capital with deep Afterpay/Block ecosystem alignment. Especially valuable for founders building products that complement BNPL or consumer-payments value chains.',
+  meta_title = 'Touch Ventures — Afterpay (Block) Investment Holding Company | Growth Capital',
+  meta_description = 'Investment holding company of Afterpay (now Block). Growth capital. High-growth scalable businesses with Afterpay ecosystem fit.',
+  details = jsonb_build_object(
+    'parent','Afterpay / Block (acquired 2022 ~US$29B)',
+    'investment_thesis','Growth capital — high-growth scalable businesses benefiting from Afterpay/Block ecosystem.'
+  ),
+  updated_at = now()
+WHERE name = 'Touch Ventures';
+
+UPDATE investors SET
+  basic_info = 'Tripple is an **Australian 100% impact-portfolio fund** — meaning every dollar deployed targets measurable real-world impact rather than blended returns.
+
+The fund operates across both **investments and grants** to solve real-world problems including:
+- **Climate justice**
+- **Housing**
+- **Tax reform**
+- **Migration**',
+  why_work_with_us = 'For Australian founders building businesses with explicit measurable impact in climate justice, housing, tax reform or migration categories — Tripple offers a 100% impact-portfolio fund with both investment and grant capability. Especially valuable for impact-aligned founders pursuing structured systemic-change capital.',
+  meta_title = 'Tripple — Australian 100% Impact Portfolio Fund | Climate / Housing / Tax / Migration',
+  meta_description = 'Australian 100% impact portfolio fund. Investments + grants. Climate justice, housing, tax reform, migration.',
+  details = jsonb_build_object(
+    'distinction','100% impact portfolio fund',
+    'instruments', ARRAY['Investments','Grants'],
+    'investment_thesis','Climate justice, housing, tax reform, migration.'
+  ),
+  updated_at = now()
+WHERE name = 'Tripple';
+
+UPDATE investors SET
+  basic_info = 'UniQuest Extension Fund (UEF) is the **University of Queensland-affiliated AU$32M venture capital fund** — operating from Brisbane, QLD via **UniQuest Pty Ltd** (UQ''s commercialisation company).
+
+The fund focuses on **Pre-Seed, Seed and Follow-on investments** with **20 portfolio companies and 30 total investments**. Sector focus: **Technology — UQ research commercialisation, with AI emphasis**.
+
+**Eligibility requirement**: portfolio companies must have a **UQ Founder link**.',
+  why_work_with_us = 'For University of Queensland researchers, alumni or spinout-founders — UniQuest Extension Fund offers AU$32M dedicated UQ-spinout capital across Pre-Seed, Seed and Follow-on rounds. Best leveraged by founders with existing UQ Founder links pursuing structured university-commercialisation pathways.',
+  meta_title = 'UniQuest Extension Fund — UQ-Affiliated $32M VC | UQ Founder Link Required',
+  meta_description = 'University of Queensland AU$32M fund. UQ research commercialisation. Pre-Seed, Seed, Follow-on. 20 companies / 30 investments.',
+  details = jsonb_build_object(
+    'parent','UniQuest Pty Ltd (University of Queensland commercialisation company)',
+    'fund_size','AU$32M',
+    'investment_thesis','UQ research commercialisation; AI emphasis — Pre-Seed, Seed, Follow-on.',
+    'eligibility','Requires UQ Founder link',
+    'portfolio_size','20 companies; 30 investments'
+  ),
+  updated_at = now()
+WHERE name = 'UniQuest Extension Fund (UEF)';
+
+COMMIT;

--- a/supabase/migrations/20260422142800_enrich_vcs_batch_07e.sql
+++ b/supabase/migrations/20260422142800_enrich_vcs_batch_07e.sql
@@ -1,0 +1,93 @@
+-- Enrich VCs — batch 07e (records 141-145: Uniseed → Virescent Ventures) — FINAL VC BATCH
+
+BEGIN;
+
+UPDATE investors SET
+  basic_info = 'Uniseed is **Australia''s longest-running university venture capital fund** — multi-decade operating history across multiple Australian universities.
+
+The firm partners with **Universities of Melbourne, Queensland, Sydney, UNSW and CSIRO** — making Uniseed the most extensive university-spinout VC platform in the country.
+
+Track record: **70 startups, 12 exits** (notable exits include **Fibrotech, Spinifex, Hatchtech**). **Fund 3: AU$50M.**
+
+Stage focus: **Seed**. Multi-city presence (Melbourne, Brisbane, Sydney).',
+  why_work_with_us = 'For Australian university researchers, postdocs, spinout-founders and academic-aligned technology founders — Uniseed is **Australia''s longest-running and most extensive university VC fund** with formal partnerships across UoM, UQ, USyd, UNSW and CSIRO. Multi-decade operating history (70 startups, 12 exits) makes Uniseed the go-to capital partner for university-commercialisation founders.',
+  meta_title = 'Uniseed — Australia''s Longest-Running University VC | UoM / UQ / USyd / UNSW / CSIRO Partnership',
+  meta_description = 'AU''s longest-running university VC. UoM, UQ, USyd, UNSW, CSIRO partners. 70 startups, 12 exits. Fund 3 $50M.',
+  details = jsonb_build_object(
+    'distinction','Australia''s longest-running university VC fund',
+    'partners', ARRAY['University of Melbourne','University of Queensland','University of Sydney','UNSW','CSIRO'],
+    'track_record','70 start-ups; 12 exits (Fibrotech, Spinifex, Hatchtech among others)',
+    'fund_3','AU$50M',
+    'investment_thesis','University commercialisation across broad technology sectors — seed.'
+  ),
+  updated_at = now()
+WHERE name = 'Uniseed';
+
+UPDATE investors SET
+  basic_info = 'Utiliti Ventures is an **Australia-based venture capital firm and ecosystem builder** that **bridges Australian tech startups to the US market**.
+
+Stage focus: **Early stage to Series B**. Sector focus: high-growth technology.',
+  why_work_with_us = 'For Australian high-growth technology founders pursuing **US market expansion** — Utiliti Ventures offers a structured AU-to-US bridge with both investment capital and ecosystem-building support.',
+  meta_title = 'Utiliti Ventures — Australian VC + US Market Bridge | Early Stage to Series B',
+  meta_description = 'Australian VC + ecosystem builder. AU-to-US tech bridge. Early stage to Series B.',
+  details = jsonb_build_object(
+    'investment_thesis','High-growth technology — AU-to-US bridge.'
+  ),
+  updated_at = now()
+WHERE name = 'Utiliti Ventures';
+
+UPDATE investors SET
+  basic_info = 'Verona Capital is the **family office of Craig and Katrina Burton**. The firm is a **global multi-asset investor** operating across **PE, VC, public equities and quant strategies**.
+
+Verona backs both **Australian and global VC funds** as an LP and makes **direct investments**.',
+  why_work_with_us = 'For Australian and global founders or fund managers — Verona Capital offers structured multi-asset family-office capital with a notable LP commitment to AU and global VC funds (LP-style relationships) plus direct-investment capability. Especially valuable for founders pursuing structured family-office partnerships or fund managers raising LP capital.',
+  meta_title = 'Verona Capital — Craig + Katrina Burton Family Office | Multi-Asset Global Investor',
+  meta_description = 'Craig + Katrina Burton family office. Multi-asset global investor (PE, VC, equities, quant). LP + direct.',
+  details = jsonb_build_object(
+    'organisation_type','Family office (multi-asset)',
+    'principals', ARRAY['Craig Burton','Katrina Burton'],
+    'investment_thesis','Multi-asset — PE, VC, public equities, quant strategies; AU and global.'
+  ),
+  updated_at = now()
+WHERE name = 'Verona Capital';
+
+UPDATE investors SET
+  basic_info = 'Victorian Clean Technology Fund (VCTF) is a **Victorian Government not-for-profit evergreen fund** investing in **novel clean technologies**.
+
+The fund''s explicit thesis: **fill the gap between discovery and commercialisation** for clean-technology and renewable-energy ventures in Victoria.
+
+**Track record: 30+ companies backed.** Initial investment: **up to AU$500K**. Stage focus: **early stage — pre-commercialisation to commercialisation**.',
+  why_work_with_us = 'For Victorian-based clean-technology and renewable-energy founders at pre-commercialisation through commercialisation stages — Victorian Clean Technology Fund is the most-credentialed VIC-Government not-for-profit evergreen cleantech vehicle. Especially valuable for early-stage cleantech founders pursuing structured Government-aligned discovery-to-commercialisation capital.',
+  meta_title = 'Victorian Clean Technology Fund (VCTF) — VIC Government Not-for-Profit Evergreen | up to $500K | 30+ Companies',
+  meta_description = 'VIC Government not-for-profit evergreen fund. Novel clean tech. 30+ companies backed. Up to AU$500K initial.',
+  details = jsonb_build_object(
+    'organisation_type','VIC Government not-for-profit evergreen fund',
+    'investment_thesis','Novel clean technologies — fill gap between discovery and commercialisation.',
+    'check_size_note','Up to AU$500K initial',
+    'portfolio_size','30+ companies backed'
+  ),
+  updated_at = now()
+WHERE name = 'Victorian Clean Technology Fund (VCTF)';
+
+UPDATE investors SET
+  basic_info = 'Virescent Ventures is **Australia''s largest dedicated climate-tech venture capital firm** — born from **CEFC''s Clean Energy Innovation Fund** in **2022**.
+
+**Fund I: AU$270M+ deployed across 37 Australian climate-tech investments.**
+
+**Fund II**: targeting **AU$200M** — first close **AU$100M (October 2024)**, raised **AU$125M (November 2024)** with **QIC backing**.
+
+Sector focus across **Clean Energy, Food/Agriculture, Circular Economy, Mobility and Hard-to-Abate Emissions**. Stage focus: **Pre-seed to Late stage** — meaning Virescent has the cheque flexibility to back climate founders from earliest concept through to growth/pre-IPO.',
+  why_work_with_us = 'For Australian climate-tech founders across clean energy, food/agriculture, circular economy, mobility and hard-to-abate-emissions categories — Virescent Ventures is **Australia''s largest dedicated climate-tech VC** with AU$270M+ Fund I deployed across 37 investments and Fund II actively raising. Especially valuable for capital-intensive climate-tech founders pursuing structured pre-seed through late-stage capital.',
+  meta_title = 'Virescent Ventures — Australia''s Largest Climate-Tech VC | Fund I $270M+ / 37 Investments | Fund II $125M',
+  meta_description = 'AU''s largest climate-tech VC. Born from CEFC. Fund I $270M+ / 37 investments. Fund II $125M raised (Nov 2024) with QIC.',
+  details = jsonb_build_object(
+    'distinction','Australia''s largest dedicated climate-tech VC',
+    'origin','Born from CEFC Clean Energy Innovation Fund (2022)',
+    'fund_i','AU$270M+ deployed in 37 Australian investments',
+    'fund_ii','Targeting AU$200M; first close AU$100M (Oct 2024); AU$125M raised (Nov 2024) with QIC backing',
+    'investment_thesis','Climate tech — clean energy, food/agriculture, circular economy, mobility, hard-to-abate emissions; pre-seed to late stage.'
+  ),
+  updated_at = now()
+WHERE name = 'Virescent Ventures';
+
+COMMIT;


### PR DESCRIPTION
## Summary — FINAL VC BATCH 🎉

Adds rich `basic_info`, `why_work_with_us`, `meta_title`, `meta_description` and structured `details` JSONB for the **FINAL 25 VCs** (records 121-145). Spans `Southern Cross Venture Partners` → `Virescent Ventures`.

**With this batch, ALL 145 VCs in the production `investors` table are now fully enriched.**

### Highlight VCs in this batch
- **Square Peg Capital** — Melbourne global VC; Fiverr, Stripe, Rokt, **Airwallex**; AU$5M–$50M; AU/Israel/SE Asia
- **Virescent Ventures** — **Australia's largest climate-tech VC** (CEFC origin); Fund I $270M+ / 37 investments; Fund II $125M (Nov 2024 QIC-backed)
- **Uniseed** — **Australia's longest-running university VC** (UoM, UQ, USyd, UNSW, CSIRO partnership); 70 startups, 12 exits
- **TEN13** — Steve Baxter + Stew Glynn syndicate; AU$110M+ since 2019; first mandate under AU$130M QVCDF
- **Touch Ventures** — Afterpay (Block) investment holding company
- **TORUS** — global early-stage investment community; 300+ VC network; Cake Equity origin
- **Tenacious Ventures** — Australia's specialist agri-food / climate tech VC; 13-company sector-pure portfolio
- **Tin Alley Ventures** — University of Melbourne / Tanarra Capital partnership; AU$125M FUM
- **UniQuest Extension Fund** — UQ-affiliated AU$32M; UQ Founder link required
- **Sprint Ventures** — Brisbane/Sydney/Melbourne with QIC partnership
- **Stoic VC** — Sydney research/commercialisation VC; Uniseed partner
- **Starfish Ventures** — Melbourne IT/life sciences/cleantech; AU$400M+
- **Southern Cross Venture Partners** — Sydney since 2006; AU$120M REVC Fund (ARENA + SoftBank China)
- **Tank Stream Ventures** — Sydney $20M fund; SaaS/eCommerce; BridgeLane Group
- **Tarnagulla Ventures** — Melbourne family-owned life-sciences VC
- **Taronga Ventures** — global RealTech VC + accelerator
- **Teoh Capital** — David Teoh (TPG Telecom founder) family office
- **Tidal Ventures** — AU founder-led seed; Tidal Seed Fund III; Shippit
- **Victorian Clean Technology Fund (VCTF)** — VIC Government cleantech evergreen; 30+ companies; up to AU$500K
- **Verona Capital** — Craig + Katrina Burton multi-asset family office
- **Strata Vision Fund** — AU PropTech (strata/apartment communities)

### Special flags
- **Tin Men Capital** — flagged Singapore SE Asia-only, NOT ANZ-focused
- **Steamworks Ventures** — flagged limited public information

## Final VC Series State

🎉 **VC ENRICHMENT SERIES COMPLETE: 145/145 (100%) VCs enriched and applied to production.**

Verification (all 145):
- `basic_info` (>100 chars): **145/145**
- `why_work_with_us`: **145/145**
- `meta_title`: **145/145**
- `portfolio_companies` (≥1): **145/145**

## Migrations applied to production

All 5 final migrations applied directly to MES production Supabase (`xhziwveaiuhzdoutpgrh`) via Supabase MCP `apply_migration`:
- `20260422142400_enrich_vcs_batch_07a` (records 121-125)
- `20260422142500_enrich_vcs_batch_07b` (records 126-130)
- `20260422142600_enrich_vcs_batch_07c` (records 131-135)
- `20260422142700_enrich_vcs_batch_07d` (records 136-140)
- `20260422142800_enrich_vcs_batch_07e` (records 141-145)

## Test plan
- [x] All 5 migration files applied to production via Supabase MCP
- [x] Verified all 145 VCs enriched (count = 145 across all enrichment fields)
- [ ] CI green on this PR

https://claude.ai/code/session_01XsHLVbJ1rAJ3oafzHY6j2N

---
_Generated by [Claude Code](https://claude.ai/code/session_01XsHLVbJ1rAJ3oafzHY6j2N)_