### PR TITLE
Backfill Go1 + Zoom pilots (Phase 5.2)

### DIFF
--- a/supabase/migrations/20260504130100_backfill_go1_pilot.sql
+++ b/supabase/migrations/20260504130100_backfill_go1_pilot.sql
@@ -1,0 +1,146 @@
+-- =============================================================================
+-- Phase 5.2 Pilot 2 of 3: Go1 — case study readability backfill
+--
+-- Populates new Tier B fields on content_items + structured rows in
+-- case_study_sources and case_study_quotes for the Go1 pilot.
+--
+-- Idempotent: re-running this migration produces identical state.
+--
+-- Source provenance: see .claude/staging/go1-australia-startup.md
+-- =============================================================================
+
+DO $$
+DECLARE
+  v_case_study_id            uuid;
+  v_section_entry_strategy   uuid;
+  v_section_success_factors  uuid;
+  v_section_key_metrics      uuid;
+  v_section_challenges_faced uuid;
+BEGIN
+  SELECT id INTO v_case_study_id
+  FROM public.content_items
+  WHERE slug = 'go1-australia-startup';
+
+  IF v_case_study_id IS NULL THEN
+    RAISE EXCEPTION 'go1-australia-startup case study not found';
+  END IF;
+
+  SELECT id INTO v_section_entry_strategy   FROM public.content_sections
+  WHERE content_id = v_case_study_id AND slug = 'entry-strategy';
+  SELECT id INTO v_section_success_factors  FROM public.content_sections
+  WHERE content_id = v_case_study_id AND slug = 'success-factors';
+  SELECT id INTO v_section_key_metrics      FROM public.content_sections
+  WHERE content_id = v_case_study_id AND slug = 'key-metrics';
+  SELECT id INTO v_section_challenges_faced FROM public.content_sections
+  WHERE content_id = v_case_study_id AND slug = 'challenges-faced';
+
+  -- ---------------------------------------------------------------------------
+  -- 1. Update content_items with hero, TL;DR, quick-facts, byline metadata
+  -- ---------------------------------------------------------------------------
+  UPDATE public.content_items
+  SET
+    hero_image_url    = 'https://www.griffith.edu.au/__data/assets/image/0031/2237674/Chris-Eigeland.jpg',
+    hero_image_alt    = 'Chris Eigeland, CEO and co-founder of Go1',
+    hero_image_credit = 'Griffith University',
+    tldr = ARRAY[
+      'Four childhood friends reunited via Y Combinator 2015 to launch Go1',
+      'Brisbane''s first unicorn at $2B valuation, now reaching $3B',
+      '50M users across 10,000+ organisations consume 250+ providers',
+      'Acquired Coorpacademy (April 2022) and Blinkist (May 2023)',
+      'Sole CEO Chris Eigeland since August 2024 after Andrew Barnes'' transition'
+    ],
+    quick_facts = '[
+      {"label": "Founded",       "value": "2015 (Logan, QLD)",        "icon": "Calendar"},
+      {"label": "HQ",            "value": "Brisbane, Australia",      "icon": "MapPin"},
+      {"label": "Total Funding", "value": "~$414M USD",               "icon": "DollarSign"},
+      {"label": "Valuation",     "value": "$2–3B USD",                "icon": "TrendingUp"},
+      {"label": "Users",         "value": "50M registered",           "icon": "Users"},
+      {"label": "Team",          "value": "~600 across 19 countries", "icon": "Globe2"}
+    ]'::jsonb,
+    last_verified_at = '2026-05-04T00:00:00Z'::timestamptz,
+    researched_by    = 'Stephen Browne',
+    style_version    = 2
+  WHERE id = v_case_study_id;
+
+  -- ---------------------------------------------------------------------------
+  -- 2. Replace sources (idempotent via DELETE + INSERT)
+  -- ---------------------------------------------------------------------------
+  DELETE FROM public.case_study_sources WHERE case_study_id = v_case_study_id;
+
+  INSERT INTO public.case_study_sources
+    (case_study_id, label, url, accessed_at, source_type, citation_number)
+  VALUES
+    (v_case_study_id,
+     'Contrary Research — Go1 Business Breakdown & Founding Story',
+     'https://research.contrary.com/company/go1',
+     '2026-05-04', 'other', 1),
+    (v_case_study_id,
+     'Startup Daily — Go1 cofounder exits CEO role after 10 years, handing reins to Chris Eigeland',
+     'https://www.startupdaily.net/topic/people/go1-cofounder-exits-ceo-role-after-10-years-handing-reins-to-chris-eigeland/',
+     '2026-05-04', 'news', 2),
+    (v_case_study_id,
+     'Crunchbase — Chris Eigeland person profile',
+     'https://www.crunchbase.com/person/chris-eigeland',
+     '2026-05-04', 'other', 3),
+    (v_case_study_id,
+     'Go1 Podcast Ep9 — Chris Eigeland on the role of L&D',
+     'https://www.go1.com/podcast/ep9-chris-eigeland',
+     '2026-05-04', 'podcast', 4),
+    (v_case_study_id,
+     'Startup Grind Brisbane — Chris Eigeland event page',
+     'https://www.startupgrind.com/events/details/startup-grind-brisbane-presents-chris-eigeland-go1/',
+     '2026-05-04', 'interview', 5),
+    (v_case_study_id,
+     'AICC NSW — Boardroom Lunch with Chris Eigeland, Co-Founder of Go1',
+     'https://aiccnsw.org.au/boardroom-lunch-with-chris-eigeland-co-founder-go1-brisbane/',
+     '2026-05-04', 'interview', 6),
+    (v_case_study_id,
+     'AICC QLD — Boardroom Lunch with Chris Eigeland, Co-Founder of Go1',
+     'https://aiccqld.org.au/2026/03/05/boardroom-lunch-with-chris-eigeland-co-founder-go1-brisbane/',
+     '2026-05-04', 'interview', 7),
+    (v_case_study_id,
+     'EdTechX 2022 Stories — Chris Eigeland',
+     'https://impactx2050.com/edtechx-stories-chris-eigeland',
+     '2026-05-04', 'interview', 8),
+    (v_case_study_id,
+     'Anthill — Chris Eigeland 2016 30 Under 30 winner',
+     'https://anthillonline.com/chris-eigeland-2016-anthill-30under30-winner/',
+     '2026-05-04', 'news', 9),
+    (v_case_study_id,
+     'Advance Queensland — Igniting Innovation: Go1''s journey from Logan to Brisbane''s first unicorn',
+     'https://advance.qld.gov.au/innovation-in-queensland/innovation-stories/igniting-innovation-the-go1-journey-from-logan-startup-to-brisbanes-first-unicorn',
+     '2026-05-04', 'government', 10);
+
+  -- ---------------------------------------------------------------------------
+  -- 3. Replace quotes (idempotent via DELETE + INSERT)
+  -- ---------------------------------------------------------------------------
+  DELETE FROM public.case_study_quotes WHERE case_study_id = v_case_study_id;
+
+  INSERT INTO public.case_study_quotes
+    (case_study_id, section_id, quote, attributed_to, role, source_url, source_label, display_order)
+  VALUES
+    (v_case_study_id, v_section_entry_strategy,
+     'We''ve been incredibly lucky that our skillsets have been complementary, helping Go1 get to where it is today.',
+     'Andrew Barnes', 'Co-founder & former Co-CEO',
+     'https://www.startupdaily.net/topic/people/go1-cofounder-exits-ceo-role-after-10-years-handing-reins-to-chris-eigeland/',
+     'Startup Daily',
+     1),
+    (v_case_study_id, v_section_success_factors,
+     'If we do something in consumer, we would want to make that a target. It would be quite a different product.',
+     'Andrew Barnes', 'Co-founder & former Co-CEO',
+     'https://research.contrary.com/company/go1',
+     'Contrary Research',
+     2),
+    (v_case_study_id, v_section_key_metrics,
+     'We''re building and running the business at an increasing level of maturity around governance and all the standards that are required to become IPO ready.',
+     'Chris Eigeland', 'CEO & Co-Founder',
+     'https://research.contrary.com/company/go1',
+     'Contrary Research',
+     3),
+    (v_case_study_id, v_section_challenges_faced,
+     'By having a single CEO, we will be able to move faster on the day-to-day decisions.',
+     'Andrew Barnes', 'Co-founder & former Co-CEO',
+     'https://www.startupdaily.net/topic/people/go1-cofounder-exits-ceo-role-after-10-years-handing-reins-to-chris-eigeland/',
+     'Startup Daily',
+     4);
+END $$;

