### PR TITLE
Case study readability overhaul (Phases 3–5.1) + Buildkite pilot

### DIFF
--- a/.claude/staging/buildkite-australia-startup.md
+++ b/.claude/staging/buildkite-australia-startup.md
@@ -1,0 +1,79 @@
+# buildkite-australia-startup: Backfill Staging
+
+**Pilot:** 1 of 3
+**case_study_id:** `095defd7-d026-4af3-970a-3cbe90152559`
+**Researched by:** Stephen Browne
+**last_verified_at:** 2026-05-04
+
+---
+
+## TLDR
+
+- Bootstrapped seven years to profitability before raising venture capital
+- $28M AUD Series A in 2020 led by OpenView at $200M+ valuation
+- Hybrid CI/CD architecture keeps customer code on customer infrastructure
+- Trusted by Shopify, Uber, Slack, Canva, OpenAI, and Anthropic
+- Founded in Melbourne 2013 by Keith Pitt and Tim Lucas
+
+## Quick Facts
+
+- Label: Founded | Value: 2013 | Icon: Calendar
+- Label: HQ | Value: Melbourne, Australia | Icon: MapPin
+- Label: Series A | Value: $28M AUD (Aug 2020) | Icon: TrendingUp
+- Label: Valuation | Value: $200M+ AUD | Icon: DollarSign
+- Label: Users | Value: 60,000+ | Icon: Users
+- Label: Investors | Value: OpenView, General Catalyst | Icon: Briefcase
+
+## Hero
+
+URL: https://www.businessdailymedia.com/images/0c/Keith_Pitt_founder_and_CEO_Buildkite.jpeg
+Alt: Keith Pitt, founder of Buildkite
+Credit: Business Daily Media
+
+## Sources
+
+1. [TechCrunch — Melbourne-based CI/CD platform Buildkite gets $28 million AUD Series A led by OpenView](https://techcrunch.com/2020/08/18/melbourne-based-ci-cd-platform-buildkite-gets-28-million-aud-series-a-led-by-openview/) - accessed 2026-05-04 - news
+2. [Authority Magazine — Keith Pitt: 5 Things I Wish Someone Told Me Before I Became Co-Founder of Buildkite](https://medium.com/authority-magazine/keith-pitt-5-things-i-wish-someone-told-me-before-i-became-the-ceo-of-buildkite-8f67f3a539e5) - accessed 2026-05-04 - interview
+3. [Startup Daily — Buildkite, "the best-kept secret in DevOps", raises $28 million for $200 million valuation](https://www.startupdaily.net/topic/buildkite-the-best-kept-secret-in-devops-raises-28-million-for-200-million-valuation/) - accessed 2026-05-04 - news
+4. [Buildkite — About Company page](https://buildkite.com/about/company/) - accessed 2026-05-04 - company_blog
+5. [General Catalyst — Buildkite portfolio entry](https://www.generalcatalyst.com/portfolio/buildkite) - accessed 2026-05-04 - company_blog
+6. [Euphemia — Buildkite awesome stories](https://euphemia.com/awesome-stories/buildkite/) - accessed 2026-05-04 - interview
+7. [Startup Playbook Ep127 — Lachlan Donald on equity over ego (YouTube)](https://www.youtube.com/watch?v=4_QEE3UHS1U) - accessed 2026-05-04 - podcast
+8. [Apple Podcasts — Startup Playbook Ep127 with Lachlan Donald](https://podcasts.apple.com/us/podcast/ep127-lachlan-donald-co-founder-ceo-buildkite-on-equity/id1135431502?i=1000489927740) - accessed 2026-05-04 - podcast
+9. [VentureBeat — Keith Pitt DataDecisionMakers author profile](https://venturebeat.com/author/keith-pitt-buildkite/) - accessed 2026-05-04 - interview
+10. [The Org — Keith Pitt at Buildkite](https://theorg.com/org/buildkite/org-chart/keith-pitt) - accessed 2026-05-04 - linkedin
+
+## Quotes
+
+> "All of the self-hosted options were incredibly outdated, given I was accustomed to using modern development workflows."
+> Attributed to: Keith Pitt, Founder & former CEO
+> Source: [Authority Magazine](https://medium.com/authority-magazine/keith-pitt-5-things-i-wish-someone-told-me-before-i-became-the-ceo-of-buildkite-8f67f3a539e5)
+> Place after section: entry-strategy
+
+> "My priority from day one as founder of Buildkite was to end this compromise."
+> Attributed to: Keith Pitt, Founder & former CEO
+> Source: [Startup Daily](https://www.startupdaily.net/topic/buildkite-the-best-kept-secret-in-devops-raises-28-million-for-200-million-valuation/)
+> Place after section: entry-strategy
+
+> "I never treated Buildkite as a startup, but rather as a business."
+> Attributed to: Keith Pitt, Founder & former CEO
+> Source: [Authority Magazine](https://medium.com/authority-magazine/keith-pitt-5-things-i-wish-someone-told-me-before-i-became-the-ceo-of-buildkite-8f67f3a539e5)
+> Place after section: success-factors
+
+> "We wanted to focus on sustainable growth and maintain control of our destiny."
+> Attributed to: Lachlan Donald, Co-founder & CEO
+> Source: [TechCrunch](https://techcrunch.com/2020/08/18/melbourne-based-ci-cd-platform-buildkite-gets-28-million-aud-series-a-led-by-openview/)
+> Place after section: success-factors
+
+> "When CI/CD doesn't work, it shows throughout the entire organisation – teams slow down, products are delayed and customers turn elsewhere."
+> Attributed to: Lachlan Donald, Co-founder & CEO
+> Source: [Startup Daily](https://www.startupdaily.net/topic/buildkite-the-best-kept-secret-in-devops-raises-28-million-for-200-million-valuation/)
+> Place after section: key-metrics
+
+---
+
+## Notes for review
+
+- Hero image is the same Keith Pitt photo already used as `content_founders.image`. Reusing avoids hot-linking a new external host. Verifiable.
+- All 10 source URLs were found via web search and the top 4 were also verified via WebFetch (200 OK).
+- 5 quotes (within the 3-6 spec range), distributed across entry-strategy / success-factors / key-metrics. Challenges + Lessons Learned have no quotes — that's fine; the renderer falls through gracefully.

--- a/.claude/staging/go1-australia-startup.md
+++ b/.claude/staging/go1-australia-startup.md
@@ -1,0 +1,75 @@
+# go1-australia-startup: Backfill Staging
+
+**Pilot:** 2 of 3
+**case_study_id:** `f8653a1a-32b8-4672-9c43-b727deb9ad9a`
+**Researched by:** Stephen Browne
+**last_verified_at:** 2026-05-04
+
+---
+
+## TLDR
+
+- Four childhood friends reunited via Y Combinator 2015 to launch Go1
+- Brisbane's first unicorn at $2B valuation, now reaching $3B
+- 50M users across 10,000+ organisations consume 250+ providers
+- Acquired Coorpacademy (April 2022) and Blinkist (May 2023)
+- Sole CEO Chris Eigeland since August 2024 after Andrew Barnes' transition
+
+## Quick Facts
+
+- Label: Founded | Value: 2015 (Logan, QLD) | Icon: Calendar
+- Label: HQ | Value: Brisbane, Australia | Icon: MapPin
+- Label: Total Funding | Value: ~$414M USD | Icon: DollarSign
+- Label: Valuation | Value: $2–3B USD | Icon: TrendingUp
+- Label: Users | Value: 50M registered | Icon: Users
+- Label: Team | Value: ~600 across 19 countries | Icon: Globe2
+
+## Hero
+
+URL: https://www.griffith.edu.au/__data/assets/image/0031/2237674/Chris-Eigeland.jpg
+Alt: Chris Eigeland, CEO and co-founder of Go1
+Credit: Griffith University
+
+## Sources
+
+1. [Contrary Research — Go1 Business Breakdown & Founding Story](https://research.contrary.com/company/go1) - accessed 2026-05-04 - other
+2. [Startup Daily — Go1 cofounder exits CEO role after 10 years, handing reins to Chris Eigeland](https://www.startupdaily.net/topic/people/go1-cofounder-exits-ceo-role-after-10-years-handing-reins-to-chris-eigeland/) - accessed 2026-05-04 - news
+3. [Crunchbase — Chris Eigeland person profile](https://www.crunchbase.com/person/chris-eigeland) - accessed 2026-05-04 - other
+4. [Go1 Podcast Ep9 — Chris Eigeland on the role of L&D](https://www.go1.com/podcast/ep9-chris-eigeland) - accessed 2026-05-04 - podcast
+5. [Startup Grind Brisbane — Chris Eigeland event page](https://www.startupgrind.com/events/details/startup-grind-brisbane-presents-chris-eigeland-go1/) - accessed 2026-05-04 - interview
+6. [AICC NSW — Boardroom Lunch with Chris Eigeland, Co-Founder of Go1](https://aiccnsw.org.au/boardroom-lunch-with-chris-eigeland-co-founder-go1-brisbane/) - accessed 2026-05-04 - interview
+7. [AICC QLD — Boardroom Lunch with Chris Eigeland, Co-Founder of Go1](https://aiccqld.org.au/2026/03/05/boardroom-lunch-with-chris-eigeland-co-founder-go1-brisbane/) - accessed 2026-05-04 - interview
+8. [EdTechX 2022 Stories — Chris Eigeland](https://impactx2050.com/edtechx-stories-chris-eigeland) - accessed 2026-05-04 - interview
+9. [Anthill — Chris Eigeland 2016 30 Under 30 winner](https://anthillonline.com/chris-eigeland-2016-anthill-30under30-winner/) - accessed 2026-05-04 - news
+10. [Advance Queensland — Igniting Innovation: Go1's journey from Logan to Brisbane's first unicorn](https://advance.qld.gov.au/innovation-in-queensland/innovation-stories/igniting-innovation-the-go1-journey-from-logan-startup-to-brisbanes-first-unicorn) - accessed 2026-05-04 - government
+
+## Quotes
+
+> "We've been incredibly lucky that our skillsets have been complementary, helping Go1 get to where it is today."
+> Attributed to: Andrew Barnes, Co-founder & former Co-CEO
+> Source: [Startup Daily](https://www.startupdaily.net/topic/people/go1-cofounder-exits-ceo-role-after-10-years-handing-reins-to-chris-eigeland/)
+> Place after section: entry-strategy
+
+> "If we do something in consumer, we would want to make that a target. It would be quite a different product."
+> Attributed to: Andrew Barnes, Co-founder & former Co-CEO
+> Source: [Contrary Research](https://research.contrary.com/company/go1)
+> Place after section: success-factors
+
+> "We're building and running the business at an increasing level of maturity around governance and all the standards that are required to become IPO ready."
+> Attributed to: Chris Eigeland, CEO & Co-Founder
+> Source: [Contrary Research](https://research.contrary.com/company/go1)
+> Place after section: key-metrics
+
+> "By having a single CEO, we will be able to move faster on the day-to-day decisions."
+> Attributed to: Andrew Barnes, Co-founder & former Co-CEO
+> Source: [Startup Daily](https://www.startupdaily.net/topic/people/go1-cofounder-exits-ceo-role-after-10-years-handing-reins-to-chris-eigeland/)
+> Place after section: challenges-faced
+
+---
+
+## Notes for review
+
+- Hero image is the existing Chris Eigeland photo from Griffith University — verifiable, already in `content_founders.image`.
+- 10 sources spanning research breakdowns, news, interviews, and a government innovation profile.
+- 4 quotes (within the 3-6 spec range), placed across entry-strategy / success-factors / key-metrics / challenges-faced.
+- Two quotes are from Andrew Barnes (co-founder, who transitioned out as Co-CEO in Aug 2024). One from Eigeland on IPO readiness. The case study's primary subject founder in `content_founders` is Eigeland — these are pull-quote callouts, not founder bio replacements, so multi-attribution is fine.

--- a/.claude/staging/zoom-australia-market-entry.md
+++ b/.claude/staging/zoom-australia-market-entry.md
@@ -1,0 +1,107 @@
+# zoom-australia-market-entry: Backfill Staging
+
+**Pilot:** 3 of 3
+**case_study_id:** `0b0025c5-4748-49ae-b646-8ec8018e67b5`
+**Researched by:** Stephen Browne
+**last_verified_at:** 2026-05-04
+
+---
+
+## TLDR
+
+- Michael Chetner became Zoom's first ANZ employee in April 2017
+- AARNet partnership (since 2014) reached 60+ Australian institutions by end-2017
+- 134% revenue growth and 105% customer growth announced December 2017
+- Australian customers: REA Group, SEEK, Movember, Western Sydney University
+- Zoom Phone launched in Australia July 2019, Zoom Contact Center 2023
+
+## Quick Facts
+
+- Label: ANZ Entry | Value: April 2017 | Icon: Calendar
+- Label: First Hire | Value: Michael Chetner | Icon: User
+- Label: Channel Partner | Value: AARNet (since 2014) | Icon: Network
+- Label: ANZ Revenue Growth | Value: 134% YoY (2017) | Icon: TrendingUp
+- Label: ANZ Customer Growth | Value: 105% YoY (2017) | Icon: Users
+- Label: Origin | Value: San Jose, USA | Icon: MapPin
+
+## Hero
+
+URL: TBD — please supply a Zoom-AU brand asset, Michael Chetner photo, or Sydney office image. Component renders nothing if `hero_image_url` is null, so this can ship null and be backfilled later.
+Alt: TBD
+Credit: TBD
+
+## Sources
+
+1. [Zoom Blog — Zoom Announces 134% Revenue Growth in Australia and New Zealand](https://blog.zoom.us/zoom-announces-134-percent-revenue-growth-australia-new-zealand/) - accessed 2026-05-04 - press_release
+2. [ITBrief — Video communication service Zoom posts 134% revenue growth in ANZ](https://itbrief.com.au/story/video-communication-service-zoom-posts-134-revenue-growth-nz) - accessed 2026-05-04 - news
+3. [ChannelLife — Zoom posts 134% revenue growth in ANZ](https://channellife.com.au/story/video-communication-service-zoom-posts-134-revenue-growth-nz) - accessed 2026-05-04 - news
+4. [ChannelLife — Exclusive interview: Targeting the university sector with AARNet and Zoom](https://channellife.com.au/story/exclusive-interview-targeting-university-sector-aarnet-and-zoom) - accessed 2026-05-04 - interview
+5. [AARNet — Transforming online collaboration for Australian universities](https://www.aarnet.edu.au/transforming-online-collaboration-for-australian-universities) - accessed 2026-05-04 - other
+6. [AARNet — Zoom Video Communications for Research & Education](https://www.aarnet.edu.au/zoom) - accessed 2026-05-04 - other
+7. [Zoom Blog — Zoom To Reach Over 1 Million in Australia Via AARNet](https://blog.zoom.us/zoom-reaches-1-million-australia-via-aarnet/) - accessed 2026-05-04 - press_release
+8. [ARN — Zoom A/NZ head Michael Chetner resigns](https://www.arnnet.com.au/article/705793/zoom-anz-head-michael-chetner-resigns/) - accessed 2026-05-04 - news
+9. [The Org — Michael Chetner, Head of Australia and Asia Pacific at Zoom](https://theorg.com/org/zoom/org-chart/michael-chetner) - accessed 2026-05-04 - linkedin
+10. [ITBrief — Zoom Virtual Agent launch promises big things for ANZ businesses](https://itbrief.com.au/story/zoom-virtual-agent-launch-promises-big-things-for-anz-businesses) - accessed 2026-05-04 - news
+11. [Atlassian — Zoom surpasses growth goals with Atlassian cloud products case study](https://www.atlassian.com/customers/zoom) - accessed 2026-05-04 - company_blog
+
+## Quotes
+
+> "They've bundled the value up really nicely. If I was to compare their offering with any other service provider, it's very easy to have the pipes but you need to have relevant applications."
+> Attributed to: Michael Chetner, Head of A/NZ, Zoom
+> Source: [ChannelLife](https://channellife.com.au/story/exclusive-interview-targeting-university-sector-aarnet-and-zoom)
+> Place after section: entry-strategy
+
+> "In today's hyper-connected world, Zoom has cut through the noise, answering the call for simplified communications."
+> Attributed to: Michael Chetner, Head of A/NZ, Zoom
+> Source: [ChannelLife](https://channellife.com.au/story/video-communication-service-zoom-posts-134-revenue-growth-nz)
+> Place after section: success-factors
+
+> "Zoom's rapid expansion into the ANZ region has been fuelled by a demand for easy and secure meeting experiences."
+> Attributed to: Eric S. Yuan, Founder & CEO, Zoom
+> Source: [ChannelLife](https://channellife.com.au/story/video-communication-service-zoom-posts-134-revenue-growth-nz)
+> Place after section: key-metrics
+
+> "There has been an amazing turn-around on our functionality requests."
+> Attributed to: Geoff Lambert, Western Sydney University
+> Source: [AARNet — Transforming online collaboration](https://www.aarnet.edu.au/transforming-online-collaboration-for-australian-universities)
+> Place after section: success-factors
+
+> "Zoom bridges the gap between on-campus and off-campus students for tutorials."
+> Attributed to: Troy Down, University of Southern Queensland
+> Source: [AARNet — Transforming online collaboration](https://www.aarnet.edu.au/transforming-online-collaboration-for-australian-universities)
+> Place after section: success-factors
+
+> "The reliability and ease of the AARNet Zoom service increased the use of desktop and mobile video conferencing."
+> Attributed to: Ben Loveridge, University of Melbourne
+> Source: [AARNet — Transforming online collaboration](https://www.aarnet.edu.au/transforming-online-collaboration-for-australian-universities)
+> Place after section: success-factors
+
+---
+
+## Notes for review
+
+- **Hero image:** flagged as TBD because I don't have a verified URL for a Zoom-AU brand asset that won't 404. Recommend you supply one of: a Zoom press kit asset, the AARNet partnership signing photo, or a Michael Chetner LinkedIn-permission photo. The page renders gracefully with `hero_image_url = null`.
+- **Inline source HTML scrub:** per Phase 2 §2.7 #2, the existing `<p class="text-sm text-muted-foreground mt-4"><em>Sources: …</em></p>` blocks appended to Zoom bodies will be stripped during the apply step (see "## Inline source-block scrub" in this file's apply plan, below).
+- 11 sources within the 8-15 range. The Atlassian case study is included as a customer-side artifact.
+- 6 quotes (max per spec). Three from inside Zoom (Chetner ×2, Yuan ×1), three from AARNet university customers (Lambert/WSU, Down/USQ, Loveridge/UoM). The customer-side voices are deliberate — they triangulate the story beyond founder narrative and match the actual case study angle (channel-partnership-led market entry).
+
+## Inline source-block scrub (apply step only — not part of upserts above)
+
+When applying this pilot to the database, ALSO run a one-time scrub of the 13 inline source blocks currently embedded in Zoom's `content_bodies.body_text`:
+
+```sql
+UPDATE public.content_bodies cb
+SET body_text = regexp_replace(
+  cb.body_text,
+  '<p class="text-sm text-muted-foreground mt-4"><em>Sources:.*?</em></p>',
+  '',
+  'gi'
+)
+FROM public.content_sections cs
+JOIN public.content_items ci ON cs.content_id = ci.id
+WHERE cb.section_id = cs.id
+  AND ci.slug = 'zoom-australia-market-entry'
+  AND cb.body_text LIKE '%Sources:%';
+```
+
+This will be packaged as a separate, reversible-via-restore migration that runs immediately before the source/quote upserts. The structured `case_study_sources` table replaces this inline HTML.

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "date-fns": "^3.6.0",
         "dompurify": "^3.3.1",
         "embla-carousel-react": "^8.3.0",
+        "html-react-parser": "^5.2.17",
         "input-otp": "^1.2.4",
         "lucide-react": "^0.462.0",
         "next-themes": "^0.3.0",
@@ -4132,6 +4133,59 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
     "node_modules/dompurify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
@@ -4139,6 +4193,20 @@
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/eastasianwidth": {
@@ -4187,6 +4255,18 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.8",
@@ -4793,6 +4873,53 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/html-dom-parser": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.1.8.tgz",
+      "integrity": "sha512-MCIUng//mF2qTtGHXJWr6OLfHWmg3Pm8ezpfiltF83tizPWY17JxT4dRLE8lykJ5bChJELoY3onQKPbufJHxYA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/remarkablemark"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "htmlparser2": "10.1.0"
+      }
+    },
+    "node_modules/html-react-parser": {
+      "version": "5.2.17",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.2.17.tgz",
+      "integrity": "sha512-m+K/7Moq1jodAB4VL0RXSOmtwLUYoAsikZhwd+hGQe5Vtw2dbWfpFd60poxojMU0Tsh9w59mN1QLEcoHz0Dx9w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/remarkablemark"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/html-react-parser"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "html-dom-parser": "5.1.8",
+        "react-property": "2.0.2",
+        "style-to-js": "1.1.21"
+      },
+      "peerDependencies": {
+        "@types/react": "0.14 || 15 || 16 || 17 || 18 || 19",
+        "react": "0.14 || 15 || 16 || 17 || 18 || 19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -4801,6 +4928,25 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
       }
     },
     "node_modules/ignore": {
@@ -6439,6 +6585,12 @@
         "@types/react": ">=18",
         "react": ">=18"
       }
+    },
+    "node_modules/react-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
+      "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==",
+      "license": "MIT"
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.1",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "date-fns": "^3.6.0",
     "dompurify": "^3.3.1",
     "embla-carousel-react": "^8.3.0",
+    "html-react-parser": "^5.2.17",
     "input-otp": "^1.2.4",
     "lucide-react": "^0.462.0",
     "next-themes": "^0.3.0",

--- a/src/components/case-study/AuthorByline.tsx
+++ b/src/components/case-study/AuthorByline.tsx
@@ -1,0 +1,53 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { LastVerifiedBadge } from "./LastVerifiedBadge";
+
+interface AuthorBylineProps {
+  researchedBy: string | null | undefined;
+  avatarUrl: string | null | undefined;
+  lastVerifiedAt: string | null | undefined;
+  className?: string;
+}
+
+export const AuthorByline = ({
+  researchedBy,
+  avatarUrl,
+  lastVerifiedAt,
+  className = "",
+}: AuthorBylineProps) => {
+  if (!researchedBy && !lastVerifiedAt) return null;
+
+  const initials = researchedBy
+    ? researchedBy
+        .split(/\s+/)
+        .map((n) => n[0])
+        .filter(Boolean)
+        .slice(0, 2)
+        .join("")
+        .toUpperCase()
+    : "?";
+
+  return (
+    <div className={`flex items-center gap-2 ${className}`}>
+      {researchedBy && (
+        <>
+          <Avatar className="h-6 w-6 border">
+            {avatarUrl && <AvatarImage src={avatarUrl} alt={researchedBy} />}
+            <AvatarFallback className="text-[10px] font-medium">
+              {initials}
+            </AvatarFallback>
+          </Avatar>
+          <span className="text-xs text-muted-foreground">
+            Researched by{" "}
+            <span className="font-medium text-foreground">{researchedBy}</span>
+          </span>
+        </>
+      )}
+      {lastVerifiedAt && (
+        <>
+          {researchedBy && <span className="text-muted-foreground">·</span>}
+          <LastVerifiedBadge lastVerifiedAt={lastVerifiedAt} />
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/components/case-study/HeroImage.tsx
+++ b/src/components/case-study/HeroImage.tsx
@@ -1,0 +1,33 @@
+interface HeroImageProps {
+  url: string | null | undefined;
+  alt: string | null | undefined;
+  credit?: string | null | undefined;
+  className?: string;
+}
+
+export const HeroImage = ({
+  url,
+  alt,
+  credit,
+  className = "",
+}: HeroImageProps) => {
+  if (!url) return null;
+
+  return (
+    <figure className={`relative w-full overflow-hidden rounded-xl mb-8 ${className}`}>
+      <div className="aspect-[16/7] bg-muted">
+        <img
+          src={url}
+          alt={alt ?? ""}
+          loading="eager"
+          className="w-full h-full object-cover"
+        />
+      </div>
+      {credit && (
+        <figcaption className="absolute bottom-0 right-0 bg-foreground/70 text-background text-[11px] px-2 py-1 rounded-tl-md">
+          {credit}
+        </figcaption>
+      )}
+    </figure>
+  );
+};

--- a/src/components/case-study/InlineCitation.tsx
+++ b/src/components/case-study/InlineCitation.tsx
@@ -1,0 +1,18 @@
+interface InlineCitationProps {
+  number: number;
+  label?: string;
+}
+
+export const InlineCitation = ({ number, label }: InlineCitationProps) => {
+  return (
+    <sup className="ml-0.5">
+      <a
+        href={`#cite-${number}`}
+        className="text-primary hover:underline font-medium"
+        aria-label={label ? `Source ${number}: ${label}` : `Source ${number}`}
+      >
+        [{number}]
+      </a>
+    </sup>
+  );
+};

--- a/src/components/case-study/LastVerifiedBadge.tsx
+++ b/src/components/case-study/LastVerifiedBadge.tsx
@@ -1,0 +1,30 @@
+import { ShieldCheck } from "lucide-react";
+
+interface LastVerifiedBadgeProps {
+  lastVerifiedAt: string | null | undefined;
+  className?: string;
+}
+
+export const LastVerifiedBadge = ({
+  lastVerifiedAt,
+  className = "",
+}: LastVerifiedBadgeProps) => {
+  if (!lastVerifiedAt) return null;
+  const date = new Date(lastVerifiedAt);
+  if (Number.isNaN(date.getTime())) return null;
+
+  const formatted = date.toLocaleDateString("en-AU", {
+    month: "short",
+    year: "numeric",
+  });
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 text-xs text-muted-foreground ${className}`}
+      title={`Last verified ${date.toLocaleDateString("en-AU", { day: "2-digit", month: "long", year: "numeric" })}`}
+    >
+      <ShieldCheck className="h-3.5 w-3.5 text-primary" aria-hidden />
+      Verified {formatted}
+    </span>
+  );
+};

--- a/src/components/case-study/PullQuote.tsx
+++ b/src/components/case-study/PullQuote.tsx
@@ -1,0 +1,42 @@
+import { Quote } from "lucide-react";
+import type { CaseStudyQuote } from "@/lib/case-study/types";
+
+interface PullQuoteProps {
+  quote: CaseStudyQuote;
+  className?: string;
+}
+
+export const PullQuote = ({ quote, className = "" }: PullQuoteProps) => {
+  if (!quote?.quote?.trim()) return null;
+
+  return (
+    <figure
+      className={`my-6 border-l-4 border-primary bg-primary/5 rounded-r-lg p-5 not-prose ${className}`}
+    >
+      <Quote className="h-5 w-5 text-primary mb-2 opacity-70" aria-hidden />
+      <blockquote className="text-base sm:text-lg italic text-foreground leading-relaxed mb-3">
+        “{quote.quote}”
+      </blockquote>
+      <figcaption className="text-sm text-muted-foreground">
+        <span className="font-semibold text-foreground not-italic">
+          {quote.attributed_to}
+        </span>
+        {quote.role && <span className="not-italic"> · {quote.role}</span>}
+        {quote.source_url && (
+          <>
+            {" "}
+            ·{" "}
+            <a
+              href={quote.source_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline not-italic"
+            >
+              {quote.source_label || "source"}
+            </a>
+          </>
+        )}
+      </figcaption>
+    </figure>
+  );
+};

--- a/src/components/case-study/QuickFactsStrip.tsx
+++ b/src/components/case-study/QuickFactsStrip.tsx
@@ -1,0 +1,54 @@
+import * as Icons from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type { QuickFact } from "@/lib/case-study/types";
+
+interface QuickFactsStripProps {
+  facts: QuickFact[] | null | undefined;
+  className?: string;
+}
+
+function resolveIcon(name: string | undefined): LucideIcon | null {
+  if (!name) return null;
+  const lookup = Icons as unknown as Record<string, LucideIcon>;
+  return lookup[name] ?? null;
+}
+
+export const QuickFactsStrip = ({
+  facts,
+  className = "",
+}: QuickFactsStripProps) => {
+  const cleaned = (facts ?? []).filter((f) => f && f.label && f.value);
+  if (cleaned.length === 0) return null;
+
+  return (
+    <div
+      aria-label="Quick facts"
+      className={`grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-${Math.min(
+        cleaned.length,
+        6,
+      )} gap-3 mb-8 ${className}`}
+    >
+      {cleaned.map((fact, i) => {
+        const Icon = resolveIcon(fact.icon);
+        return (
+          <div
+            key={`${fact.label}-${i}`}
+            className="rounded-lg border border-border bg-card p-3 flex items-start gap-2.5"
+          >
+            {Icon && (
+              <Icon className="h-4 w-4 text-primary mt-0.5 flex-shrink-0" aria-hidden />
+            )}
+            <div className="min-w-0">
+              <div className="text-[11px] uppercase tracking-wide text-muted-foreground truncate">
+                {fact.label}
+              </div>
+              <div className="text-sm sm:text-base font-semibold text-foreground leading-tight">
+                {fact.value}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/components/case-study/ReadingProgressBar.tsx
+++ b/src/components/case-study/ReadingProgressBar.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+
+export const ReadingProgressBar = () => {
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    let raf = 0;
+    const update = () => {
+      const scrollTop = window.scrollY;
+      const docHeight =
+        document.documentElement.scrollHeight - window.innerHeight;
+      const next = docHeight > 0 ? Math.min(scrollTop / docHeight, 1) : 0;
+      setProgress(next);
+      raf = 0;
+    };
+    const onScroll = () => {
+      if (raf) return;
+      raf = requestAnimationFrame(update);
+    };
+    update();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onScroll);
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onScroll);
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, []);
+
+  return (
+    <div className="fixed top-0 left-0 right-0 z-50 h-0.5 bg-transparent print:hidden">
+      <div
+        className="h-full bg-primary transition-[width] duration-150 ease-out"
+        style={{ width: `${progress * 100}%` }}
+      />
+    </div>
+  );
+};

--- a/src/components/case-study/SourcesSection.tsx
+++ b/src/components/case-study/SourcesSection.tsx
@@ -1,0 +1,69 @@
+import { ExternalLink } from "lucide-react";
+import type { CaseStudySource } from "@/lib/case-study/types";
+
+interface SourcesSectionProps {
+  sources: CaseStudySource[] | null | undefined;
+  className?: string;
+}
+
+export const SourcesSection = ({
+  sources,
+  className = "",
+}: SourcesSectionProps) => {
+  if (!sources || sources.length === 0) return null;
+
+  const sorted = [...sources].sort((a, b) => {
+    const an = a.citation_number ?? Number.MAX_SAFE_INTEGER;
+    const bn = b.citation_number ?? Number.MAX_SAFE_INTEGER;
+    return an - bn;
+  });
+
+  return (
+    <section
+      id="sources"
+      aria-labelledby="sources-heading"
+      className={`mt-12 pt-6 border-t border-border ${className}`}
+    >
+      <h2
+        id="sources-heading"
+        className="text-lg font-semibold text-foreground mb-4"
+      >
+        Sources
+      </h2>
+      <ol className="space-y-2 text-sm">
+        {sorted.map((src, i) => {
+          const n = src.citation_number ?? i + 1;
+          return (
+            <li
+              key={src.id}
+              id={`cite-${n}`}
+              className="grid grid-cols-[auto_1fr] gap-2 items-baseline scroll-mt-24"
+            >
+              <span className="text-muted-foreground tabular-nums">[{n}]</span>
+              <span className="min-w-0">
+                <a
+                  href={src.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary hover:underline break-words inline-flex items-baseline gap-1"
+                >
+                  {src.label}
+                  <ExternalLink className="h-3 w-3 self-center flex-shrink-0" aria-hidden />
+                </a>
+                {src.accessed_at && (
+                  <span className="text-muted-foreground ml-2">
+                    · accessed {new Date(src.accessed_at).toLocaleDateString("en-AU", {
+                      day: "2-digit",
+                      month: "short",
+                      year: "numeric",
+                    })}
+                  </span>
+                )}
+              </span>
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  );
+};

--- a/src/components/case-study/TLDRBlock.tsx
+++ b/src/components/case-study/TLDRBlock.tsx
@@ -1,0 +1,32 @@
+import { Sparkles } from "lucide-react";
+
+interface TLDRBlockProps {
+  bullets: string[] | null | undefined;
+  className?: string;
+}
+
+export const TLDRBlock = ({ bullets, className = "" }: TLDRBlockProps) => {
+  const cleaned = (bullets ?? []).map((b) => b.trim()).filter(Boolean);
+  if (cleaned.length === 0) return null;
+
+  return (
+    <aside
+      aria-label="TL;DR"
+      className={`rounded-xl border border-primary/20 bg-primary/5 p-5 mb-8 ${className}`}
+    >
+      <div className="flex items-center gap-2 mb-3">
+        <Sparkles className="h-4 w-4 text-primary" aria-hidden />
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-primary m-0">
+          TL;DR
+        </h2>
+      </div>
+      <ul className="space-y-2 list-disc list-outside pl-5 marker:text-primary text-sm sm:text-base text-foreground">
+        {cleaned.map((bullet, i) => (
+          <li key={i} className="leading-relaxed">
+            {bullet}
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+};

--- a/src/components/detail/ContentBodyRenderer.tsx
+++ b/src/components/detail/ContentBodyRenderer.tsx
@@ -1,4 +1,11 @@
 import DOMPurify from "dompurify";
+import { applyEnhancements } from "@/lib/case-study/applyEnhancements";
+import { PullQuote } from "@/components/case-study/PullQuote";
+import type {
+  CaseStudyQuote,
+  CaseStudySource,
+  LinkerEntry,
+} from "@/lib/case-study/types";
 
 interface ContentBody {
   id: string;
@@ -19,16 +26,59 @@ interface ContentBodyRendererProps {
   groupedContent: GroupedSection[];
   /** Style variant for question display */
   questionStyle?: "box" | "heading";
+  /** When defined, enables case-study readability enhancements. */
+  linkerCorpus?: LinkerEntry[];
+  sources?: CaseStudySource[];
+  quotes?: CaseStudyQuote[];
+  subjectName?: string;
+  subjectAliases?: string[];
+  googleFallback?: boolean;
 }
 
 export const ContentBodyRenderer = ({
   generalContent,
   groupedContent,
   questionStyle = "heading",
+  linkerCorpus,
+  sources,
+  quotes,
+  subjectName,
+  subjectAliases,
+  googleFallback,
 }: ContentBodyRendererProps) => {
+  const enhanced = linkerCorpus !== undefined;
+  // Shared "first match per page wins" set across all bodies in this render.
+  const linkedNames = new Set<string>();
+
+  const renderBody = (text: string) => {
+    if (enhanced) {
+      return applyEnhancements(text, {
+        corpus: linkerCorpus ?? [],
+        linkedNames,
+        sources,
+        subjectName,
+        subjectAliases,
+        googleFallback,
+      });
+    }
+    return (
+      <span
+        dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(text) }}
+      />
+    );
+  };
+
+  // Group quotes by section_id for injection after each section's bodies.
+  const quotesBySection = new Map<string, CaseStudyQuote[]>();
+  (quotes ?? []).forEach((q) => {
+    const key = q.section_id ?? "__general__";
+    const list = quotesBySection.get(key) ?? [];
+    list.push(q);
+    quotesBySection.set(key, list);
+  });
+
   return (
     <>
-      {/* General Content (not in sections) */}
       {generalContent.length > 0 && (
         <div className="prose prose-lg max-w-none mb-12">
           {generalContent.map((body) => (
@@ -46,46 +96,52 @@ export const ContentBodyRenderer = ({
                   </h3>
                 )
               )}
-              <div
-                className="text-muted-foreground leading-relaxed"
-                dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(body.body_text) }}
-              />
+              <div className="text-muted-foreground leading-relaxed">
+                {renderBody(body.body_text)}
+              </div>
             </div>
           ))}
         </div>
       )}
 
-      {/* Sectioned Content */}
       <div className="prose prose-lg max-w-none">
-        {groupedContent.map((section) => (
-          <div key={section.id} id={section.slug} className="mb-14 scroll-mt-8">
-            <h2 className="text-2xl font-bold text-foreground mb-6 pb-3 border-b border-border">
-              {section.title}
-            </h2>
+        {groupedContent.map((section) => {
+          const sectionQuotes = quotesBySection.get(section.id) ?? [];
+          return (
+            <div key={section.id} id={section.slug} className="mb-14 scroll-mt-8">
+              <h2 className="text-2xl font-bold text-foreground mb-6 pb-3 border-b border-border">
+                {section.title}
+              </h2>
 
-            {section.bodies.map((body) => (
-              <div key={body.id} className="mb-6">
-                {body.question && (
-                  questionStyle === "box" ? (
-                    <div className="bg-muted/50 border-l-4 border-primary rounded-r-lg p-4 mb-4 not-prose">
-                      <h3 className="text-lg font-semibold text-foreground m-0">
+              {section.bodies.map((body) => (
+                <div key={body.id} className="mb-6">
+                  {body.question && (
+                    questionStyle === "box" ? (
+                      <div className="bg-muted/50 border-l-4 border-primary rounded-r-lg p-4 mb-4 not-prose">
+                        <h3 className="text-lg font-semibold text-foreground m-0">
+                          {body.question}
+                        </h3>
+                      </div>
+                    ) : (
+                      <h3 className="text-xl font-semibold text-foreground mt-6 mb-3">
                         {body.question}
                       </h3>
-                    </div>
-                  ) : (
-                    <h3 className="text-xl font-semibold text-foreground mt-6 mb-3">
-                      {body.question}
-                    </h3>
-                  )
-                )}
-                <div
-                  className="text-muted-foreground leading-relaxed"
-                  dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(body.body_text) }}
-                />
-              </div>
-            ))}
-          </div>
-        ))}
+                    )
+                  )}
+                  <div className="text-muted-foreground leading-relaxed">
+                    {renderBody(body.body_text)}
+                  </div>
+                </div>
+              ))}
+
+              {sectionQuotes
+                .sort((a, b) => a.display_order - b.display_order)
+                .map((q) => (
+                  <PullQuote key={q.id} quote={q} />
+                ))}
+            </div>
+          );
+        })}
       </div>
     </>
   );

--- a/src/hooks/useAutolinkCorpus.ts
+++ b/src/hooks/useAutolinkCorpus.ts
@@ -1,0 +1,70 @@
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import type { LinkerEntry } from "@/lib/case-study/types";
+
+/**
+ * Build the autolinker corpus from the database.
+ *
+ * Sources:
+ *  - service_providers: company name → /service-providers/<slug>
+ *  - content_items (case_study): subject company name → /case-studies/<slug>
+ *
+ * Skipped (no detail route exists):
+ *  - community_members
+ *  - content_founders
+ *
+ * Names not in this corpus fall through to the Google fallback in the
+ * autolinker (when enabled).
+ */
+export const useAutolinkCorpus = () => {
+  return useQuery({
+    queryKey: ["autolink-corpus"],
+    staleTime: 60 * 60 * 1000,
+    queryFn: async (): Promise<LinkerEntry[]> => {
+      const [providers, caseStudies] = await Promise.all([
+        supabase
+          .from("service_providers")
+          .select("name, slug")
+          .order("name"),
+        supabase
+          .from("content_items")
+          .select("slug, content_company_profiles(company_name)")
+          .eq("content_type", "case_study")
+          .eq("status", "published"),
+      ]);
+
+      const entries: LinkerEntry[] = [];
+
+      (providers.data ?? []).forEach((p) => {
+        if (p?.name && p.slug) {
+          entries.push({
+            name: p.name,
+            href: `/service-providers/${p.slug}`,
+            type: "company",
+          });
+        }
+      });
+
+      (caseStudies.data ?? []).forEach((row: any) => {
+        const companyName = row?.content_company_profiles?.[0]?.company_name;
+        if (companyName && row.slug) {
+          entries.push({
+            name: companyName,
+            href: `/case-studies/${row.slug}`,
+            type: "company",
+          });
+        }
+      });
+
+      // Dedupe by lowercased name (last write wins; service_providers preferred
+      // since they're inserted first).
+      const seen = new Set<string>();
+      return entries.filter((e) => {
+        const key = e.name.toLowerCase();
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      });
+    },
+  });
+};

--- a/src/hooks/useCaseStudies.ts
+++ b/src/hooks/useCaseStudies.ts
@@ -74,10 +74,28 @@ export const useCaseStudy = (slug: string) => {
 
       if (bodiesError) throw bodiesError;
 
+      // case_study_sources and case_study_quotes are not in the auto-generated
+      // Supabase types yet (added in migration 20260504120100). Cast as any per
+      // the project pattern documented in CLAUDE.md §2.
+      const [{ data: sources }, { data: quotes }] = await Promise.all([
+        (supabase as any)
+          .from('case_study_sources')
+          .select('*')
+          .eq('case_study_id', contentItem.id)
+          .order('citation_number', { ascending: true, nullsFirst: false }),
+        (supabase as any)
+          .from('case_study_quotes')
+          .select('*')
+          .eq('case_study_id', contentItem.id)
+          .order('display_order', { ascending: true }),
+      ]);
+
       return {
         ...contentItem,
         content_sections: sections || [],
-        content_bodies: bodies || []
+        content_bodies: bodies || [],
+        case_study_sources: sources || [],
+        case_study_quotes: quotes || []
       };
     },
     enabled: !!slug

--- a/src/lib/case-study/applyEnhancements.tsx
+++ b/src/lib/case-study/applyEnhancements.tsx
@@ -1,0 +1,181 @@
+import type { ReactNode } from "react";
+import DOMPurify from "dompurify";
+import parse, { Element, Text } from "html-react-parser";
+import type { DOMNode, HTMLReactParserOptions } from "html-react-parser";
+
+import { autolinkText, type LinkToken } from "./autolink";
+import { decodeApostrophes } from "./decodeApostrophes";
+import { splitParagraph } from "./splitParagraphs";
+import type { CaseStudySource, LinkerEntry } from "./types";
+
+import { InlineCitation } from "@/components/case-study/InlineCitation";
+
+interface ApplyEnhancementsOptions {
+  corpus: LinkerEntry[];
+  linkedNames: Set<string>;
+  sources?: CaseStudySource[];
+  subjectName?: string;
+  subjectAliases?: string[];
+  googleFallback?: boolean;
+  maxWords?: number;
+}
+
+const CITATION_REGEX = /\[(\d+)\]/g;
+
+interface SourceLookup {
+  byNumber: Map<number, CaseStudySource>;
+}
+
+function buildSourceLookup(sources: CaseStudySource[] | undefined): SourceLookup {
+  const byNumber = new Map<number, CaseStudySource>();
+  (sources ?? []).forEach((s, i) => {
+    const n = s.citation_number ?? i + 1;
+    byNumber.set(n, s);
+  });
+  return { byNumber };
+}
+
+function tokensToReactNodes(tokens: LinkToken[], keyPrefix: string): ReactNode[] {
+  return tokens.map((tok, i) => {
+    if (tok.kind === "text") return tok.text;
+    return (
+      <a
+        key={`${keyPrefix}-${i}`}
+        href={tok.href}
+        rel={tok.nofollow ? "nofollow noopener noreferrer" : undefined}
+        target={tok.nofollow ? "_blank" : undefined}
+        className="text-primary underline-offset-2 hover:underline"
+      >
+        {tok.text}
+      </a>
+    );
+  });
+}
+
+function transformText(
+  text: string,
+  opts: ApplyEnhancementsOptions,
+  lookup: SourceLookup,
+  keyPrefix: string,
+): ReactNode[] {
+  if (!text) return [];
+
+  const segments: { kind: "text" | "cite"; value: string; n?: number }[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  const re = new RegExp(CITATION_REGEX.source, "g");
+
+  while ((match = re.exec(text)) !== null) {
+    const n = Number(match[1]);
+    if (match.index > lastIndex) {
+      segments.push({ kind: "text", value: text.slice(lastIndex, match.index) });
+    }
+    segments.push({ kind: "cite", value: match[0], n });
+    lastIndex = match.index + match[0].length;
+  }
+  if (lastIndex < text.length) {
+    segments.push({ kind: "text", value: text.slice(lastIndex) });
+  }
+
+  const out: ReactNode[] = [];
+  segments.forEach((seg, i) => {
+    const segKey = `${keyPrefix}-s${i}`;
+    if (seg.kind === "cite" && seg.n !== undefined) {
+      const src = lookup.byNumber.get(seg.n);
+      if (src) {
+        out.push(<InlineCitation key={segKey} number={seg.n} label={src.label} />);
+        return;
+      }
+      out.push(seg.value);
+      return;
+    }
+    const tokens = autolinkText(seg.value, {
+      corpus: opts.corpus,
+      linkedNames: opts.linkedNames,
+      subjectName: opts.subjectName,
+      subjectAliases: opts.subjectAliases,
+      googleFallback: opts.googleFallback,
+    });
+    out.push(...tokensToReactNodes(tokens, segKey));
+  });
+
+  return out;
+}
+
+function getElementText(el: Element): string {
+  let txt = "";
+  for (const child of el.children as DOMNode[]) {
+    if (child instanceof Text) {
+      txt += child.data;
+    } else if (child instanceof Element) {
+      txt += getElementText(child);
+    }
+  }
+  return txt;
+}
+
+function hasInlineTags(el: Element): boolean {
+  return el.children.some((c) => c instanceof Element);
+}
+
+function countWords(text: string): number {
+  return text.trim().split(/\s+/).filter(Boolean).length;
+}
+
+/**
+ * Render an HTML body with all readability enhancements applied.
+ *
+ * - Sanitises via DOMPurify
+ * - Decodes doubled apostrophes (defence-in-depth for the Go1 bug)
+ * - Splits long plain-text <p>s on sentence boundaries (>80 words default)
+ *   NOTE: paragraphs containing inline tags (<strong>/<em>/<a>) are left as
+ *   one paragraph to preserve formatting — this is a known Tier A limitation.
+ * - Replaces [N] citation markers with <InlineCitation>
+ * - Autolinks corpus matches and (optionally) Google fallbacks in text nodes
+ */
+export function applyEnhancements(
+  rawHtml: string,
+  opts: ApplyEnhancementsOptions,
+): ReactNode {
+  const safe = DOMPurify.sanitize(decodeApostrophes(rawHtml));
+  const lookup = buildSourceLookup(opts.sources);
+  const maxWords = opts.maxWords ?? 80;
+
+  const parserOptions: HTMLReactParserOptions = {
+    replace: (node) => {
+      // Split long plain-text paragraphs into multiple <p>s.
+      if (node instanceof Element && node.name === "p") {
+        const fullText = getElementText(node);
+        if (!hasInlineTags(node) && countWords(fullText) > maxWords) {
+          const paragraphs = splitParagraph(fullText, maxWords);
+          return (
+            <>
+              {paragraphs.map((p, i) => (
+                <p key={`split-${i}`} className="mb-4 last:mb-0">
+                  {transformText(p, opts, lookup, `split-${i}`)}
+                </p>
+              ))}
+            </>
+          );
+        }
+      }
+
+      // Transform text nodes: apply autolink + citation replacement.
+      if (node instanceof Text) {
+        const transformed = transformText(
+          String(node.data ?? ""),
+          opts,
+          lookup,
+          "t",
+        );
+        return <>{transformed}</>;
+      }
+
+      // Other element types: let the parser walk into children with the
+      // same callback (returns undefined => default behaviour).
+      return undefined;
+    },
+  };
+
+  return parse(safe, parserOptions);
+}

--- a/src/lib/case-study/autolink.ts
+++ b/src/lib/case-study/autolink.ts
@@ -1,0 +1,162 @@
+import type { LinkerEntry } from "./types";
+
+/**
+ * Apply autolinks to a text string.
+ *
+ * Rules (Phase 2 plan, section 2.3):
+ *   1. First match per page wins (use `linkedNames` set across calls).
+ *   2. Word-boundary match on the entry name.
+ *   3. Case-sensitive (avoids "Pitt" matching "Brad Pitt", etc.).
+ *   4. Skip `subjectName` so a case study doesn't link itself.
+ *   5. Google fallback for unknown names if `googleFallback: true`.
+ *
+ * Returns an array of plain text and link tokens. Caller (applyEnhancements)
+ * maps tokens to React nodes.
+ */
+
+export type LinkToken =
+  | { kind: "text"; text: string }
+  | { kind: "link"; text: string; href: string; nofollow: boolean; type: LinkerEntry["type"] };
+
+export interface AutolinkOptions {
+  corpus: LinkerEntry[];
+  linkedNames: Set<string>;
+  subjectName?: string;
+  subjectAliases?: string[];
+  googleFallback?: boolean;
+  /**
+   * Heuristic regex for spotting capitalised proper-noun candidates the corpus
+   * doesn't cover. Used only when `googleFallback: true`. Tuned to match
+   * "Capitalised Words" (1–4 tokens) excluding the start of a sentence.
+   */
+  fallbackCandidateRegex?: RegExp;
+}
+
+const DEFAULT_FALLBACK_REGEX =
+  /(?<![\w])((?:[A-Z][a-z]+(?:\s+[A-Z][a-z]+){1,3}))(?![\w])/g;
+
+function escapeRegex(raw: string): string {
+  return raw.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function isSubject(name: string, opts: AutolinkOptions): boolean {
+  if (opts.subjectName && name === opts.subjectName) return true;
+  if (opts.subjectAliases?.includes(name)) return true;
+  return false;
+}
+
+/**
+ * Sort corpus by name length descending so multi-word names ("Amazon Web
+ * Services") match before single tokens ("Amazon").
+ */
+export function sortCorpus(corpus: LinkerEntry[]): LinkerEntry[] {
+  return [...corpus].sort((a, b) => b.name.length - a.name.length);
+}
+
+/**
+ * Tokenise a single text string against the corpus.
+ *
+ * Strategy: walk all corpus entries (longest first), and for each, try to find
+ * its first un-tokenised match. Replace that span with a link token. Repeat
+ * for the rest of the corpus. Then optionally add Google-fallback links to
+ * remaining proper-noun candidates.
+ */
+export function autolinkText(text: string, opts: AutolinkOptions): LinkToken[] {
+  if (!text) return [{ kind: "text", text }];
+  let tokens: LinkToken[] = [{ kind: "text", text }];
+
+  const sorted = sortCorpus(opts.corpus);
+
+  for (const entry of sorted) {
+    if (opts.linkedNames.has(entry.name.toLowerCase())) continue;
+    if (isSubject(entry.name, opts)) continue;
+
+    const re = new RegExp(`(?<![\\w])${escapeRegex(entry.name)}(?![\\w])`);
+    const next: LinkToken[] = [];
+    let matched = false;
+
+    for (const tok of tokens) {
+      if (matched || tok.kind !== "text") {
+        next.push(tok);
+        continue;
+      }
+      const m = tok.text.match(re);
+      if (!m || m.index === undefined) {
+        next.push(tok);
+        continue;
+      }
+      const before = tok.text.slice(0, m.index);
+      const matchText = tok.text.slice(m.index, m.index + m[0].length);
+      const after = tok.text.slice(m.index + m[0].length);
+      if (before) next.push({ kind: "text", text: before });
+      next.push({
+        kind: "link",
+        text: matchText,
+        href: entry.href,
+        nofollow: !!entry.fallback,
+        type: entry.type,
+      });
+      if (after) next.push({ kind: "text", text: after });
+      opts.linkedNames.add(entry.name.toLowerCase());
+      matched = true;
+    }
+    tokens = next;
+  }
+
+  if (opts.googleFallback) {
+    tokens = addGoogleFallbacks(tokens, opts);
+  }
+
+  return tokens;
+}
+
+function addGoogleFallbacks(
+  tokens: LinkToken[],
+  opts: AutolinkOptions,
+): LinkToken[] {
+  const re = new RegExp(
+    (opts.fallbackCandidateRegex || DEFAULT_FALLBACK_REGEX).source,
+    "g",
+  );
+  const out: LinkToken[] = [];
+
+  for (const tok of tokens) {
+    if (tok.kind !== "text") {
+      out.push(tok);
+      continue;
+    }
+    let lastIndex = 0;
+    let m: RegExpExecArray | null;
+    re.lastIndex = 0;
+
+    while ((m = re.exec(tok.text)) !== null) {
+      const candidate = m[1];
+      const key = candidate.toLowerCase();
+
+      if (
+        opts.linkedNames.has(key) ||
+        isSubject(candidate, opts) ||
+        candidate.split(/\s+/).length < 2
+      ) {
+        continue;
+      }
+
+      const before = tok.text.slice(lastIndex, m.index);
+      if (before) out.push({ kind: "text", text: before });
+
+      out.push({
+        kind: "link",
+        text: candidate,
+        href: `https://www.google.com/search?q=${encodeURIComponent(candidate)}`,
+        nofollow: true,
+        type: "person",
+      });
+      opts.linkedNames.add(key);
+      lastIndex = m.index + m[0].length;
+    }
+    const tail = tok.text.slice(lastIndex);
+    if (tail) out.push({ kind: "text", text: tail });
+  }
+
+  return out;
+}

--- a/src/lib/case-study/decodeApostrophes.ts
+++ b/src/lib/case-study/decodeApostrophes.ts
@@ -1,0 +1,14 @@
+/**
+ * Render-time fallback for the doubled-apostrophe encoding bug found in Go1
+ * case study bodies during the Phase 1 audit.
+ *
+ * Migration 20260504120200_fix_go1_apostrophe_encoding.sql is the primary fix.
+ * This utility is defence-in-depth: if a future ingest path regresses the bug,
+ * rendering still looks right.
+ *
+ * @deprecated Tech debt — remove once we're confident no ingest path regresses.
+ */
+export function decodeApostrophes(html: string): string {
+  if (!html) return html;
+  return html.replace(/''/g, "'");
+}

--- a/src/lib/case-study/splitParagraphs.ts
+++ b/src/lib/case-study/splitParagraphs.ts
@@ -1,0 +1,122 @@
+/**
+ * Sentence-aware paragraph splitter.
+ *
+ * Splits prose paragraphs that exceed `maxWords` on sentence boundaries
+ * (`.`, `?`, `!` followed by a space + capital letter), respecting a safelist
+ * of common abbreviations so we don't break "Mr. Smith" or "U.S. market".
+ *
+ * Operates on the *text* inside an HTML paragraph, not on raw HTML — the
+ * caller (applyEnhancements) is responsible for invoking this on text content
+ * extracted from a parsed DOM, then re-emitting `<p>` blocks.
+ */
+
+const ABBREVIATIONS = new Set([
+  "Mr.",
+  "Mrs.",
+  "Ms.",
+  "Dr.",
+  "Prof.",
+  "Sr.",
+  "Jr.",
+  "St.",
+  "Ave.",
+  "Inc.",
+  "Co.",
+  "Ltd.",
+  "Pty.",
+  "Corp.",
+  "vs.",
+  "e.g.",
+  "i.e.",
+  "etc.",
+  "U.S.",
+  "U.K.",
+  "U.S.A.",
+  "No.",
+  "Vol.",
+  "Sgt.",
+  "Capt.",
+  "Lt.",
+  "Gen.",
+]);
+
+const SENTENCE_TERMINATOR = /([.!?])\s+(?=[A-Z"'‘“(])/g;
+
+function isAbbreviation(textBefore: string, terminator: string): boolean {
+  if (terminator !== ".") return false;
+  const lastWordMatch = textBefore.match(/(\S+)$/);
+  if (!lastWordMatch) return false;
+  return ABBREVIATIONS.has(lastWordMatch[1]);
+}
+
+export function splitIntoSentences(text: string): string[] {
+  const sentences: string[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  const re = new RegExp(SENTENCE_TERMINATOR.source, "g");
+
+  while ((match = re.exec(text)) !== null) {
+    const before = text.slice(lastIndex, match.index + 1);
+    if (isAbbreviation(text.slice(lastIndex, match.index), match[1])) {
+      continue;
+    }
+    sentences.push(before.trim());
+    lastIndex = match.index + match[0].length;
+  }
+
+  const tail = text.slice(lastIndex).trim();
+  if (tail) sentences.push(tail);
+  return sentences;
+}
+
+function countWords(text: string): number {
+  const trimmed = text.trim();
+  if (!trimmed) return 0;
+  return trimmed.split(/\s+/).length;
+}
+
+/**
+ * Group sentences into paragraphs, each <= maxWords.
+ *
+ * Greedy: pack sentences into the current paragraph until the next sentence
+ * would push it over the limit; then start a new paragraph. A single sentence
+ * longer than maxWords gets its own paragraph (we don't split mid-sentence).
+ */
+export function groupSentencesIntoParagraphs(
+  sentences: string[],
+  maxWords = 80,
+): string[] {
+  if (sentences.length <= 1) return sentences;
+
+  const paragraphs: string[] = [];
+  let current: string[] = [];
+  let currentWords = 0;
+
+  for (const sentence of sentences) {
+    const w = countWords(sentence);
+    if (current.length === 0) {
+      current.push(sentence);
+      currentWords = w;
+      continue;
+    }
+    if (currentWords + w > maxWords) {
+      paragraphs.push(current.join(" "));
+      current = [sentence];
+      currentWords = w;
+    } else {
+      current.push(sentence);
+      currentWords += w;
+    }
+  }
+  if (current.length) paragraphs.push(current.join(" "));
+  return paragraphs;
+}
+
+/**
+ * Convenience: text in, array of paragraph-text out, each <= maxWords.
+ */
+export function splitParagraph(text: string, maxWords = 80): string[] {
+  if (countWords(text) <= maxWords) return [text];
+  const sentences = splitIntoSentences(text);
+  return groupSentencesIntoParagraphs(sentences, maxWords);
+}

--- a/src/lib/case-study/types.ts
+++ b/src/lib/case-study/types.ts
@@ -1,0 +1,45 @@
+export interface CaseStudySource {
+  id: string;
+  case_study_id: string;
+  section_id: string | null;
+  label: string;
+  url: string;
+  accessed_at: string | null;
+  source_type: string | null;
+  citation_number: number | null;
+}
+
+export interface CaseStudyQuote {
+  id: string;
+  case_study_id: string;
+  section_id: string | null;
+  quote: string;
+  attributed_to: string;
+  role: string | null;
+  source_url: string | null;
+  source_label: string | null;
+  display_order: number;
+}
+
+export interface QuickFact {
+  label: string;
+  value: string;
+  icon?: string;
+}
+
+export interface BodyImage {
+  url: string;
+  alt: string;
+  caption?: string;
+  credit?: string;
+  position_after_section_id?: string;
+}
+
+export type LinkerEntryType = "company" | "person";
+
+export interface LinkerEntry {
+  name: string;
+  href: string;
+  type: LinkerEntryType;
+  fallback?: boolean;
+}

--- a/src/pages/CaseStudyDetail.tsx
+++ b/src/pages/CaseStudyDetail.tsx
@@ -8,11 +8,19 @@ import { useCaseStudy, useRelatedCaseStudies } from "@/hooks/useCaseStudies";
 import { useIncrementViewCount } from "@/hooks/useContent";
 import { useScrollSpy } from "@/hooks/useScrollSpy";
 import { useContentActions } from "@/hooks/useContentActions";
+import { useAutolinkCorpus } from "@/hooks/useAutolinkCorpus";
 import { FreemiumGate } from "@/components/FreemiumGate";
 import { SEOHead } from "@/components/common/SEOHead";
 import { EntityBreadcrumb } from "@/components/common/EntityBreadcrumb";
 import { SectionNav } from "@/components/detail/SectionNav";
 import { ContentBodyRenderer } from "@/components/detail/ContentBodyRenderer";
+import { ReadingProgressBar } from "@/components/case-study/ReadingProgressBar";
+import { HeroImage } from "@/components/case-study/HeroImage";
+import { TLDRBlock } from "@/components/case-study/TLDRBlock";
+import { QuickFactsStrip } from "@/components/case-study/QuickFactsStrip";
+import { AuthorByline } from "@/components/case-study/AuthorByline";
+import { SourcesSection } from "@/components/case-study/SourcesSection";
+import type { CaseStudyQuote, CaseStudySource, QuickFact } from "@/lib/case-study/types";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { toast } from "sonner";
 import { getLogoUrl } from "@/lib/logoUtils";
@@ -52,6 +60,7 @@ const CaseStudyDetail = () => {
   const { slug } = useParams<{ slug: string }>();
 
   const { data: caseStudy, isLoading, error } = useCaseStudy(slug || '');
+  const { data: linkerCorpus = [] } = useAutolinkCorpus();
   const incrementViewCount = useIncrementViewCount();
   const { isSaved, toggleSave, handleShare: handleShareBase, copied } = useContentActions(caseStudy?.id);
 
@@ -136,14 +145,27 @@ const CaseStudyDetail = () => {
   const companyName = companyProfile?.company_name || caseStudy.title;
   const metaDescription = caseStudy.subtitle || caseStudy.meta_description || caseStudy.title;
   const outcome = companyProfile?.outcome;
+
+  const sources: CaseStudySource[] = (caseStudy as any).case_study_sources || [];
+  const quotes: CaseStudyQuote[] = (caseStudy as any).case_study_quotes || [];
+  const heroImageUrl = (caseStudy as any).hero_image_url as string | null | undefined;
+  const heroImageAlt = (caseStudy as any).hero_image_alt as string | null | undefined;
+  const heroImageCredit = (caseStudy as any).hero_image_credit as string | null | undefined;
+  const tldr = (caseStudy as any).tldr as string[] | null | undefined;
+  const quickFacts = (caseStudy as any).quick_facts as QuickFact[] | null | undefined;
+  const lastVerifiedAt = (caseStudy as any).last_verified_at as string | null | undefined;
+  const researchedBy = (caseStudy as any).researched_by as string | null | undefined;
+  const researchedByAvatarUrl = (caseStudy as any).researched_by_avatar_url as string | null | undefined;
+
   return (
     <>
+      <ReadingProgressBar />
       <SEOHead
         title={`How ${companyName} Entered the Australian Market | Market Entry Secrets`}
         description={`${metaDescription.slice(0, 150)}. Learn the entry strategy, challenges, and lessons from ${companyName}'s expansion into Australia.`}
         canonicalPath={`/case-studies/${caseStudy.slug}`}
         ogType="article"
-        ogImage={companyProfile?.company_logo || undefined}
+        ogImage={heroImageUrl || companyProfile?.company_logo || undefined}
         jsonLd={{
           type: "Article",
           data: {
@@ -247,6 +269,9 @@ const CaseStudyDetail = () => {
               contentDescription={caseStudy.subtitle || caseStudy.meta_description}
             >
               <div className="mb-8">
+                {/* Hero image (renders nothing if hero_image_url is null) */}
+                <HeroImage url={heroImageUrl} alt={heroImageAlt} credit={heroImageCredit} />
+
                 {/* Header */}
                 <div className="flex flex-col sm:flex-row items-start gap-4 mb-6">
                   <Avatar className="h-16 w-16 rounded-xl border-2 border-border flex-shrink-0">
@@ -301,6 +326,13 @@ const CaseStudyDetail = () => {
                         {caseStudy.view_count || 0} views
                       </span>
                     </div>
+                    {/* Author byline (renders nothing if researched_by and last_verified_at are null) */}
+                    <AuthorByline
+                      researchedBy={researchedBy}
+                      avatarUrl={researchedByAvatarUrl}
+                      lastVerifiedAt={lastVerifiedAt}
+                      className="mt-2"
+                    />
                   </div>
 
                   {/* Mobile actions */}
@@ -331,6 +363,9 @@ const CaseStudyDetail = () => {
                     {caseStudy.subtitle}
                   </p>
                 )}
+
+                {/* TL;DR (renders nothing if tldr is null/empty) */}
+                <TLDRBlock bullets={tldr} />
 
                 {/* Mobile section nav */}
                 <SectionNav sections={sections} scrollToSection={scrollToSection} variant="mobile" />
@@ -401,11 +436,22 @@ const CaseStudyDetail = () => {
                   </Card>
                 )}
 
+                {/* Quick facts (renders nothing if quick_facts is null/empty) */}
+                <QuickFactsStrip facts={quickFacts} />
+
                 <ContentBodyRenderer
                   generalContent={generalContent}
                   groupedContent={groupedContent}
                   questionStyle="heading"
+                  linkerCorpus={linkerCorpus}
+                  sources={sources}
+                  quotes={quotes}
+                  subjectName={companyName}
+                  googleFallback
                 />
+
+                {/* Sources list (renders nothing if no sources) */}
+                <SourcesSection sources={sources} />
               </div>
 
               {/* Bottom CTA: Report Creator */}

--- a/supabase/migrations/20260504120000_add_case_study_readability_columns.sql
+++ b/supabase/migrations/20260504120000_add_case_study_readability_columns.sql
@@ -1,0 +1,43 @@
+-- =============================================================================
+-- Add readability columns to content_items for the Case Study overhaul (Tier B).
+--
+-- All columns are nullable so the 41 existing case studies and the ~8
+-- non-case-study rows (compliance, best_practice, interview, guide) keep
+-- working unchanged. Components render nothing when the value is null.
+-- =============================================================================
+
+ALTER TABLE public.content_items
+  ADD COLUMN hero_image_url           text,
+  ADD COLUMN hero_image_alt           text,
+  ADD COLUMN hero_image_credit        text,
+  ADD COLUMN body_images              jsonb,
+  ADD COLUMN tldr                     text[],
+  ADD COLUMN quick_facts              jsonb,
+  ADD COLUMN last_verified_at         timestamptz,
+  ADD COLUMN researched_by            text,
+  ADD COLUMN researched_by_avatar_url text,
+  ADD COLUMN style_version            int NOT NULL DEFAULT 1;
+
+COMMENT ON COLUMN public.content_items.body_images IS
+  'Array of {url, alt, caption, credit, position_after_section_id} objects, validated at app layer.';
+COMMENT ON COLUMN public.content_items.quick_facts IS
+  'Array of {label, value, icon} objects, where icon is a Lucide icon name.';
+COMMENT ON COLUMN public.content_items.tldr IS
+  'Array of 3-5 short bullets, max ~12 words each, enforced at app layer.';
+COMMENT ON COLUMN public.content_items.style_version IS
+  'Tracks which house-style/voice version a case study was last edited under.';
+
+-- =============================================================================
+-- Down-migration (manual rollback only — paste into a fresh migration if needed)
+-- =============================================================================
+-- ALTER TABLE public.content_items
+--   DROP COLUMN style_version,
+--   DROP COLUMN researched_by_avatar_url,
+--   DROP COLUMN researched_by,
+--   DROP COLUMN last_verified_at,
+--   DROP COLUMN quick_facts,
+--   DROP COLUMN tldr,
+--   DROP COLUMN body_images,
+--   DROP COLUMN hero_image_credit,
+--   DROP COLUMN hero_image_alt,
+--   DROP COLUMN hero_image_url;

--- a/supabase/migrations/20260504120100_create_case_study_sources_quotes.sql
+++ b/supabase/migrations/20260504120100_create_case_study_sources_quotes.sql
@@ -1,0 +1,94 @@
+-- =============================================================================
+-- Create case_study_sources and case_study_quotes tables (Tier B).
+--
+-- - case_study_sources: numbered citation list rendered at the bottom of each
+--   case study, plus inline [n] markers in body prose.
+-- - case_study_quotes:  pull-quote callouts injected mid-body, anchored to a
+--   section.
+--
+-- RLS pattern mirrors content_items / content_sections / content_bodies:
+--   * `TO public USING (true|filter)` for SELECT.
+--   * No INSERT/UPDATE/DELETE policies — service_role bypasses RLS for backfill.
+--
+-- Trigger pattern mirrors the same tables: handle_updated_at() (already
+-- defined project-wide). The moddatetime extension is not installed.
+-- =============================================================================
+
+CREATE TABLE public.case_study_sources (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  case_study_id   uuid NOT NULL
+    REFERENCES public.content_items(id) ON DELETE CASCADE,
+  section_id      uuid
+    REFERENCES public.content_sections(id) ON DELETE SET NULL,
+  label           text NOT NULL,
+  url             text NOT NULL,
+  accessed_at     date,
+  source_type     text,
+  citation_number int,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT case_study_sources_unique_url
+    UNIQUE (case_study_id, url),
+  CONSTRAINT case_study_sources_source_type_check
+    CHECK (source_type IS NULL OR source_type IN (
+      'news', 'company_blog', 'sec_filing', 'interview', 'linkedin',
+      'podcast', 'press_release', 'government', 'academic', 'other'
+    ))
+);
+
+CREATE INDEX case_study_sources_case_study_idx
+  ON public.case_study_sources(case_study_id);
+
+CREATE INDEX case_study_sources_section_idx
+  ON public.case_study_sources(section_id);
+
+CREATE TABLE public.case_study_quotes (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  case_study_id uuid NOT NULL
+    REFERENCES public.content_items(id) ON DELETE CASCADE,
+  section_id    uuid
+    REFERENCES public.content_sections(id) ON DELETE SET NULL,
+  quote         text NOT NULL,
+  attributed_to text NOT NULL,
+  role          text,
+  source_url    text,
+  source_label  text,
+  display_order int NOT NULL DEFAULT 0,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT case_study_quotes_unique_position
+    UNIQUE (case_study_id, attributed_to, display_order)
+);
+
+CREATE INDEX case_study_quotes_case_study_idx
+  ON public.case_study_quotes(case_study_id);
+
+CREATE INDEX case_study_quotes_section_idx
+  ON public.case_study_quotes(section_id);
+
+-- updated_at triggers (mirrors content_items / content_sections / content_bodies)
+CREATE TRIGGER handle_updated_at
+  BEFORE UPDATE ON public.case_study_sources
+  FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();
+
+CREATE TRIGGER handle_updated_at
+  BEFORE UPDATE ON public.case_study_quotes
+  FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();
+
+-- RLS
+ALTER TABLE public.case_study_sources ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.case_study_quotes  ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Public can view case study sources"
+  ON public.case_study_sources FOR SELECT
+  TO public USING (true);
+
+CREATE POLICY "Public can view case study quotes"
+  ON public.case_study_quotes FOR SELECT
+  TO public USING (true);
+
+-- =============================================================================
+-- Down-migration
+-- =============================================================================
+-- DROP TABLE public.case_study_quotes;
+-- DROP TABLE public.case_study_sources;

--- a/supabase/migrations/20260504120200_fix_go1_apostrophe_encoding.sql
+++ b/supabase/migrations/20260504120200_fix_go1_apostrophe_encoding.sql
@@ -1,0 +1,46 @@
+-- =============================================================================
+-- One-time data fix: scrub doubled apostrophes ('') in Go1 case study bodies.
+--
+-- Phase 1 audit found 11/11 Go1 content_bodies contain literal '' (double
+-- single-quote) where ' should be — almost certainly an ingest path that fed
+-- SQL-escaped strings into a non-SQL code path.
+--
+-- Buildkite (0/16) and Zoom (0/17) are clean, so the fix is targeted to Go1.
+-- The DO block raises if any '' pairs remain after the UPDATE.
+-- =============================================================================
+
+UPDATE public.content_bodies cb
+SET body_text = REPLACE(cb.body_text, '''''', '''')
+FROM public.content_sections cs
+JOIN public.content_items ci ON cs.content_id = ci.id
+WHERE cb.section_id = cs.id
+  AND ci.slug = 'go1-australia-startup'
+  AND cb.body_text LIKE '%''''%';
+
+DO $$
+DECLARE
+  remaining int;
+BEGIN
+  SELECT COUNT(*) INTO remaining
+  FROM public.content_bodies cb
+  JOIN public.content_sections cs ON cb.section_id = cs.id
+  JOIN public.content_items ci ON cs.content_id = ci.id
+  WHERE ci.slug = 'go1-australia-startup'
+    AND cb.body_text LIKE '%''''%';
+
+  IF remaining > 0 THEN
+    RAISE EXCEPTION
+      'Go1 encoding fix incomplete: % bodies still contain doubled apostrophes',
+      remaining;
+  END IF;
+END $$;
+
+-- =============================================================================
+-- Down-migration: NOT REVERSIBLE.
+--
+-- The doubled-apostrophe state was incorrect data. Re-introducing it via
+-- REPLACE(body_text, '''', '''''') would also corrupt any single apostrophes
+-- that were originally correct (the in-prose Coorpacademy/Blinkist phrases),
+-- because the original double-apostrophe positions cannot be recovered.
+-- If a rollback is needed, restore from PITR / backup.
+-- =============================================================================

--- a/supabase/migrations/20260504130000_backfill_buildkite_pilot.sql
+++ b/supabase/migrations/20260504130000_backfill_buildkite_pilot.sql
@@ -1,0 +1,159 @@
+-- =============================================================================
+-- Phase 5.2 Pilot 1 of 3: Buildkite — case study readability backfill
+--
+-- Populates new Tier B fields on content_items + structured rows in
+-- case_study_sources and case_study_quotes for the Buildkite pilot.
+--
+-- Idempotent: re-running this migration produces identical state. Sources and
+-- quotes are deleted-then-reinserted to handle row drift. content_items uses
+-- a single UPDATE.
+--
+-- Source provenance: see .claude/staging/buildkite-australia-startup.md
+-- =============================================================================
+
+DO $$
+DECLARE
+  v_case_study_id           uuid;
+  v_section_entry_strategy  uuid;
+  v_section_success_factors uuid;
+  v_section_key_metrics     uuid;
+BEGIN
+  SELECT id INTO v_case_study_id
+  FROM public.content_items
+  WHERE slug = 'buildkite-australia-startup';
+
+  IF v_case_study_id IS NULL THEN
+    RAISE EXCEPTION 'buildkite-australia-startup case study not found';
+  END IF;
+
+  SELECT id INTO v_section_entry_strategy
+  FROM public.content_sections
+  WHERE content_id = v_case_study_id AND slug = 'entry-strategy';
+
+  SELECT id INTO v_section_success_factors
+  FROM public.content_sections
+  WHERE content_id = v_case_study_id AND slug = 'success-factors';
+
+  SELECT id INTO v_section_key_metrics
+  FROM public.content_sections
+  WHERE content_id = v_case_study_id AND slug = 'key-metrics';
+
+  -- ---------------------------------------------------------------------------
+  -- 1. Update content_items with hero, TL;DR, quick-facts, byline metadata
+  -- ---------------------------------------------------------------------------
+  UPDATE public.content_items
+  SET
+    hero_image_url    = 'https://www.businessdailymedia.com/images/0c/Keith_Pitt_founder_and_CEO_Buildkite.jpeg',
+    hero_image_alt    = 'Keith Pitt, founder of Buildkite',
+    hero_image_credit = 'Business Daily Media',
+    tldr = ARRAY[
+      'Bootstrapped seven years to profitability before raising venture capital',
+      '$28M AUD Series A in 2020 led by OpenView at $200M+ valuation',
+      'Hybrid CI/CD architecture keeps customer code on customer infrastructure',
+      'Trusted by Shopify, Uber, Slack, Canva, OpenAI, and Anthropic',
+      'Founded in Melbourne 2013 by Keith Pitt and Tim Lucas'
+    ],
+    quick_facts = '[
+      {"label": "Founded",      "value": "2013",                          "icon": "Calendar"},
+      {"label": "HQ",           "value": "Melbourne, Australia",          "icon": "MapPin"},
+      {"label": "Series A",     "value": "$28M AUD (Aug 2020)",           "icon": "TrendingUp"},
+      {"label": "Valuation",    "value": "$200M+ AUD",                    "icon": "DollarSign"},
+      {"label": "Users",        "value": "60,000+",                       "icon": "Users"},
+      {"label": "Investors",    "value": "OpenView, General Catalyst",    "icon": "Briefcase"}
+    ]'::jsonb,
+    last_verified_at = '2026-05-04T00:00:00Z'::timestamptz,
+    researched_by    = 'Stephen Browne',
+    style_version    = 2
+  WHERE id = v_case_study_id;
+
+  -- ---------------------------------------------------------------------------
+  -- 2. Replace sources (idempotent via DELETE + INSERT)
+  -- ---------------------------------------------------------------------------
+  DELETE FROM public.case_study_sources WHERE case_study_id = v_case_study_id;
+
+  INSERT INTO public.case_study_sources
+    (case_study_id, label, url, accessed_at, source_type, citation_number)
+  VALUES
+    (v_case_study_id,
+     'TechCrunch — Melbourne-based CI/CD platform Buildkite gets $28 million AUD Series A led by OpenView',
+     'https://techcrunch.com/2020/08/18/melbourne-based-ci-cd-platform-buildkite-gets-28-million-aud-series-a-led-by-openview/',
+     '2026-05-04', 'news', 1),
+    (v_case_study_id,
+     'Authority Magazine — Keith Pitt: 5 Things I Wish Someone Told Me Before I Became Co-Founder of Buildkite',
+     'https://medium.com/authority-magazine/keith-pitt-5-things-i-wish-someone-told-me-before-i-became-the-ceo-of-buildkite-8f67f3a539e5',
+     '2026-05-04', 'interview', 2),
+    (v_case_study_id,
+     'Startup Daily — Buildkite, "the best-kept secret in DevOps", raises $28 million for $200 million valuation',
+     'https://www.startupdaily.net/topic/buildkite-the-best-kept-secret-in-devops-raises-28-million-for-200-million-valuation/',
+     '2026-05-04', 'news', 3),
+    (v_case_study_id,
+     'Buildkite — About Company page',
+     'https://buildkite.com/about/company/',
+     '2026-05-04', 'company_blog', 4),
+    (v_case_study_id,
+     'General Catalyst — Buildkite portfolio entry',
+     'https://www.generalcatalyst.com/portfolio/buildkite',
+     '2026-05-04', 'company_blog', 5),
+    (v_case_study_id,
+     'Euphemia — Buildkite awesome stories',
+     'https://euphemia.com/awesome-stories/buildkite/',
+     '2026-05-04', 'interview', 6),
+    (v_case_study_id,
+     'Startup Playbook Ep127 — Lachlan Donald on equity over ego (YouTube)',
+     'https://www.youtube.com/watch?v=4_QEE3UHS1U',
+     '2026-05-04', 'podcast', 7),
+    (v_case_study_id,
+     'Apple Podcasts — Startup Playbook Ep127 with Lachlan Donald',
+     'https://podcasts.apple.com/us/podcast/ep127-lachlan-donald-co-founder-ceo-buildkite-on-equity/id1135431502?i=1000489927740',
+     '2026-05-04', 'podcast', 8),
+    (v_case_study_id,
+     'VentureBeat — Keith Pitt DataDecisionMakers author profile',
+     'https://venturebeat.com/author/keith-pitt-buildkite/',
+     '2026-05-04', 'interview', 9),
+    (v_case_study_id,
+     'The Org — Keith Pitt at Buildkite',
+     'https://theorg.com/org/buildkite/org-chart/keith-pitt',
+     '2026-05-04', 'linkedin', 10);
+
+  -- ---------------------------------------------------------------------------
+  -- 3. Replace quotes (idempotent via DELETE + INSERT)
+  --
+  -- display_order is global per case_study and ascending in render order.
+  -- Quotes are grouped by section_id at render time (ContentBodyRenderer).
+  -- ---------------------------------------------------------------------------
+  DELETE FROM public.case_study_quotes WHERE case_study_id = v_case_study_id;
+
+  INSERT INTO public.case_study_quotes
+    (case_study_id, section_id, quote, attributed_to, role, source_url, source_label, display_order)
+  VALUES
+    (v_case_study_id, v_section_entry_strategy,
+     'All of the self-hosted options were incredibly outdated, given I was accustomed to using modern development workflows.',
+     'Keith Pitt', 'Founder & former CEO',
+     'https://medium.com/authority-magazine/keith-pitt-5-things-i-wish-someone-told-me-before-i-became-the-ceo-of-buildkite-8f67f3a539e5',
+     'Authority Magazine',
+     1),
+    (v_case_study_id, v_section_entry_strategy,
+     'My priority from day one as founder of Buildkite was to end this compromise.',
+     'Keith Pitt', 'Founder & former CEO',
+     'https://www.startupdaily.net/topic/buildkite-the-best-kept-secret-in-devops-raises-28-million-for-200-million-valuation/',
+     'Startup Daily',
+     2),
+    (v_case_study_id, v_section_success_factors,
+     'I never treated Buildkite as a startup, but rather as a business.',
+     'Keith Pitt', 'Founder & former CEO',
+     'https://medium.com/authority-magazine/keith-pitt-5-things-i-wish-someone-told-me-before-i-became-the-ceo-of-buildkite-8f67f3a539e5',
+     'Authority Magazine',
+     3),
+    (v_case_study_id, v_section_success_factors,
+     'We wanted to focus on sustainable growth and maintain control of our destiny.',
+     'Lachlan Donald', 'Co-founder & CEO',
+     'https://techcrunch.com/2020/08/18/melbourne-based-ci-cd-platform-buildkite-gets-28-million-aud-series-a-led-by-openview/',
+     'TechCrunch',
+     4),
+    (v_case_study_id, v_section_key_metrics,
+     'When CI/CD doesn''t work, it shows throughout the entire organisation – teams slow down, products are delayed and customers turn elsewhere.',
+     'Lachlan Donald', 'Co-founder & CEO',
+     'https://www.startupdaily.net/topic/buildkite-the-best-kept-secret-in-devops-raises-28-million-for-200-million-valuation/',
+     'Startup Daily',
+     5);
+END $$;


### PR DESCRIPTION
## Summary

Ships the case-study readability overhaul end-to-end up to and including the Buildkite pilot:

- **Phase 3 — schema** (`901e0fd`): adds nullable readability columns to `content_items` (`hero_image_url`, `hero_image_alt`, `hero_image_credit`, `body_images`, `tldr`, `quick_facts`, `last_verified_at`, `researched_by`, `researched_by_avatar_url`, `style_version`) and creates two new tables (`case_study_sources`, `case_study_quotes`) with RLS, indexes, and `handle_updated_at` triggers. Already applied to production via Supabase MCP.
- **Phase 4 — render layer** (`1b6b916`): adds 8 new components under `src/components/case-study/` (HeroImage, TLDRBlock, QuickFactsStrip, AuthorByline, LastVerifiedBadge, ReadingProgressBar, PullQuote, SourcesSection, InlineCitation) plus `applyEnhancements`, `autolink`, `splitParagraphs`, `decodeApostrophes` helpers. Wires them into `CaseStudyDetail.tsx` and `ContentBodyRenderer.tsx`. **All components render nothing when their data is null**, so the 41 existing case studies are unaffected until backfilled per pilot.
- **Phase 5.1 — staging files** (`bc5f807`): three audit-trail markdown files under `.claude/staging/` documenting source provenance, quote attribution, and quick-fact decisions for the three pilots (Buildkite, Go1, Zoom).
- **Phase 5.2 pilot 1 — Buildkite backfill** (`2cb0cb1`): one idempotent SQL migration that populates Tier B fields for the Buildkite case study (hero, 5-bullet TL;DR, 6 quick facts, byline, 10 sources with citation numbers 1–10, 5 quotes anchored across `entry-strategy` / `success-factors` / `key-metrics`). Already applied to production via Supabase MCP.

After this merge, Lovable redeploys and `https://market-entry-secrets.lovable.app/case-studies/buildkite-australia-startup` will render the full Tier B layout. Go1 and Zoom pilots remain pending — their staging files are in this PR but their backfill migrations come next.

## Test plan

- [ ] Visit `/case-studies/buildkite-australia-startup` and confirm: hero image loads, TL;DR shows 5 bullets, quick-facts strip shows 6 facts with Lucide icons, byline shows "Stephen Browne · 4 May 2026", 5 pull-quotes appear in the right sections, sources list renders 10 numbered citations at the bottom, reading progress bar tracks scroll
- [ ] Visit one untouched case study (e.g. `/case-studies/canva-australia-success-story`) and confirm: page renders identically to before — no hero image, no TL;DR, no quick-facts, no byline, no sources section
- [ ] Verify TypeScript build passes (already verified locally in Phase 4)

https://claude.ai/code/session_01AhPPWhM77SejR69ePuPrV4

---
_Generated by [Claude Code](https://claude.ai/code/session_01AhPPWhM77SejR69ePuPrV4)_