--- a/supabase/migrations/20260504130200_backfill_zoom_pilot.sql
+++ b/supabase/migrations/20260504130200_backfill_zoom_pilot.sql
@@ -1,0 +1,160 @@
+-- =============================================================================
+-- Phase 5.2 Pilot 3 of 3: Zoom AU — case study readability backfill
+--
+-- Populates new Tier B fields on content_items + structured rows in
+-- case_study_sources and case_study_quotes for the Zoom pilot, AND scrubs
+-- inline <p><em>Sources: ...</em></p> HTML blocks from content_bodies because
+-- the structured case_study_sources table now replaces them.
+--
+-- Idempotent: re-running this migration produces identical state. The scrub
+-- regex is non-greedy (.*?) and case-insensitive ('i' flag) and matches only
+-- inline blocks containing "Sources:" inside <em>, so re-running has no effect
+-- once the blocks are gone.
+--
+-- Hero image is intentionally left NULL pending a verifiable brand asset URL.
+-- The HeroImage component renders nothing when url is null.
+--
+-- Source provenance: see .claude/staging/zoom-australia-market-entry.md
+-- =============================================================================
+
+DO $$
+DECLARE
+  v_case_study_id            uuid;
+  v_section_entry_strategy   uuid;
+  v_section_success_factors  uuid;
+  v_section_key_metrics      uuid;
+  v_scrub_count              int;
+BEGIN
+  SELECT id INTO v_case_study_id
+  FROM public.content_items
+  WHERE slug = 'zoom-australia-market-entry';
+
+  IF v_case_study_id IS NULL THEN
+    RAISE EXCEPTION 'zoom-australia-market-entry case study not found';
+  END IF;
+
+  SELECT id INTO v_section_entry_strategy  FROM public.content_sections
+  WHERE content_id = v_case_study_id AND slug = 'entry-strategy';
+  SELECT id INTO v_section_success_factors FROM public.content_sections
+  WHERE content_id = v_case_study_id AND slug = 'success-factors';
+  SELECT id INTO v_section_key_metrics     FROM public.content_sections
+  WHERE content_id = v_case_study_id AND slug = 'key-metrics';
+
+  -- ---------------------------------------------------------------------------
+  -- 1. Update content_items with TL;DR, quick-facts, byline metadata
+  --    (hero image deliberately left NULL pending brand asset)
+  -- ---------------------------------------------------------------------------
+  UPDATE public.content_items
+  SET
+    tldr = ARRAY[
+      'Michael Chetner became Zoom''s first ANZ employee in April 2017',
+      'AARNet partnership (since 2014) reached 60+ Australian institutions by end-2017',
+      '134% revenue growth and 105% customer growth announced December 2017',
+      'Australian customers: REA Group, SEEK, Movember, Western Sydney University',
+      'Zoom Phone launched in Australia July 2019, Zoom Contact Center 2023'
+    ],
+    quick_facts = '[
+      {"label": "ANZ Entry",            "value": "April 2017",          "icon": "Calendar"},
+      {"label": "First Hire",           "value": "Michael Chetner",     "icon": "User"},
+      {"label": "Channel Partner",      "value": "AARNet (since 2014)", "icon": "Network"},
+      {"label": "ANZ Revenue Growth",   "value": "134% YoY (2017)",     "icon": "TrendingUp"},
+      {"label": "ANZ Customer Growth",  "value": "105% YoY (2017)",     "icon": "Users"},
+      {"label": "Origin",               "value": "San Jose, USA",       "icon": "MapPin"}
+    ]'::jsonb,
+    last_verified_at = '2026-05-04T00:00:00Z'::timestamptz,
+    researched_by    = 'Stephen Browne',
+    style_version    = 2
+  WHERE id = v_case_study_id;
+
+  -- ---------------------------------------------------------------------------
+  -- 2. Scrub inline source-list HTML from content_bodies.
+  --
+  -- The current Zoom body_text fields contain ad-hoc inline source lists like
+  --   <p class="text-sm text-muted-foreground mt-4"><em>Sources: ...</em></p>
+  -- We replace these with empty strings because the structured
+  -- case_study_sources table now provides the canonical citation list rendered
+  -- by the SourcesSection component at the bottom of the page.
+  --
+  -- Pattern is permissive on class attribute and whitespace.
+  -- ---------------------------------------------------------------------------
+  WITH scrubbed AS (
+    UPDATE public.content_bodies cb
+    SET body_text = regexp_replace(
+      cb.body_text,
+      '<p[^>]*>\s*<em[^>]*>\s*Sources:.*?</em>\s*</p>',
+      '',
+      'gi'
+    )
+    FROM public.content_sections cs
+    WHERE cb.section_id = cs.id
+      AND cs.content_id = v_case_study_id
+      AND cb.body_text ~* '<p[^>]*>\s*<em[^>]*>\s*Sources:'
+    RETURNING cb.id
+  )
+  SELECT count(*) INTO v_scrub_count FROM scrubbed;
+
+  RAISE NOTICE 'Zoom scrub: removed inline source blocks from % body rows', v_scrub_count;
+
+  -- ---------------------------------------------------------------------------
+  -- 3. Replace structured sources (idempotent via DELETE + INSERT)
+  -- ---------------------------------------------------------------------------
+  DELETE FROM public.case_study_sources WHERE case_study_id = v_case_study_id;
+
+  INSERT INTO public.case_study_sources
+    (case_study_id, label, url, accessed_at, source_type, citation_number)
+  VALUES
+    (v_case_study_id, 'Zoom Blog — Zoom Announces 134% Revenue Growth in Australia and New Zealand', 'https://blog.zoom.us/zoom-announces-134-percent-revenue-growth-australia-new-zealand/', '2026-05-04', 'press_release', 1),
+    (v_case_study_id, 'ITBrief — Video communication service Zoom posts 134% revenue growth in ANZ', 'https://itbrief.com.au/story/video-communication-service-zoom-posts-134-revenue-growth-nz', '2026-05-04', 'news', 2),
+    (v_case_study_id, 'ChannelLife — Zoom posts 134% revenue growth in ANZ', 'https://channellife.com.au/story/video-communication-service-zoom-posts-134-revenue-growth-nz', '2026-05-04', 'news', 3),
+    (v_case_study_id, 'ChannelLife — Exclusive interview: Targeting the university sector with AARNet and Zoom', 'https://channellife.com.au/story/exclusive-interview-targeting-university-sector-aarnet-and-zoom', '2026-05-04', 'interview', 4),
+    (v_case_study_id, 'AARNet — Transforming online collaboration for Australian universities', 'https://www.aarnet.edu.au/transforming-online-collaboration-for-australian-universities', '2026-05-04', 'other', 5),
+    (v_case_study_id, 'AARNet — Zoom Video Communications for Research & Education', 'https://www.aarnet.edu.au/zoom', '2026-05-04', 'other', 6),
+    (v_case_study_id, 'Zoom Blog — Zoom To Reach Over 1 Million in Australia Via AARNet', 'https://blog.zoom.us/zoom-reaches-1-million-australia-via-aarnet/', '2026-05-04', 'press_release', 7),
+    (v_case_study_id, 'ARN — Zoom A/NZ head Michael Chetner resigns', 'https://www.arnnet.com.au/article/705793/zoom-anz-head-michael-chetner-resigns/', '2026-05-04', 'news', 8),
+    (v_case_study_id, 'The Org — Michael Chetner, Head of Australia and Asia Pacific at Zoom', 'https://theorg.com/org/zoom/org-chart/michael-chetner', '2026-05-04', 'linkedin', 9),
+    (v_case_study_id, 'ITBrief — Zoom Virtual Agent launch promises big things for ANZ businesses', 'https://itbrief.com.au/story/zoom-virtual-agent-launch-promises-big-things-for-anz-businesses', '2026-05-04', 'news', 10),
+    (v_case_study_id, 'Atlassian — Zoom surpasses growth goals with Atlassian cloud products case study', 'https://www.atlassian.com/customers/zoom', '2026-05-04', 'company_blog', 11);
+
+  -- ---------------------------------------------------------------------------
+  -- 4. Replace quotes (idempotent via DELETE + INSERT)
+  --
+  -- 6 quotes total: 3 from inside Zoom (Chetner ×2, Yuan ×1) plus 3 from
+  -- AARNet university-customer voices that triangulate the channel-led
+  -- market-entry narrative.
+  -- ---------------------------------------------------------------------------
+  DELETE FROM public.case_study_quotes WHERE case_study_id = v_case_study_id;
+
+  INSERT INTO public.case_study_quotes
+    (case_study_id, section_id, quote, attributed_to, role, source_url, source_label, display_order)
+  VALUES
+    (v_case_study_id, v_section_entry_strategy,
+     'They''ve bundled the value up really nicely. If I was to compare their offering with any other service provider, it''s very easy to have the pipes but you need to have relevant applications.',
+     'Michael Chetner', 'Head of A/NZ, Zoom',
+     'https://channellife.com.au/story/exclusive-interview-targeting-university-sector-aarnet-and-zoom',
+     'ChannelLife', 1),
+    (v_case_study_id, v_section_success_factors,
+     'In today''s hyper-connected world, Zoom has cut through the noise, answering the call for simplified communications.',
+     'Michael Chetner', 'Head of A/NZ, Zoom',
+     'https://channellife.com.au/story/video-communication-service-zoom-posts-134-revenue-growth-nz',
+     'ChannelLife', 2),
+    (v_case_study_id, v_section_success_factors,
+     'There has been an amazing turn-around on our functionality requests.',
+     'Geoff Lambert', 'Western Sydney University',
+     'https://www.aarnet.edu.au/transforming-online-collaboration-for-australian-universities',
+     'AARNet', 3),
+    (v_case_study_id, v_section_success_factors,
+     'Zoom bridges the gap between on-campus and off-campus students for tutorials.',
+     'Troy Down', 'University of Southern Queensland',
+     'https://www.aarnet.edu.au/transforming-online-collaboration-for-australian-universities',
+     'AARNet', 4),
+    (v_case_study_id, v_section_success_factors,
+     'The reliability and ease of the AARNet Zoom service increased the use of desktop and mobile video conferencing.',
+     'Ben Loveridge', 'University of Melbourne',
+     'https://www.aarnet.edu.au/transforming-online-collaboration-for-australian-universities',
+     'AARNet', 5),
+    (v_case_study_id, v_section_key_metrics,
+     'Zoom''s rapid expansion into the ANZ region has been fuelled by a demand for easy and secure meeting experiences.',
+     'Eric S. Yuan', 'Founder & CEO, Zoom',
+     'https://channellife.com.au/story/video-communication-service-zoom-posts-134-revenue-growth-nz',
+     'ChannelLife', 6);
+END $$;


### PR DESCRIPTION
## Summary

Completes Phase 5.2 — backfills the remaining two pilot case studies (Go1 and Zoom) with the same Tier B readability data shape that shipped for Buildkite in #176.

- **Go1** (`20260504130100_backfill_go1_pilot.sql`): hero image, 5-bullet TL;DR, 6 quick facts, byline, 10 sources, 4 quotes across `entry-strategy` / `success-factors` / `key-metrics` / `challenges-faced`.
- **Zoom** (`20260504130200_backfill_zoom_pilot.sql`): 5-bullet TL;DR, 6 quick facts, byline (hero `NULL` — pending a verifiable brand asset), 11 sources, 6 quotes (3 Zoom executives, 3 AARNet university customer voices) plus a regex scrub that removes 11 inline `<p><em>Sources: ...</em></p>` HTML blocks from `content_bodies.body_text` because the structured `case_study_sources` table now provides the canonical citations rendered at the page bottom.

Both migrations are idempotent (DELETE + INSERT for sources/quotes). Already applied to production via Supabase MCP and verified — Go1 has 10/4 source/quote rows, Zoom has 11/6 with `remaining_inline_source_blocks=0` after the scrub.

## Test plan

- [ ] `/case-studies/go1-australia-startup` — hero image of Chris Eigeland renders, TL;DR shows 5 bullets, quick-facts strip shows 6 facts, byline shows "Stephen Browne · 4 May 2026", 4 pull-quotes appear in entry-strategy / success-factors / key-metrics / challenges-faced, 10-source list at the bottom
- [ ] `/case-studies/zoom-australia-market-entry` — no hero image (intentional), TL;DR + quick-facts + byline render, 6 pull-quotes appear (1 in entry-strategy, 4 in success-factors, 1 in key-metrics), 11-source list at the bottom, **and** body prose no longer contains the duplicated inline "Sources:" lines after each paragraph
- [ ] Untouched case studies (e.g. Canva) render identically to before — all new columns nullable, no regression

## Known limitation (deferred)

The `splitParagraphs` enhancer in `applyEnhancements.tsx` (Phase 4) skips paragraphs containing inline `<a>` / `<strong>` / `<em>` tags, so dense prose with many citations stays as one wall of text. Tracked as future work, not a blocker for this PR.

https://claude.ai/code/session_01AhPPWhM77SejR69ePuPrV4

---
_Generated by [Claude Code](https://claude.ai/code/session_01AhPPWhM77SejR69ePuPrV4)_