### PR TITLE
Backfill Batch 1 (8/10): US enterprise SaaS AU market entries

### DIFF
--- a/.claude/staging/anthropic-australia-market-entry.md
+++ b/.claude/staging/anthropic-australia-market-entry.md
@@ -1,0 +1,70 @@
+# anthropic-australia-market-entry: Backfill Staging
+
+**Pilot:** Batch 1 of 4 (study 1 of 10)
+**Researched by:** Stephen Browne
+**last_verified_at:** 2026-05-04
+
+---
+
+## TLDR
+
+- Sydney office officially opened 28 April 2026
+- Theo Hourmouzis named GM ANZ from Snowflake
+- Customers include Commonwealth Bank, Quantium, Canva, Xero
+- Claude 3.5 Sonnet live in AWS Sydney region
+- Federal MOU signed for AI safety collaboration
+
+## Quick Facts
+
+- ANZ Office Launch | 28 April 2026 | Calendar
+- GM ANZ | Theo Hourmouzis (ex-Snowflake SVP) | User
+- AU HQ | Sydney, NSW | MapPin
+- AU Customers | CommBank, Quantium, Canva, Xero | Building
+- Data Residency | Claude on Amazon Bedrock, AWS Sydney | Shield
+- Origin | San Francisco, USA | Globe2
+
+## Hero
+
+URL: TBD
+Alt: TBD
+Credit: TBD
+
+## Sources
+
+1. Anthropic — Sydney will become Anthropic's fourth office in Asia-Pacific | https://www.anthropic.com/news/sydney-fourth-office-asia-pacific | company_blog
+2. Anthropic — Theo Hourmouzis to lead Anthropic in Australia and New Zealand | https://www.anthropic.com/news/theo-hourmouzis-general-manager-australia-new-zealand | press_release
+3. Anthropic — Australian Government and Anthropic sign MOU | https://www.anthropic.com/news/australia-MOU | press_release
+4. Department of Industry, Science and Resources — MOU with Anthropic | https://www.industry.gov.au/news/australian-government-has-signed-memorandum-understanding-mou-global-ai-innovator-anthropic | government
+5. ITBrief AU — Anthropic opens Sydney office, names NZ & Australia chief | https://itbrief.com.au/story/anthropic-opens-sydney-office-names-nz-australia-chief | news
+6. Marketing-Interactive — Anthropic appoints Hourmouzis as Sydney office officially opens | https://www.marketing-interactive.com/anthropic-appoints-theo-hourmouzis-to-lead-anz-as-sydney-office-officially-opens | news
+7. Mumbrella — Anthropic appoints GM for ANZ and opens Sydney office | https://mumbrella.com.au/anthropic-appoints-gm-for-anz-and-opens-sydney-office-921617 | news
+8. EdTech Innovation Hub — Anthropic touches down in Sydney with Hourmouzis | https://www.edtechinnovationhub.com/news/anthropic-touches-down-in-sydney-with-former-snowflake-vp-theo-hourmouzis-at-the-helm | news
+9. AWS — Claude 3.5 Sonnet now available in AWS Sydney Region | https://aws.amazon.com/about-aws/whats-new/2025/02/anthropics-upgraded-claude-3-5-sonnet-sydney-region/ | press_release
+10. ARN — Anthropic opens in Sydney with Hourmouzis at the helm | https://www.arnnet.com.au/article/4163981/anthropic-opens-in-sydney-with-theo-hourmouzis-at-the-helm.html | news
+
+## Quotes
+
+> "Organisations across Australia and New Zealand are thinking carefully about how to adopt AI and they want partners who take safety and rigor as seriously as they take the opportunity. That's what drew me to Anthropic."
+> Attributed to: Theo Hourmouzis, General Manager, Australia and New Zealand, Anthropic
+> Source: Marketing-Interactive (https://www.marketing-interactive.com/anthropic-appoints-theo-hourmouzis-to-lead-anz-as-sydney-office-officially-opens)
+> Place after section: entry-strategy
+
+> "Theo's appointment reflects the conviction we share with the Australian government that AI can drive economic growth when it's developed and deployed responsibly."
+> Attributed to: Chris Ciauri, Managing Director of International, Anthropic
+> Source: ITBrief AU (https://itbrief.com.au/story/anthropic-opens-sydney-office-names-nz-australia-chief)
+> Place after section: success-factors
+
+> "Establishing a local presence will help us to develop strong partnerships in ANZ and ensure Claude is built with respect for the unique goals, opportunities, and challenges of the region."
+> Attributed to: Chris Ciauri, Managing Director of International, Anthropic
+> Source: Anthropic (https://www.anthropic.com/news/sydney-fourth-office-asia-pacific)
+> Place after section: entry-strategy
+
+> "Australia's investment in AI safety makes it a natural partner for responsible AI development. This MOU gives our collaboration a formal foundation."
+> Attributed to: Dario Amodei, CEO, Anthropic
+> Source: Anthropic (https://www.anthropic.com/news/australia-MOU)
+> Place after section: lessons-learned
+
+> "The future for us is about Claude becoming embedded infrastructure, a core part of how we run the organisation."
+> Attributed to: Devan Seamans, Head of Marketing & Technology, YMCA South Australia
+> Source: ITBrief AU (https://itbrief.com.au/story/anthropic-opens-sydney-office-names-nz-australia-chief)
+> Place after section: key-metrics

--- a/.claude/staging/aws-australia-market-entry.md
+++ b/.claude/staging/aws-australia-market-entry.md
@@ -1,0 +1,74 @@
+# aws-australia-market-entry: Backfill Staging
+
+**Pilot:** Batch 1 of 4 (study 8 of 10)
+**Researched by:** Stephen Browne
+**last_verified_at:** 2026-05-04
+
+---
+
+## TLDR
+
+- AWS launched Sydney region in November 2012, Melbourne January 2023
+- Iain Rouse leads ANZ Public Sector; Rianne Van Veldhuizen is ANZ MD
+- Customers include CBA, NAB, ANZ, Telstra, Atlassian, Canva
+- AU$20B investment announced for 2025–2029 data centre expansion
+- Dual-region strategy delivered data sovereignty plus disaster recovery
+
+## Quick Facts
+
+- ANZ Entry Year | 2012 (Sydney region) | Calendar
+- Sydney Region Launch | 12 November 2012 | MapPin
+- Melbourne Region Launch | 23 January 2023 | Building
+- ANZ Leadership | Iain Rouse (Public Sector); Rianne Van Veldhuizen (MD) | User
+- AU Customers | CBA, NAB, ANZ, Telstra, Atlassian, Canva | Users
+- Investment Commitment | AU$20B by 2029 | DollarSign
+
+## Hero
+
+URL: TBD
+Alt: TBD
+Credit: TBD
+
+## Sources
+
+1. AWS Blog — Now Open AWS Asia Pacific (Melbourne) Region | https://aws.amazon.com/blogs/aws/now-open-aws-asia-pacific-melbourne-region-in-australia/ | company_blog
+2. Amazon Press — AWS Launches Second Infrastructure Region in Australia | https://press.aboutamazon.com/2023/1/aws-launches-second-infrastructure-region-in-australia | press_release
+3. About Amazon AU — AWS Launches Region in Melbourne, Invests $6.8B by 2037 | https://www.aboutamazon.com.au/aws-launches-aws-region-in-melbourne-invests-6-8-billion-by-2037 | press_release
+4. About Amazon — Amazon Investing AU$20B in Australian Data Centres | https://www.aboutamazon.com/news/aws/amazon-data-center-investment-in-australia | press_release
+5. Austrade — AWS to Invest A$13.2B in Cloud Infrastructure in Australia | https://international.austrade.gov.au/en/news-and-analysis/news/aws-to-invest-13-2-billion-aud-in-cloud-infrastructure-in-australia | government
+6. AWS — Announcing the Asia Pacific (Sydney) Region (2012) | https://aws.amazon.com/about-aws/whats-new/2012/11/12/announcing-the-aws-asia-pacific-sydney-region/ | company_blog
+7. All Things Distributed — Expanding the Cloud: Sydney Region | https://www.allthingsdistributed.com/2012/11/asia-pacifc-sydney-region.html | company_blog
+8. Breaking Defense — A$2B Top Secret Aussie Cloud Deal with AWS | https://breakingdefense.com/2024/07/2-billion-aud-deal-for-top-secret-aussie-cloud-with-aws/ | news
+9. AWS Local — AWS in Australia | https://aws.amazon.com/local/australia/ | company_blog
+
+## Quotes
+
+> "This planned investment deepens our long-term commitment to supporting the growth and development of Australian organizations of all sizes."
+> Attributed to: Matt Garman, CEO, AWS
+> Source: About Amazon (https://www.aboutamazon.com/news/aws/amazon-data-center-investment-in-australia)
+> Place after section: entry-strategy
+
+> "This is the largest investment our country has seen from a global technology provider, and is an exciting opportunity for Australia to build AI capability."
+> Attributed to: Anthony Albanese, Prime Minister of Australia
+> Source: About Amazon (https://www.aboutamazon.com/news/aws/amazon-data-center-investment-in-australia)
+> Place after section: key-metrics
+
+> "Customers around the world are using AWS Regions to leverage advanced technologies, save costs, accelerate innovation, increase speed to market of new products and services, and expand their geographic infrastructure footprint in minutes."
+> Attributed to: Rianne Van Veldhuizen, Managing Director, AWS Australia and New Zealand
+> Source: About Amazon Australia (https://www.aboutamazon.com.au/aws-launches-aws-region-in-melbourne-invests-6-8-billion-by-2037)
+> Place after section: success-factors
+
+> "Australian citizens expect seamless and personalized access to government services anywhere and anytime. Today's launch of an AWS Region in Melbourne will be a key enabler for the Victorian government and other public sector customers to help meet this demand."
+> Attributed to: Iain Rouse, Country Director for Worldwide Public Sector, AWS ANZ
+> Source: About Amazon Australia (https://www.aboutamazon.com.au/aws-launches-aws-region-in-melbourne-invests-6-8-billion-by-2037)
+> Place after section: entry-strategy
+
+> "Locating key banking applications and critical workloads geographically close to our mainframe compute platform will provide lower latency benefits, streamline our disaster recovery procedures, and further increase our resilience."
+> Attributed to: Steve Day, Chief Technology Officer, NAB
+> Source: About Amazon Australia (https://www.aboutamazon.com.au/aws-launches-aws-region-in-melbourne-invests-6-8-billion-by-2037)
+> Place after section: success-factors
+
+> "The launch of a second AWS Region in Australia provides even greater resilience and enables more customers to develop cloud-based applications that help fuel economic development across the country."
+> Attributed to: Prasad Kalyanaraman, Vice President of Infrastructure Services, AWS
+> Source: Austrade (https://international.austrade.gov.au/en/news-and-analysis/news/aws-to-invest-13-2-billion-aud-in-cloud-infrastructure-in-australia)
+> Place after section: lessons-learned

--- a/.claude/staging/databricks-australia-market-entry.md
+++ b/.claude/staging/databricks-australia-market-entry.md
@@ -1,0 +1,75 @@
+# databricks-australia-market-entry: Backfill Staging
+
+**Pilot:** Batch 1 of 4 (study 4 of 10)
+**Researched by:** Stephen Browne
+**last_verified_at:** 2026-05-04
+
+---
+
+## TLDR
+
+- Sydney office opened June 2020, ANZ country manager November 2019
+- Bede Hackney named inaugural ANZ Country Manager, succeeded by Adam Beavis (2023)
+- AU customers include Atlassian, Tabcorp, NAB, Sportsbet, Healthdirect
+- Lakehouse runs on AWS Sydney region (ap-southeast-2)
+- Doubled ANZ headcount to 150+; 70% annual ANZ growth
+
+## Quick Facts
+
+- ANZ Entry Year | 2019 (Country Manager); 2020 (Sydney office) | Calendar
+- AU HQ City | Sydney, NSW | MapPin
+- Country Manager | Adam Beavis, VP & Country Manager ANZ | User
+- AU Customers | Atlassian, Tabcorp, NAB, Sportsbet, Healthdirect | Building
+- ANZ Growth | Doubled to 150+ employees in two years | TrendingUp
+- Origin | San Francisco, USA | Globe2
+
+## Hero
+
+URL: TBD
+Alt: TBD
+Credit: TBD
+
+## Sources
+
+1. Databricks Newsroom — Adam Beavis Appointment as Head of ANZ | https://www.databricks.com/company/newsroom/press-releases/databricks-announces-appointment-adam-beavis-head-australia-and-new | press_release
+2. Databricks Newsroom — Databricks Doubles ANZ Headcount | https://www.databricks.com/company/newsroom/press-releases/databricks-doubles-anz-headcount-signalling-growing-demand | press_release
+3. Databricks Newsroom — 70% Annual Growth in ANZ Market | https://www.databricks.com/company/newsroom/press-releases/databricks-sees-over-70-annual-growth-anz-market-enterprise-ai | press_release
+4. Databricks Newsroom — Deepens APJ Leadership Bench (Mar 2020) | https://www.databricks.com/company/newsroom/press-releases/databricks-deepens-leadership-bench-across-asia-pacific-and-japan | press_release
+5. Databricks Newsroom — Momentum Continues in ANZ | https://www.databricks.com/company/newsroom/press-releases/databricks-momentum-continues-anz-organisations-demand-more-ai-data | press_release
+6. ARN — Databricks Hires Tenable's Bede Hackney as A/NZ Leader | https://www.arnnet.com.au/article/668514/databricks-hires-tenable-bede-hackney-new-nz-leader/ | news
+7. ITBrief AU — Databricks Accelerates APJ Expansion After $250M Round | https://itbrief.com.au/story/databricks-accelerates-apj-expansion-following-250-million-funding-round | news
+8. Databricks Customers — Tabcorp Case Study | https://www.databricks.com/customers/tabcorp | company_blog
+9. Databricks Customers — Atlassian Security Lakehouse | https://www.databricks.com/customers/atlassian/security-lakehouse | company_blog
+10. Databricks Docs — AWS Supported Regions (ap-southeast-2 Sydney) | https://docs.databricks.com/aws/en/resources/supported-regions | other
+
+## Quotes
+
+> "Databricks is at the centre of all things data. Our customer use cases speak for themselves – from credit card fraud detection to personalised healthcare, we are helping data teams solve the world's toughest problems."
+> Attributed to: Bede Hackney, A/NZ Country Manager, Databricks
+> Source: ARN (https://www.arnnet.com.au/article/668514/databricks-hires-tenable-bede-hackney-new-nz-leader/)
+> Place after section: entry-strategy
+
+> "We're in a pivotal moment in time where data and AI technologies are evolving rapidly. The companies who succeed in the next five to 10 years will be those who can harness the power of their data and keep up with the pace of innovation."
+> Attributed to: Adam Beavis, Vice President and Country Manager, Databricks ANZ
+> Source: Databricks Newsroom (https://www.databricks.com/company/newsroom/press-releases/databricks-announces-appointment-adam-beavis-head-australia-and-new)
+> Place after section: entry-strategy
+
+> "As businesses of all sizes look to drive greater insights by leveraging their data, Databricks wants to ensure that they are supported by teams that understand their local needs and requirements."
+> Attributed to: Adam Beavis, Vice President and Country Manager, Databricks ANZ
+> Source: Databricks Newsroom (https://www.databricks.com/company/newsroom/press-releases/databricks-doubles-anz-headcount-signalling-growing-demand)
+> Place after section: success-factors
+
+> "Data is a massive enabler for Tabcorp as we raise the game to create more personalised and responsible gambling experiences for our customers."
+> Attributed to: Matt McKenzie, GM Technology - Strategy, Architecture, Data & Engineering, Tabcorp
+> Source: Databricks Newsroom (https://www.databricks.com/company/newsroom/press-releases/databricks-doubles-anz-headcount-signalling-growing-demand)
+> Place after section: key-metrics
+
+> "We have worked with Databricks for a number of years to build foundational capabilities for Atlassian's platform that help us handle data securely."
+> Attributed to: Sherif Mansour, Head of Product for Atlassian Intelligence
+> Source: Databricks Newsroom (https://www.databricks.com/company/newsroom/press-releases/databricks-doubles-anz-headcount-signalling-growing-demand)
+> Place after section: success-factors
+
+> "We are powering our data strategy with Databricks' Lakehouse, driving business-critical use cases including customer 360, fraud detection, and digital personalisation."
+> Attributed to: Joanna Gurry, Executive, Data Delivery, NAB
+> Source: Databricks Newsroom (https://www.databricks.com/company/newsroom/press-releases/databricks-doubles-anz-headcount-signalling-growing-demand)
+> Place after section: lessons-learned

--- a/.claude/staging/docusign-australia-market-entry.md
+++ b/.claude/staging/docusign-australia-market-entry.md
@@ -1,0 +1,74 @@
+# docusign-australia-market-entry: Backfill Staging
+
+**Pilot:** Batch 1 of 4 (study 6 of 10)
+**Researched by:** Stephen Browne
+**last_verified_at:** 2026-05-04
+
+---
+
+## TLDR
+
+- DocuSign opened Sydney APAC office in September 2013
+- Brad Newton served six years as APAC Vice President
+- CBA, AIA Australia, Adecco named DocuSign customers
+- InfoTrack SignIT integration powered Australian e-conveyancing contracts
+- Onshore data centres followed IRAP assessment for government compliance
+
+## Quick Facts
+
+- ANZ Entry Year | 2013 (Sydney APAC office) | Calendar
+- APAC VP | Brad Newton (~2015–2021) | User
+- AU/APAC HQ | Sydney, NSW | MapPin
+- AU Customers | CBA, AIA Australia, Adecco, InfoTrack | Building
+- Regulatory Anchor | IRAP + DTA Cloud Services Panel | Shield
+- Origin | San Francisco, USA | Globe2
+
+## Hero
+
+URL: TBD
+Alt: TBD
+Credit: TBD
+
+## Sources
+
+1. IDM Magazine — DocuSign heads downunder | https://idm.net.au/article/009760-docusign-heads-downunder | news
+2. Telecom Times — DocuSign ups Australian market play with local DCs, Sydney as APAC HQ | http://telecomtimes.com.au/files/2018/06/17/docusign-steps-up-australian-market-play-flags-first-local-dcs-confirms-sydney-as-apac-hq/ | news
+3. ITnews — CBA targets DocuSign for all its commercial loans | https://www.itnews.com.au/news/cba-targets-docusign-for-all-its-commercial-loans-578621 | news
+4. DocuSign Customer Story — DocuSign helps CBA accelerate its digital strategy | https://www.docusign.com/en-au/customer-stories/docusign-helps-cba-accelerate-its-digital-strategy | company_blog
+5. ARN — DocuSign's Brad Newton takes over as head of Cohesity A/NZ | https://www.arnnet.com.au/article/686528/docusign-brad-newton-takes-over-head-cohesity-nz/ | news
+6. Cohesity — Cohesity Appoints Brad Newton as Head of ANZ | https://www.cohesity.com/newsroom/press/cohesity-appoints-brad-newton-as-head-of-australia-and-new-zealand/ | press_release
+7. DocuSign AU Blog — eSignatures a compelling opportunity for the Australian government | https://www.docusign.com/en-au/blog/esignatures-a-compelling-opportunity-for-the-australian-government | company_blog
+8. PR Newswire APAC — Docusign plans Australian data centre | https://www.prnewswire.com/apac/news-releases/docusign-plans-australian-data-centre-answering-national-push-for-digital-sovereignty-and-data-security-302528681.html | press_release
+9. GovTechReview — DocuSign launches Australian data centres | https://www.govtechreview.com.au/content/gov-datacentre/news/docusign-launches-australian-data-centres-730674429 | news
+
+## Quotes
+
+> "After seeing eleven of the top fifteen insurance companies, ten of the top fifteen wealth management companies, and high tech companies like salesforce.com, Microsoft, HP, NetSuite, and LinkedIn all standardise on DocuSign in hundreds of departments and use cases, I had to join the industry leader."
+> Attributed to: Eitan Saban, APAC General Manager, DocuSign
+> Source: IDM Magazine (https://idm.net.au/article/009760-docusign-heads-downunder)
+> Place after section: entry-strategy
+
+> "A lot of our customers - at the moment - have been running off our European data centers, mainly because the patriot act in the US doesn't make sense for our Australian customers."
+> Attributed to: Brad Newton, APAC Vice President, DocuSign
+> Source: IT Brief Australia (https://itbrief.com.au/story/docusign-launches-three-new-data-centre-locations-australia)
+> Place after section: challenges-faced
+
+> "The fantastic news now is that any new customer that buys DocuSign in Australia is established onshore, which will be a great thing for both parties."
+> Attributed to: Brad Newton, APAC Vice President, DocuSign
+> Source: IT Brief Australia (https://itbrief.com.au/story/docusign-launches-three-new-data-centre-locations-australia)
+> Place after section: success-factors
+
+> "The Federal Government is focused on delivering data accessibility and unmatched privacy to its internal and external stakeholders—and we believe that preparing, sharing, signing and managing agreements is a key part of this."
+> Attributed to: Brad Newton, Vice President, ANZ, DocuSign
+> Source: GovTechReview (https://www.govtechreview.com.au/content/gov-datacentre/news/docusign-launches-australian-data-centres-730674429)
+> Place after section: entry-strategy
+
+> "We now use Docusign for over 95% of loans."
+> Attributed to: Tim Roberts, Executive Manager, Digitisation, Commonwealth Bank of Australia
+> Source: DocuSign Customer Stories (https://www.docusign.com/en-au/customer-stories/docusign-helps-cba-accelerate-its-digital-strategy)
+> Place after section: key-metrics
+
+> "Some of our commercial lending deals involve 20 different documents. There might be five or six different envelopes that need sending to different combinations of borrowers and guarantors. It's a complex process that could take considerable time, now it takes just hours with Docusign."
+> Attributed to: Tim Roberts, Executive Manager, Digitisation, Commonwealth Bank of Australia
+> Source: DocuSign Customer Stories (https://www.docusign.com/en-au/customer-stories/docusign-helps-cba-accelerate-its-digital-strategy)
+> Place after section: success-factors

--- a/.claude/staging/openai-australia-market-entry.md
+++ b/.claude/staging/openai-australia-market-entry.md
@@ -1,0 +1,75 @@
+# openai-australia-market-entry: Backfill Staging
+
+**Pilot:** Batch 1 of 4 (study 2 of 10)
+**Researched by:** Stephen Browne
+**last_verified_at:** 2026-05-04
+
+---
+
+## TLDR
+
+- Sydney office announced August 28, 2025; opened December 2025
+- COO Brad Lightcap led announcement; no AU country manager named publicly
+- Customers: CommBank, Canva, Atlassian, Coles, Wesfarmers, Fortescue
+- A$7B NEXTDC sovereign AI campus partnership at Eastern Creek
+- ChatGPT weekly active users in Australia grew 2.5x year-on-year
+
+## Quick Facts
+
+- ANZ Entry Date | 28 August 2025 (announced) | Calendar
+- AU Public Policy Lead | Brent Thomas (ex-Tech Council) | User
+- AU HQ City | Sydney | MapPin
+- AU Customers | CommBank, Canva, Atlassian, Coles, Wesfarmers | Building
+- Infrastructure Partner | NEXTDC – A$7B AI campus, Eastern Creek | Network
+- Origin | San Francisco, USA | Globe2
+
+## Hero
+
+URL: TBD
+Alt: TBD
+Credit: TBD
+
+## Sources
+
+1. OpenAI — Introducing OpenAI for Australia | https://openai.com/global-affairs/openai-for-australia/ | company_blog
+2. B&T — OpenAI Opens First Australian Office | https://www.bandt.com.au/openai-opens-first-australian-office/ | news
+3. Marketing-Interactive — OpenAI to open Sydney office as ChatGPT adoption surges | https://www.marketing-interactive.com/openai-to-open-sydney-office-as-chatgpt-adoption-surges | news
+4. Marketing-Interactive — OpenAI opens first Australian office, local leadership details under wraps | https://www.marketing-interactive.com/openai-opens-first-australian-office-local-leadership-details-under-wraps | news
+5. SmartCompany — OpenAI courts Australian startups alongside Sydney office debut | https://www.smartcompany.com.au/artificial-intelligence/openai-australia-startup-program-sydney-office/ | news
+6. CommBank Newsroom — CommBank and OpenAI Australia-First Strategic Partnership | https://www.commbank.com.au/articles/newsroom/2025/08/tech-ai-partnership.html | press_release
+7. NSW Government — Minns Labor Government welcomes OpenAI's investment to NSW | https://www.nsw.gov.au/ministerial-releases/minns-labor-government-welcomes-openais-investment-to-nsw | government
+8. NEXTDC — Building the Next Generation of Sovereign AI Infrastructure in Australia | https://www.nextdc.com/news/building-the-next-generation-of-sovereign-ai-infrastructure-in-australia | press_release
+9. Information Age (ACS) — OpenAI, NEXTDC ink $7B Australian data centre deal | https://ia.acs.org.au/article/2025/openai--nextdc-ink--7b-australian-data-centre-deal.html | news
+10. ChannelLife — OpenAI hires Brent Thomas to lead public policy in ANZ | https://channellife.com.au/story/openai-hires-brent-thomas-to-lead-public-policy-in-anz | news
+
+## Quotes
+
+> "Australia's government, businesses and world-class developer ecosystem are already shaping the future of AI."
+> Attributed to: Brad Lightcap, Chief Operating Officer, OpenAI
+> Source: Marketing-Interactive (https://www.marketing-interactive.com/openai-to-open-sydney-office-as-chatgpt-adoption-surges)
+> Place after section: entry-strategy
+
+> "We're excited to expand our presence in Australia and build a local team to work closely with partners, customers and the millions of Australians who use ChatGPT daily."
+> Attributed to: Brad Lightcap, Chief Operating Officer, OpenAI
+> Source: Marketing-Interactive (https://www.marketing-interactive.com/openai-to-open-sydney-office-as-chatgpt-adoption-surges)
+> Place after section: entry-strategy
+
+> "Australia is well-placed to lead the world in AI. It has a history of early technology adoption, a world-class developer community, and a clear ambition to lift productivity."
+> Attributed to: Jason Kwon, Chief Strategy Officer, OpenAI
+> Source: B&T (https://www.bandt.com.au/openai-opens-first-australian-office/)
+> Place after section: success-factors
+
+> "Sydney is Australia's digital capital, backed by world-class talent and strong government investment – and OpenAI's arrival here takes that even further."
+> Attributed to: Daniel Mookhey, NSW Treasurer
+> Source: B&T (https://www.bandt.com.au/openai-opens-first-australian-office/)
+> Place after section: success-factors
+
+> "Our strategic partnership with OpenAI reflects our commitment to bringing world class capabilities to Australia."
+> Attributed to: Matt Comyn, CEO, Commonwealth Bank of Australia
+> Source: CommBank Newsroom (https://www.commbank.com.au/articles/newsroom/2025/08/tech-ai-partnership.html)
+> Place after section: key-metrics
+
+> "To be globally competitive, Australia must embrace this new era of rapid technological change."
+> Attributed to: Matt Comyn, CEO, Commonwealth Bank of Australia
+> Source: CommBank Newsroom (https://www.commbank.com.au/articles/newsroom/2025/08/tech-ai-partnership.html)
+> Place after section: lessons-learned

--- a/.claude/staging/servicenow-australia-market-entry.md
+++ b/.claude/staging/servicenow-australia-market-entry.md
@@ -1,0 +1,74 @@
+# servicenow-australia-market-entry: Backfill Staging
+
+**Pilot:** Batch 1 of 4 (study 5 of 10)
+**Researched by:** Stephen Browne
+**last_verified_at:** 2026-05-04
+
+---
+
+## TLDR
+
+- ServiceNow opened APAC support centre in Sydney, March 2014
+- David Oakley led ANZ ~8 years until 2019; Eric Swift succeeded
+- Major AU customers include Telstra, NAB, and the DTA
+- Offices now in Sydney, Melbourne, Canberra, Brisbane, Perth
+- Founded Santa Clara, USA; ANZ HQ at 680 George St Sydney
+
+## Quick Facts
+
+- ANZ Entry / Sydney Centre Live | March 2014 | Calendar
+- AU MD (long-tenured) | David Oakley (~8 yrs to 2019) | User
+- AU HQ | Sydney, 680 George St | MapPin
+- Other AU Offices | Melbourne, Canberra, Brisbane, Perth | Building
+- AU Customers | Telstra, NAB, DTA, Canberra Health Services | Users
+- Origin | Santa Clara, USA | Globe2
+
+## Hero
+
+URL: TBD
+Alt: TBD
+Credit: TBD
+
+## Sources
+
+1. ARN — ServiceNow to open APAC support centre in Sydney | https://www.arnnet.com.au/article/533070/servicenow_open_apac_support_centre_sydney/ | news
+2. ChannelLife AU — ServiceNow holds ANZ Partner Summit in newly opened Sydney office | https://channellife.com.au/story/servicenow-holds-nz-partner-summit-newly-opened-sydney-office | news
+3. ARN — ServiceNow appoints Microsoft veteran Eric Swift to lead A/NZ | https://www.arnnet.com.au/article/687849/servicenow-appoints-microsoft-veteran-eric-swift-lead-nz/ | news
+4. CIO — Doing business with David Oakley of ServiceNow | https://www.cio.com/article/3509002/doing-business-with-david-oakley-of-servicenow-digital-disruption-is-a-silicon-valley-term-for-final.html | interview
+5. ChannelLife NZ — ServiceNow ramps up Kiwi focus with first local country manager | https://channellife.co.nz/story/servicenow-ramps-kiwi-focus-first-local-country-manager | news
+6. ServiceNow — DTA customer story (BuyICT) | https://www.servicenow.com/customers/dta.html | company_blog
+7. ServiceNow — National Australia Bank customer story | https://www.servicenow.com/customers/nab.html | company_blog
+8. iTnews — Inside Telstra's effort to slash NBN complaint wait times | https://www.itnews.com.au/news/inside-telstras-effort-to-slash-nbn-complaint-wait-times-481205 | news
+9. ServiceNow — Office Locations (Australia) | https://www.servicenow.com/au/company/locations.html | company_blog
+
+## Quotes
+
+> "We save organisations time and money by automating their essential tasks and processes to reduce human intervention, eliminating bottlenecks and delivering better service experiences."
+> Attributed to: David Oakley, Managing Director, ANZ, ServiceNow
+> Source: CIO (https://www.cio.com/article/3509002/doing-business-with-david-oakley-of-servicenow-digital-disruption-is-a-silicon-valley-term-for-final.html)
+> Place after section: entry-strategy
+
+> "ServiceNow has a strong and loyal customer base in New Zealand and with our growing success in this market the timing is right to double down and accelerate the journey."
+> Attributed to: David Oakley, Managing Director, ANZ, ServiceNow
+> Source: ChannelLife NZ (https://channellife.co.nz/story/servicenow-ramps-kiwi-focus-first-local-country-manager)
+> Place after section: success-factors
+
+> "Get out and engage with the market – visit other organisations to see and touch what they're doing."
+> Attributed to: David Oakley, Managing Director, ANZ, ServiceNow
+> Source: CIO (https://www.cio.com/article/3509002/doing-business-with-david-oakley-of-servicenow-digital-disruption-is-a-silicon-valley-term-for-final.html)
+> Place after section: lessons-learned
+
+> "For one of our staff to interact with an NBN fixed line customer, historically they would have to interact with nine different systems."
+> Attributed to: John Romano, CIO, Telstra
+> Source: iTnews (https://www.itnews.com.au/news/inside-telstras-effort-to-slash-nbn-complaint-wait-times-481205)
+> Place after section: challenges-faced
+
+> "The government procurement space is complex. ServiceNow helps us build a platform that is simple, fair, and fast to manage buying and selling, and also comply with rules and legislation."
+> Attributed to: Anthony Conway, Product Manager and Director, Digital Sourcing Platforms, DTA
+> Source: ServiceNow Customer Story (https://www.servicenow.com/customers/dta.html)
+> Place after section: key-metrics
+
+> "We have seen an 82% increase in contract value, from AUD700 million to almost AUD3.9 billion in 2021."
+> Attributed to: Anthony Conway, Product Manager and Director, Digital Sourcing Platforms, DTA
+> Source: ServiceNow Customer Story (https://www.servicenow.com/customers/dta.html)
+> Place after section: key-metrics

--- a/.claude/staging/snowflake-australia-market-entry.md
+++ b/.claude/staging/snowflake-australia-market-entry.md
@@ -1,0 +1,74 @@
+# snowflake-australia-market-entry: Backfill Staging
+
+**Pilot:** Batch 1 of 4 (study 3 of 10)
+**Researched by:** Stephen Browne
+**last_verified_at:** 2026-05-04
+
+---
+
+## TLDR
+
+- Snowflake opened Sydney/Melbourne offices in February 2018
+- Peter O'Connor became APAC VP Sales, first APJ hire (2017)
+- AWS Sydney deployment announced September 2017, live early 2018
+- Aussie customers: Carsales, Domain, Bunnings, Judo Bank, Coles
+- Distinguishing move: data sovereignty plus partner-led ANZ ecosystem
+
+## Quick Facts
+
+- ANZ Entry Year | 2017–2018 | Calendar
+- APAC VP / Country Lead | Peter O'Connor | User
+- AU HQ City | Sydney (plus Melbourne) | MapPin
+- AU Customers | Carsales, Domain, Bunnings, Judo Bank | Building
+- AWS Sydney Deployment | Sept 2017 announced | Globe2
+- Origin | San Mateo, USA | Briefcase
+
+## Hero
+
+URL: TBD
+Alt: TBD
+Credit: TBD
+
+## Sources
+
+1. ComputerWeekly — Snowflake making headway in Australia | https://www.computerweekly.com/news/252448438/Snowflake-making-headway-in-Australia | news
+2. PR Wire — Snowflake Computing Accelerates APJ Expansion with Sydney and Melbourne Office Launch | https://prwire.com.au/pr/75557/snowflake-computing-accelerates-apj-expansion-with-sydney-and-melbourne-office-launch-and-two-senior-executive-appointments | press_release
+3. Intelligent CIO APAC — Get to Know: Peter O'Connor of Snowflake | https://www.intelligentcio.com/apac/2020/07/31/get-to-know-peter-oconnor-of-snowflake/ | interview
+4. ChannelLife — Snowflake honours top tier Aussie partners | https://channellife.com.au/story/snowflake-honours-top-tier-aussie-partners | news
+5. ChannelLife — 10 Minute IT Jams: Who is Snowflake? | https://channellife.com.au/story/video-10-minute-it-jams-who-is-snowflake | interview
+6. PR Newswire — Snowflake Continues Global Expansion With Australian Data Center Deployment | https://www.prnewswire.com/news-releases/snowflake-continues-global-expansion-with-australian-data-center-deployment-300518145.html | press_release
+7. iTnews — Carsales drives real time data | https://www.itnews.com.au/news/carsales-drives-real-time-data-599862 | news
+8. ComputerWeekly — Snowflake brings AI to data for Australian businesses | https://www.computerweekly.com/news/366615242/Snowflake-brings-AI-to-data-for-Australian-businesses | news
+9. GovTechReview — Interview: Peter O'Connor, Snowflake | https://www.govtechreview.com.au/content/gov-digital/article/interview-peter-o-connor-snowflake-764003577 | interview
+
+## Quotes
+
+> "When I joined Snowflake in 2017, I had the great fortune of being its first employee in Asia Pacific."
+> Attributed to: Peter O'Connor, Vice President of Sales, Asia Pacific, Snowflake
+> Source: Intelligent CIO APAC (https://www.intelligentcio.com/apac/2020/07/31/get-to-know-peter-oconnor-of-snowflake/)
+> Place after section: entry-strategy
+
+> "Changing rules around data sovereignty is also a big issue. Most governments these days are wanting data that's generated in-country to stay in-country."
+> Attributed to: Peter O'Connor, Vice President of Sales, Asia Pacific, Snowflake
+> Source: Intelligent CIO APAC (https://www.intelligentcio.com/apac/2020/07/31/get-to-know-peter-oconnor-of-snowflake/)
+> Place after section: challenges-faced
+
+> "Snowflake today runs on both AWS and Azure in Australia, which obviously covers the Australia and New Zealand market."
+> Attributed to: Peter O'Connor, Vice President of Sales, Asia Pacific, Snowflake
+> Source: ChannelLife Australia (https://channellife.com.au/story/video-10-minute-it-jams-who-is-snowflake)
+> Place after section: success-factors
+
+> "This past year has been a particularly successful one for Snowflake in ANZ and we recognise the role our partners have played in achieving market momentum."
+> Attributed to: Peter O'Connor, APAC Sales Vice President, Snowflake
+> Source: ChannelLife Australia (https://channellife.com.au/story/snowflake-honours-top-tier-aussie-partners)
+> Place after section: success-factors
+
+> "By providing an Australian deployment, Snowflake enables customers with Australian data to keep that information close to home."
+> Attributed to: Bob Muglia, CEO, Snowflake Computing
+> Source: PR Newswire (https://www.prnewswire.com/news-releases/snowflake-continues-global-expansion-with-australian-data-center-deployment-300518145.html)
+> Place after section: entry-strategy
+
+> "The combined experience which Peter and Alan bring to Snowflake in the Asia Pacific region will be crucial to accelerating our market presence in the data sharing economy."
+> Attributed to: Chris Degnan, Chief Revenue Officer, Snowflake
+> Source: PR Wire Australia (https://prwire.com.au/pr/75557/snowflake-computing-accelerates-apj-expansion-with-sydney-and-melbourne-office-launch-and-two-senior-executive-appointments)
+> Place after section: entry-strategy

--- a/.claude/staging/twilio-australia-market-entry.md
+++ b/.claude/staging/twilio-australia-market-entry.md
@@ -1,0 +1,64 @@
+# twilio-australia-market-entry: Backfill Staging
+
+**Pilot:** Batch 1 of 4 (study 7 of 10)
+**Researched by:** Stephen Browne
+**last_verified_at:** 2026-05-04
+
+---
+
+## TLDR
+
+- Twilio opened first Australian offices in April 2018
+- Sydney HQ plus Melbourne office launched simultaneously
+- Richard Watson appointed first AU country director
+- Early AU customers: Atlassian, Domino's, Airtasker, zipMoney
+- SIGNAL Sydney 2025 marked sold-out APJ debut event
+
+## Quick Facts
+
+- ANZ Entry Year | April 2018 | Calendar
+- First AU Country Director | Richard Watson | User
+- AU Offices | Sydney and Melbourne | MapPin
+- AU Customers | Atlassian, Domino's, Airtasker, zipMoney, Lendi | Building
+- International Office No. | 11th outside the US | Globe2
+- Origin | San Francisco, USA | Briefcase
+
+## Hero
+
+URL: TBD
+Alt: TBD
+Credit: TBD
+
+## Sources
+
+1. Twilio Press Release — Twilio Establishes Presence in Australia | https://www.twilio.com/en-us/press/releases/cloud-communications-platform-twilio-establishes-presence-in-australia-and-appoints-new-regional-director | press_release
+2. SmartCompany — Silicon Valley giant Twilio opens two offices in Australia | https://www.smartcompany.com.au/startupsmart/news/cloud-communications-giant-twilio-opens-two-offices-in-australia/ | news
+3. ChannelLife AU — Twilio boosts local presence with first Aussie office | https://channellife.com.au/story/twilio-boosts-local-presence-first-aussie-office | news
+4. Startup Daily — Twilio opens Australian office to push growth | https://www.startupdaily.net/topic/cloud-communications-provider-twilio-opens-australian-office-push-growth/ | news
+5. ARN — Twilio makes Aussie push with former Symantec channel talent | https://www.arnnet.com.au/article/1265899/twilio-makes-aussie-push-with-former-symantec-channel-talent.html | news
+6. Twilio Blog — SIGNAL Sydney 2025: A Sold-out Debut on the Harbour | https://www.twilio.com/en-us/blog/events/signal-sydney-2025-recap | company_blog
+7. Twilio Blog — Welcome to the Builder's Arcade at SIGNAL Sydney 2025 | https://www.twilio.com/en-us/blog/events/twilio-builders-arcade-syd25 | company_blog
+8. SIGNAL Sydney 2025 Event Page | https://signal.twilio.com/sydney2025 | company_blog
+9. M Moser Associates — Twilio Sydney Office Project | https://www.mmoser.com/projects/twilio-sydney/ | other
+
+## Quotes
+
+> "We have had a fantastic amount of organic traction here in Australia, with leading companies including Atlassian, zipMoney, Domino's and Airtasker already building and scaling their applications using the Twilio platform."
+> Attributed to: Richard Watson, Country Director, Australia, Twilio
+> Source: ChannelLife Australia (https://channellife.com.au/story/twilio-boosts-local-presence-first-aussie-office)
+> Place after section: entry-strategy
+
+> "This is a testament to the quality of Twilio's product offering and also to the maturity of the Australian market."
+> Attributed to: Richard Watson, Country Director, Australia, Twilio
+> Source: ChannelLife Australia (https://channellife.com.au/story/twilio-boosts-local-presence-first-aussie-office)
+> Place after section: success-factors
+
+> "Engagement between businesses and their customers continues to be a pain point and I believe Twilio will go a long way to help solve this problem."
+> Attributed to: Richard Watson, Country Director, Australia, Twilio
+> Source: ChannelLife Australia (https://channellife.com.au/story/twilio-boosts-local-presence-first-aussie-office)
+> Place after section: lessons-learned
+
+> "International expansion represents a significant long-term growth opportunity for Twilio. This move builds on our existing customer and developer momentum in Australia."
+> Attributed to: George Hu, Chief Operating Officer, Twilio
+> Source: ARN Australia (https://www.arnnet.com.au/article/1265899/twilio-makes-aussie-push-with-former-symantec-channel-talent.html)
+> Place after section: entry-strategy

--- a/supabase/migrations/20260504130300_backfill_anthropic_au.sql
+++ b/supabase/migrations/20260504130300_backfill_anthropic_au.sql
@@ -1,0 +1,93 @@
+-- Phase 5.3 Batch 1 (1/10): Anthropic AU market entry backfill
+-- Idempotent. Hero left NULL pending verifiable brand asset.
+-- Source provenance: .claude/staging/anthropic-australia-market-entry.md
+
+DO $$
+DECLARE
+  v_case_study_id      uuid;
+  v_sec_entry          uuid;
+  v_sec_success        uuid;
+  v_sec_metrics        uuid;
+  v_sec_lessons        uuid;
+BEGIN
+  SELECT id INTO v_case_study_id
+  FROM public.content_items
+  WHERE slug = 'anthropic-australia-market-entry';
+  IF v_case_study_id IS NULL THEN
+    RAISE EXCEPTION 'anthropic-australia-market-entry not found';
+  END IF;
+
+  SELECT id INTO v_sec_entry   FROM public.content_sections
+   WHERE content_id = v_case_study_id AND slug = 'entry-strategy';
+  SELECT id INTO v_sec_success FROM public.content_sections
+   WHERE content_id = v_case_study_id AND slug = 'success-factors';
+  SELECT id INTO v_sec_metrics FROM public.content_sections
+   WHERE content_id = v_case_study_id AND slug = 'key-metrics';
+  SELECT id INTO v_sec_lessons FROM public.content_sections
+   WHERE content_id = v_case_study_id AND slug = 'lessons-learned';
+
+  UPDATE public.content_items
+  SET
+    tldr = ARRAY[
+      'Sydney office officially opened 28 April 2026',
+      'Theo Hourmouzis named GM ANZ from Snowflake',
+      'Customers include Commonwealth Bank, Quantium, Canva, Xero',
+      'Claude 3.5 Sonnet live in AWS Sydney region',
+      'Federal MOU signed for AI safety collaboration'
+    ],
+    quick_facts = '[
+      {"label": "ANZ Office Launch", "value": "28 April 2026",                    "icon": "Calendar"},
+      {"label": "GM ANZ",            "value": "Theo Hourmouzis (ex-Snowflake)",   "icon": "User"},
+      {"label": "AU HQ",             "value": "Sydney, NSW",                      "icon": "MapPin"},
+      {"label": "AU Customers",      "value": "CommBank, Quantium, Canva, Xero",  "icon": "Building"},
+      {"label": "Data Residency",    "value": "Claude on AWS Sydney",             "icon": "Shield"},
+      {"label": "Origin",            "value": "San Francisco, USA",               "icon": "Globe2"}
+    ]'::jsonb,
+    last_verified_at = '2026-05-04T00:00:00Z'::timestamptz,
+    researched_by    = 'Stephen Browne',
+    style_version    = 2
+  WHERE id = v_case_study_id;
+
+  DELETE FROM public.case_study_sources WHERE case_study_id = v_case_study_id;
+  INSERT INTO public.case_study_sources
+    (case_study_id, label, url, accessed_at, source_type, citation_number) VALUES
+    (v_case_study_id, 'Anthropic — Sydney will become Anthropic''s fourth office in Asia-Pacific', 'https://www.anthropic.com/news/sydney-fourth-office-asia-pacific', '2026-05-04', 'company_blog', 1),
+    (v_case_study_id, 'Anthropic — Theo Hourmouzis to lead Anthropic in Australia and New Zealand', 'https://www.anthropic.com/news/theo-hourmouzis-general-manager-australia-new-zealand', '2026-05-04', 'press_release', 2),
+    (v_case_study_id, 'Anthropic — Australian Government and Anthropic sign MOU', 'https://www.anthropic.com/news/australia-MOU', '2026-05-04', 'press_release', 3),
+    (v_case_study_id, 'Department of Industry, Science and Resources — MOU with Anthropic', 'https://www.industry.gov.au/news/australian-government-has-signed-memorandum-understanding-mou-global-ai-innovator-anthropic', '2026-05-04', 'government', 4),
+    (v_case_study_id, 'ITBrief AU — Anthropic opens Sydney office, names NZ & Australia chief', 'https://itbrief.com.au/story/anthropic-opens-sydney-office-names-nz-australia-chief', '2026-05-04', 'news', 5),
+    (v_case_study_id, 'Marketing-Interactive — Anthropic appoints Hourmouzis as Sydney office officially opens', 'https://www.marketing-interactive.com/anthropic-appoints-theo-hourmouzis-to-lead-anz-as-sydney-office-officially-opens', '2026-05-04', 'news', 6),
+    (v_case_study_id, 'Mumbrella — Anthropic appoints GM for ANZ and opens Sydney office', 'https://mumbrella.com.au/anthropic-appoints-gm-for-anz-and-opens-sydney-office-921617', '2026-05-04', 'news', 7),
+    (v_case_study_id, 'EdTech Innovation Hub — Anthropic touches down in Sydney with Hourmouzis', 'https://www.edtechinnovationhub.com/news/anthropic-touches-down-in-sydney-with-former-snowflake-vp-theo-hourmouzis-at-the-helm', '2026-05-04', 'news', 8),
+    (v_case_study_id, 'AWS — Claude 3.5 Sonnet now available in AWS Sydney Region', 'https://aws.amazon.com/about-aws/whats-new/2025/02/anthropics-upgraded-claude-3-5-sonnet-sydney-region/', '2026-05-04', 'press_release', 9),
+    (v_case_study_id, 'ARN — Anthropic opens in Sydney with Hourmouzis at the helm', 'https://www.arnnet.com.au/article/4163981/anthropic-opens-in-sydney-with-theo-hourmouzis-at-the-helm.html', '2026-05-04', 'news', 10);
+
+  DELETE FROM public.case_study_quotes WHERE case_study_id = v_case_study_id;
+  INSERT INTO public.case_study_quotes
+    (case_study_id, section_id, quote, attributed_to, role, source_url, source_label, display_order) VALUES
+    (v_case_study_id, v_sec_entry,
+     'Organisations across Australia and New Zealand are thinking carefully about how to adopt AI and they want partners who take safety and rigor as seriously as they take the opportunity. That''s what drew me to Anthropic.',
+     'Theo Hourmouzis', 'General Manager, Australia and New Zealand, Anthropic',
+     'https://www.marketing-interactive.com/anthropic-appoints-theo-hourmouzis-to-lead-anz-as-sydney-office-officially-opens',
+     'Marketing-Interactive', 1),
+    (v_case_study_id, v_sec_success,
+     'Theo''s appointment reflects the conviction we share with the Australian government that AI can drive economic growth when it''s developed and deployed responsibly.',
+     'Chris Ciauri', 'Managing Director of International, Anthropic',
+     'https://itbrief.com.au/story/anthropic-opens-sydney-office-names-nz-australia-chief',
+     'ITBrief AU', 2),
+    (v_case_study_id, v_sec_entry,
+     'Establishing a local presence will help us to develop strong partnerships in ANZ and ensure Claude is built with respect for the unique goals, opportunities, and challenges of the region.',
+     'Chris Ciauri', 'Managing Director of International, Anthropic',
+     'https://www.anthropic.com/news/sydney-fourth-office-asia-pacific',
+     'Anthropic', 3),
+    (v_case_study_id, v_sec_lessons,
+     'Australia''s investment in AI safety makes it a natural partner for responsible AI development. This MOU gives our collaboration a formal foundation.',
+     'Dario Amodei', 'CEO, Anthropic',
+     'https://www.anthropic.com/news/australia-MOU',
+     'Anthropic', 4),
+    (v_case_study_id, v_sec_metrics,
+     'The future for us is about Claude becoming embedded infrastructure, a core part of how we run the organisation.',
+     'Devan Seamans', 'Head of Marketing & Technology, YMCA South Australia',
+     'https://itbrief.com.au/story/anthropic-opens-sydney-office-names-nz-australia-chief',
+     'ITBrief AU', 5);
+END $$;

--- a/supabase/migrations/20260504130400_backfill_openai_au.sql
+++ b/supabase/migrations/20260504130400_backfill_openai_au.sql
@@ -1,0 +1,90 @@
+-- Phase 5.3 Batch 1 (2/10): OpenAI AU market entry backfill
+-- Idempotent. Hero left NULL pending verifiable brand asset.
+
+DO $$
+DECLARE
+  v_case_study_id uuid;
+  v_sec_entry     uuid;
+  v_sec_success   uuid;
+  v_sec_metrics   uuid;
+  v_sec_lessons   uuid;
+BEGIN
+  SELECT id INTO v_case_study_id FROM public.content_items
+   WHERE slug = 'openai-australia-market-entry';
+  IF v_case_study_id IS NULL THEN RAISE EXCEPTION 'openai-australia-market-entry not found'; END IF;
+
+  SELECT id INTO v_sec_entry   FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'entry-strategy';
+  SELECT id INTO v_sec_success FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'success-factors';
+  SELECT id INTO v_sec_metrics FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'key-metrics';
+  SELECT id INTO v_sec_lessons FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'lessons-learned';
+
+  UPDATE public.content_items
+  SET
+    tldr = ARRAY[
+      'Sydney office announced August 28, 2025; opened December 2025',
+      'COO Brad Lightcap led announcement; no AU country manager named publicly',
+      'Customers: CommBank, Canva, Atlassian, Coles, Wesfarmers, Fortescue',
+      'A$7B NEXTDC sovereign AI campus partnership at Eastern Creek',
+      'ChatGPT weekly active users in Australia grew 2.5x year-on-year'
+    ],
+    quick_facts = '[
+      {"label": "ANZ Entry Date",   "value": "28 August 2025 (announced)",         "icon": "Calendar"},
+      {"label": "AU Public Policy", "value": "Brent Thomas (ex-Tech Council)",     "icon": "User"},
+      {"label": "AU HQ City",       "value": "Sydney",                             "icon": "MapPin"},
+      {"label": "AU Customers",     "value": "CommBank, Canva, Atlassian, Coles",  "icon": "Building"},
+      {"label": "Infra Partner",    "value": "NEXTDC – A$7B Eastern Creek campus", "icon": "Network"},
+      {"label": "Origin",           "value": "San Francisco, USA",                 "icon": "Globe2"}
+    ]'::jsonb,
+    last_verified_at = '2026-05-04T00:00:00Z'::timestamptz,
+    researched_by    = 'Stephen Browne',
+    style_version    = 2
+  WHERE id = v_case_study_id;
+
+  DELETE FROM public.case_study_sources WHERE case_study_id = v_case_study_id;
+  INSERT INTO public.case_study_sources
+    (case_study_id, label, url, accessed_at, source_type, citation_number) VALUES
+    (v_case_study_id, 'OpenAI — Introducing OpenAI for Australia', 'https://openai.com/global-affairs/openai-for-australia/', '2026-05-04', 'company_blog', 1),
+    (v_case_study_id, 'B&T — OpenAI Opens First Australian Office', 'https://www.bandt.com.au/openai-opens-first-australian-office/', '2026-05-04', 'news', 2),
+    (v_case_study_id, 'Marketing-Interactive — OpenAI to open Sydney office as ChatGPT adoption surges', 'https://www.marketing-interactive.com/openai-to-open-sydney-office-as-chatgpt-adoption-surges', '2026-05-04', 'news', 3),
+    (v_case_study_id, 'Marketing-Interactive — OpenAI opens first Australian office, local leadership details under wraps', 'https://www.marketing-interactive.com/openai-opens-first-australian-office-local-leadership-details-under-wraps', '2026-05-04', 'news', 4),
+    (v_case_study_id, 'SmartCompany — OpenAI courts Australian startups alongside Sydney office debut', 'https://www.smartcompany.com.au/artificial-intelligence/openai-australia-startup-program-sydney-office/', '2026-05-04', 'news', 5),
+    (v_case_study_id, 'CommBank Newsroom — CommBank and OpenAI Australia-First Strategic Partnership', 'https://www.commbank.com.au/articles/newsroom/2025/08/tech-ai-partnership.html', '2026-05-04', 'press_release', 6),
+    (v_case_study_id, 'NSW Government — Minns Labor Government welcomes OpenAI''s investment to NSW', 'https://www.nsw.gov.au/ministerial-releases/minns-labor-government-welcomes-openais-investment-to-nsw', '2026-05-04', 'government', 7),
+    (v_case_study_id, 'NEXTDC — Building the Next Generation of Sovereign AI Infrastructure in Australia', 'https://www.nextdc.com/news/building-the-next-generation-of-sovereign-ai-infrastructure-in-australia', '2026-05-04', 'press_release', 8),
+    (v_case_study_id, 'Information Age (ACS) — OpenAI, NEXTDC ink $7B Australian data centre deal', 'https://ia.acs.org.au/article/2025/openai--nextdc-ink--7b-australian-data-centre-deal.html', '2026-05-04', 'news', 9),
+    (v_case_study_id, 'ChannelLife — OpenAI hires Brent Thomas to lead public policy in ANZ', 'https://channellife.com.au/story/openai-hires-brent-thomas-to-lead-public-policy-in-anz', '2026-05-04', 'news', 10);
+
+  DELETE FROM public.case_study_quotes WHERE case_study_id = v_case_study_id;
+  INSERT INTO public.case_study_quotes
+    (case_study_id, section_id, quote, attributed_to, role, source_url, source_label, display_order) VALUES
+    (v_case_study_id, v_sec_entry,
+     'Australia''s government, businesses and world-class developer ecosystem are already shaping the future of AI.',
+     'Brad Lightcap', 'Chief Operating Officer, OpenAI',
+     'https://www.marketing-interactive.com/openai-to-open-sydney-office-as-chatgpt-adoption-surges',
+     'Marketing-Interactive', 1),
+    (v_case_study_id, v_sec_entry,
+     'We''re excited to expand our presence in Australia and build a local team to work closely with partners, customers and the millions of Australians who use ChatGPT daily.',
+     'Brad Lightcap', 'Chief Operating Officer, OpenAI',
+     'https://www.marketing-interactive.com/openai-to-open-sydney-office-as-chatgpt-adoption-surges',
+     'Marketing-Interactive', 2),
+    (v_case_study_id, v_sec_success,
+     'Australia is well-placed to lead the world in AI. It has a history of early technology adoption, a world-class developer community, and a clear ambition to lift productivity.',
+     'Jason Kwon', 'Chief Strategy Officer, OpenAI',
+     'https://www.bandt.com.au/openai-opens-first-australian-office/',
+     'B&T', 3),
+    (v_case_study_id, v_sec_success,
+     'Sydney is Australia''s digital capital, backed by world-class talent and strong government investment – and OpenAI''s arrival here takes that even further.',
+     'Daniel Mookhey', 'NSW Treasurer',
+     'https://www.bandt.com.au/openai-opens-first-australian-office/',
+     'B&T', 4),
+    (v_case_study_id, v_sec_metrics,
+     'Our strategic partnership with OpenAI reflects our commitment to bringing world class capabilities to Australia.',
+     'Matt Comyn', 'CEO, Commonwealth Bank of Australia',
+     'https://www.commbank.com.au/articles/newsroom/2025/08/tech-ai-partnership.html',
+     'CommBank Newsroom', 5),
+    (v_case_study_id, v_sec_lessons,
+     'To be globally competitive, Australia must embrace this new era of rapid technological change.',
+     'Matt Comyn', 'CEO, Commonwealth Bank of Australia',
+     'https://www.commbank.com.au/articles/newsroom/2025/08/tech-ai-partnership.html',
+     'CommBank Newsroom', 6);
+END $$;

--- a/supabase/migrations/20260504130500_backfill_snowflake_au.sql
+++ b/supabase/migrations/20260504130500_backfill_snowflake_au.sql
@@ -1,0 +1,85 @@
+-- Phase 5.3 Batch 1 (3/10): Snowflake AU market entry backfill
+
+DO $$
+DECLARE
+  v_case_study_id uuid;
+  v_sec_entry     uuid;
+  v_sec_success   uuid;
+  v_sec_challenges uuid;
+BEGIN
+  SELECT id INTO v_case_study_id FROM public.content_items WHERE slug = 'snowflake-australia-market-entry';
+  IF v_case_study_id IS NULL THEN RAISE EXCEPTION 'snowflake-australia-market-entry not found'; END IF;
+
+  SELECT id INTO v_sec_entry      FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'entry-strategy';
+  SELECT id INTO v_sec_success    FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'success-factors';
+  SELECT id INTO v_sec_challenges FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'challenges-faced';
+
+  UPDATE public.content_items
+  SET
+    tldr = ARRAY[
+      'Snowflake opened Sydney/Melbourne offices in February 2018',
+      'Peter O''Connor became APAC VP Sales, first APJ hire (2017)',
+      'AWS Sydney deployment announced September 2017, live early 2018',
+      'Aussie customers: Carsales, Domain, Bunnings, Judo Bank, Coles',
+      'Distinguishing move: data sovereignty plus partner-led ANZ ecosystem'
+    ],
+    quick_facts = '[
+      {"label": "ANZ Entry Year",        "value": "2017–2018",                        "icon": "Calendar"},
+      {"label": "APAC VP / Country Lead","value": "Peter O''Connor",                  "icon": "User"},
+      {"label": "AU HQ City",            "value": "Sydney (plus Melbourne)",          "icon": "MapPin"},
+      {"label": "AU Customers",          "value": "Carsales, Domain, Bunnings, Judo", "icon": "Building"},
+      {"label": "AWS Sydney Deployment", "value": "Sept 2017 announced",              "icon": "Globe2"},
+      {"label": "Origin",                "value": "San Mateo, USA",                   "icon": "Briefcase"}
+    ]'::jsonb,
+    last_verified_at = '2026-05-04T00:00:00Z'::timestamptz,
+    researched_by    = 'Stephen Browne',
+    style_version    = 2
+  WHERE id = v_case_study_id;
+
+  DELETE FROM public.case_study_sources WHERE case_study_id = v_case_study_id;
+  INSERT INTO public.case_study_sources
+    (case_study_id, label, url, accessed_at, source_type, citation_number) VALUES
+    (v_case_study_id, 'ComputerWeekly — Snowflake making headway in Australia', 'https://www.computerweekly.com/news/252448438/Snowflake-making-headway-in-Australia', '2026-05-04', 'news', 1),
+    (v_case_study_id, 'PR Wire — Snowflake Computing Accelerates APJ Expansion with Sydney and Melbourne Office Launch', 'https://prwire.com.au/pr/75557/snowflake-computing-accelerates-apj-expansion-with-sydney-and-melbourne-office-launch-and-two-senior-executive-appointments', '2026-05-04', 'press_release', 2),
+    (v_case_study_id, 'Intelligent CIO APAC — Get to Know: Peter O''Connor of Snowflake', 'https://www.intelligentcio.com/apac/2020/07/31/get-to-know-peter-oconnor-of-snowflake/', '2026-05-04', 'interview', 3),
+    (v_case_study_id, 'ChannelLife — Snowflake honours top tier Aussie partners', 'https://channellife.com.au/story/snowflake-honours-top-tier-aussie-partners', '2026-05-04', 'news', 4),
+    (v_case_study_id, 'ChannelLife — 10 Minute IT Jams: Who is Snowflake?', 'https://channellife.com.au/story/video-10-minute-it-jams-who-is-snowflake', '2026-05-04', 'interview', 5),
+    (v_case_study_id, 'PR Newswire — Snowflake Continues Global Expansion With Australian Data Center Deployment', 'https://www.prnewswire.com/news-releases/snowflake-continues-global-expansion-with-australian-data-center-deployment-300518145.html', '2026-05-04', 'press_release', 6),
+    (v_case_study_id, 'iTnews — Carsales drives real time data', 'https://www.itnews.com.au/news/carsales-drives-real-time-data-599862', '2026-05-04', 'news', 7),
+    (v_case_study_id, 'ComputerWeekly — Snowflake brings AI to data for Australian businesses', 'https://www.computerweekly.com/news/366615242/Snowflake-brings-AI-to-data-for-Australian-businesses', '2026-05-04', 'news', 8),
+    (v_case_study_id, 'GovTechReview — Interview: Peter O''Connor, Snowflake', 'https://www.govtechreview.com.au/content/gov-digital/article/interview-peter-o-connor-snowflake-764003577', '2026-05-04', 'interview', 9);
+
+  DELETE FROM public.case_study_quotes WHERE case_study_id = v_case_study_id;
+  INSERT INTO public.case_study_quotes
+    (case_study_id, section_id, quote, attributed_to, role, source_url, source_label, display_order) VALUES
+    (v_case_study_id, v_sec_entry,
+     'When I joined Snowflake in 2017, I had the great fortune of being its first employee in Asia Pacific.',
+     'Peter O''Connor', 'Vice President of Sales, Asia Pacific, Snowflake',
+     'https://www.intelligentcio.com/apac/2020/07/31/get-to-know-peter-oconnor-of-snowflake/',
+     'Intelligent CIO APAC', 1),
+    (v_case_study_id, v_sec_challenges,
+     'Changing rules around data sovereignty is also a big issue. Most governments these days are wanting data that''s generated in-country to stay in-country.',
+     'Peter O''Connor', 'Vice President of Sales, Asia Pacific, Snowflake',
+     'https://www.intelligentcio.com/apac/2020/07/31/get-to-know-peter-oconnor-of-snowflake/',
+     'Intelligent CIO APAC', 2),
+    (v_case_study_id, v_sec_success,
+     'Snowflake today runs on both AWS and Azure in Australia, which obviously covers the Australia and New Zealand market.',
+     'Peter O''Connor', 'Vice President of Sales, Asia Pacific, Snowflake',
+     'https://channellife.com.au/story/video-10-minute-it-jams-who-is-snowflake',
+     'ChannelLife Australia', 3),
+    (v_case_study_id, v_sec_success,
+     'This past year has been a particularly successful one for Snowflake in ANZ and we recognise the role our partners have played in achieving market momentum.',
+     'Peter O''Connor', 'APAC Sales Vice President, Snowflake',
+     'https://channellife.com.au/story/snowflake-honours-top-tier-aussie-partners',
+     'ChannelLife Australia', 4),
+    (v_case_study_id, v_sec_entry,
+     'By providing an Australian deployment, Snowflake enables customers with Australian data to keep that information close to home.',
+     'Bob Muglia', 'CEO, Snowflake Computing',
+     'https://www.prnewswire.com/news-releases/snowflake-continues-global-expansion-with-australian-data-center-deployment-300518145.html',
+     'PR Newswire', 5),
+    (v_case_study_id, v_sec_entry,
+     'The combined experience which Peter and Alan bring to Snowflake in the Asia Pacific region will be crucial to accelerating our market presence in the data sharing economy.',
+     'Chris Degnan', 'Chief Revenue Officer, Snowflake',
+     'https://prwire.com.au/pr/75557/snowflake-computing-accelerates-apj-expansion-with-sydney-and-melbourne-office-launch-and-two-senior-executive-appointments',
+     'PR Wire Australia', 6);
+END $$;

--- a/supabase/migrations/20260504130600_backfill_databricks_au.sql
+++ b/supabase/migrations/20260504130600_backfill_databricks_au.sql
@@ -1,0 +1,88 @@
+-- Phase 5.3 Batch 1 (4/10): Databricks AU market entry backfill
+
+DO $$
+DECLARE
+  v_case_study_id uuid;
+  v_sec_entry     uuid;
+  v_sec_success   uuid;
+  v_sec_metrics   uuid;
+  v_sec_lessons   uuid;
+BEGIN
+  SELECT id INTO v_case_study_id FROM public.content_items WHERE slug = 'databricks-australia-market-entry';
+  IF v_case_study_id IS NULL THEN RAISE EXCEPTION 'databricks-australia-market-entry not found'; END IF;
+
+  SELECT id INTO v_sec_entry   FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'entry-strategy';
+  SELECT id INTO v_sec_success FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'success-factors';
+  SELECT id INTO v_sec_metrics FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'key-metrics';
+  SELECT id INTO v_sec_lessons FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'lessons-learned';
+
+  UPDATE public.content_items
+  SET
+    tldr = ARRAY[
+      'Sydney office opened June 2020, ANZ country manager November 2019',
+      'Bede Hackney named inaugural ANZ Country Manager, succeeded by Adam Beavis (2023)',
+      'AU customers include Atlassian, Tabcorp, NAB, Sportsbet, Healthdirect',
+      'Lakehouse runs on AWS Sydney region (ap-southeast-2)',
+      'Doubled ANZ headcount to 150+; 70% annual ANZ growth'
+    ],
+    quick_facts = '[
+      {"label": "ANZ Entry Year",  "value": "2019 (CM); 2020 (Sydney office)",     "icon": "Calendar"},
+      {"label": "AU HQ City",      "value": "Sydney, NSW",                         "icon": "MapPin"},
+      {"label": "Country Manager", "value": "Adam Beavis, VP & CM ANZ",            "icon": "User"},
+      {"label": "AU Customers",    "value": "Atlassian, Tabcorp, NAB, Sportsbet",  "icon": "Building"},
+      {"label": "ANZ Growth",      "value": "Doubled to 150+ in 2 years",          "icon": "TrendingUp"},
+      {"label": "Origin",          "value": "San Francisco, USA",                  "icon": "Globe2"}
+    ]'::jsonb,
+    last_verified_at = '2026-05-04T00:00:00Z'::timestamptz,
+    researched_by    = 'Stephen Browne',
+    style_version    = 2
+  WHERE id = v_case_study_id;
+
+  DELETE FROM public.case_study_sources WHERE case_study_id = v_case_study_id;
+  INSERT INTO public.case_study_sources
+    (case_study_id, label, url, accessed_at, source_type, citation_number) VALUES
+    (v_case_study_id, 'Databricks Newsroom — Adam Beavis Appointment as Head of ANZ', 'https://www.databricks.com/company/newsroom/press-releases/databricks-announces-appointment-adam-beavis-head-australia-and-new', '2026-05-04', 'press_release', 1),
+    (v_case_study_id, 'Databricks Newsroom — Databricks Doubles ANZ Headcount', 'https://www.databricks.com/company/newsroom/press-releases/databricks-doubles-anz-headcount-signalling-growing-demand', '2026-05-04', 'press_release', 2),
+    (v_case_study_id, 'Databricks Newsroom — 70% Annual Growth in ANZ Market', 'https://www.databricks.com/company/newsroom/press-releases/databricks-sees-over-70-annual-growth-anz-market-enterprise-ai', '2026-05-04', 'press_release', 3),
+    (v_case_study_id, 'Databricks Newsroom — Deepens APJ Leadership Bench (Mar 2020)', 'https://www.databricks.com/company/newsroom/press-releases/databricks-deepens-leadership-bench-across-asia-pacific-and-japan', '2026-05-04', 'press_release', 4),
+    (v_case_study_id, 'Databricks Newsroom — Momentum Continues in ANZ', 'https://www.databricks.com/company/newsroom/press-releases/databricks-momentum-continues-anz-organisations-demand-more-ai-data', '2026-05-04', 'press_release', 5),
+    (v_case_study_id, 'ARN — Databricks Hires Tenable''s Bede Hackney as A/NZ Leader', 'https://www.arnnet.com.au/article/668514/databricks-hires-tenable-bede-hackney-new-nz-leader/', '2026-05-04', 'news', 6),
+    (v_case_study_id, 'ITBrief AU — Databricks Accelerates APJ Expansion After $250M Round', 'https://itbrief.com.au/story/databricks-accelerates-apj-expansion-following-250-million-funding-round', '2026-05-04', 'news', 7),
+    (v_case_study_id, 'Databricks Customers — Tabcorp Case Study', 'https://www.databricks.com/customers/tabcorp', '2026-05-04', 'company_blog', 8),
+    (v_case_study_id, 'Databricks Customers — Atlassian Security Lakehouse', 'https://www.databricks.com/customers/atlassian/security-lakehouse', '2026-05-04', 'company_blog', 9),
+    (v_case_study_id, 'Databricks Docs — AWS Supported Regions (ap-southeast-2 Sydney)', 'https://docs.databricks.com/aws/en/resources/supported-regions', '2026-05-04', 'other', 10);
+
+  DELETE FROM public.case_study_quotes WHERE case_study_id = v_case_study_id;
+  INSERT INTO public.case_study_quotes
+    (case_study_id, section_id, quote, attributed_to, role, source_url, source_label, display_order) VALUES
+    (v_case_study_id, v_sec_entry,
+     'Databricks is at the centre of all things data. Our customer use cases speak for themselves – from credit card fraud detection to personalised healthcare, we are helping data teams solve the world''s toughest problems.',
+     'Bede Hackney', 'A/NZ Country Manager, Databricks',
+     'https://www.arnnet.com.au/article/668514/databricks-hires-tenable-bede-hackney-new-nz-leader/',
+     'ARN', 1),
+    (v_case_study_id, v_sec_entry,
+     'We''re in a pivotal moment in time where data and AI technologies are evolving rapidly. The companies who succeed in the next five to 10 years will be those who can harness the power of their data and keep up with the pace of innovation.',
+     'Adam Beavis', 'Vice President and Country Manager, Databricks ANZ',
+     'https://www.databricks.com/company/newsroom/press-releases/databricks-announces-appointment-adam-beavis-head-australia-and-new',
+     'Databricks Newsroom', 2),
+    (v_case_study_id, v_sec_success,
+     'As businesses of all sizes look to drive greater insights by leveraging their data, Databricks wants to ensure that they are supported by teams that understand their local needs and requirements.',
+     'Adam Beavis', 'Vice President and Country Manager, Databricks ANZ',
+     'https://www.databricks.com/company/newsroom/press-releases/databricks-doubles-anz-headcount-signalling-growing-demand',
+     'Databricks Newsroom', 3),
+    (v_case_study_id, v_sec_metrics,
+     'Data is a massive enabler for Tabcorp as we raise the game to create more personalised and responsible gambling experiences for our customers.',
+     'Matt McKenzie', 'GM Technology - Strategy, Architecture, Data & Engineering, Tabcorp',
+     'https://www.databricks.com/company/newsroom/press-releases/databricks-doubles-anz-headcount-signalling-growing-demand',
+     'Databricks Newsroom', 4),
+    (v_case_study_id, v_sec_success,
+     'We have worked with Databricks for a number of years to build foundational capabilities for Atlassian''s platform that help us handle data securely.',
+     'Sherif Mansour', 'Head of Product for Atlassian Intelligence',
+     'https://www.databricks.com/company/newsroom/press-releases/databricks-doubles-anz-headcount-signalling-growing-demand',
+     'Databricks Newsroom', 5),
+    (v_case_study_id, v_sec_lessons,
+     'We are powering our data strategy with Databricks'' Lakehouse, driving business-critical use cases including customer 360, fraud detection, and digital personalisation.',
+     'Joanna Gurry', 'Executive, Data Delivery, NAB',
+     'https://www.databricks.com/company/newsroom/press-releases/databricks-doubles-anz-headcount-signalling-growing-demand',
+     'Databricks Newsroom', 6);
+END $$;

--- a/supabase/migrations/20260504130700_backfill_servicenow_au.sql
+++ b/supabase/migrations/20260504130700_backfill_servicenow_au.sql
@@ -1,0 +1,89 @@
+-- Phase 5.3 Batch 1 (5/10): ServiceNow AU market entry backfill
+
+DO $$
+DECLARE
+  v_case_study_id  uuid;
+  v_sec_entry      uuid;
+  v_sec_success    uuid;
+  v_sec_metrics    uuid;
+  v_sec_challenges uuid;
+  v_sec_lessons    uuid;
+BEGIN
+  SELECT id INTO v_case_study_id FROM public.content_items WHERE slug = 'servicenow-australia-market-entry';
+  IF v_case_study_id IS NULL THEN RAISE EXCEPTION 'servicenow-australia-market-entry not found'; END IF;
+
+  SELECT id INTO v_sec_entry      FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'entry-strategy';
+  SELECT id INTO v_sec_success    FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'success-factors';
+  SELECT id INTO v_sec_metrics    FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'key-metrics';
+  SELECT id INTO v_sec_challenges FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'challenges-faced';
+  SELECT id INTO v_sec_lessons    FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'lessons-learned';
+
+  UPDATE public.content_items
+  SET
+    tldr = ARRAY[
+      'ServiceNow opened APAC support centre in Sydney, March 2014',
+      'David Oakley led ANZ ~8 years until 2019; Eric Swift succeeded',
+      'Major AU customers include Telstra, NAB, and the DTA',
+      'Offices now in Sydney, Melbourne, Canberra, Brisbane, Perth',
+      'Founded Santa Clara, USA; ANZ HQ at 680 George St Sydney'
+    ],
+    quick_facts = '[
+      {"label": "ANZ Entry",        "value": "March 2014 (Sydney centre)",        "icon": "Calendar"},
+      {"label": "AU MD",            "value": "David Oakley (~8 yrs to 2019)",     "icon": "User"},
+      {"label": "AU HQ",            "value": "Sydney, 680 George St",             "icon": "MapPin"},
+      {"label": "Other AU Offices", "value": "Melbourne, Canberra, Brisbane, Perth","icon": "Building"},
+      {"label": "AU Customers",     "value": "Telstra, NAB, DTA, ACT Health",     "icon": "Users"},
+      {"label": "Origin",           "value": "Santa Clara, USA",                  "icon": "Globe2"}
+    ]'::jsonb,
+    last_verified_at = '2026-05-04T00:00:00Z'::timestamptz,
+    researched_by    = 'Stephen Browne',
+    style_version    = 2
+  WHERE id = v_case_study_id;
+
+  DELETE FROM public.case_study_sources WHERE case_study_id = v_case_study_id;
+  INSERT INTO public.case_study_sources
+    (case_study_id, label, url, accessed_at, source_type, citation_number) VALUES
+    (v_case_study_id, 'ARN — ServiceNow to open APAC support centre in Sydney', 'https://www.arnnet.com.au/article/533070/servicenow_open_apac_support_centre_sydney/', '2026-05-04', 'news', 1),
+    (v_case_study_id, 'ChannelLife AU — ServiceNow holds ANZ Partner Summit in newly opened Sydney office', 'https://channellife.com.au/story/servicenow-holds-nz-partner-summit-newly-opened-sydney-office', '2026-05-04', 'news', 2),
+    (v_case_study_id, 'ARN — ServiceNow appoints Microsoft veteran Eric Swift to lead A/NZ', 'https://www.arnnet.com.au/article/687849/servicenow-appoints-microsoft-veteran-eric-swift-lead-nz/', '2026-05-04', 'news', 3),
+    (v_case_study_id, 'CIO — Doing business with David Oakley of ServiceNow', 'https://www.cio.com/article/3509002/doing-business-with-david-oakley-of-servicenow-digital-disruption-is-a-silicon-valley-term-for-final.html', '2026-05-04', 'interview', 4),
+    (v_case_study_id, 'ChannelLife NZ — ServiceNow ramps up Kiwi focus with first local country manager', 'https://channellife.co.nz/story/servicenow-ramps-kiwi-focus-first-local-country-manager', '2026-05-04', 'news', 5),
+    (v_case_study_id, 'ServiceNow — DTA customer story (BuyICT)', 'https://www.servicenow.com/customers/dta.html', '2026-05-04', 'company_blog', 6),
+    (v_case_study_id, 'ServiceNow — National Australia Bank customer story', 'https://www.servicenow.com/customers/nab.html', '2026-05-04', 'company_blog', 7),
+    (v_case_study_id, 'iTnews — Inside Telstra''s effort to slash NBN complaint wait times', 'https://www.itnews.com.au/news/inside-telstras-effort-to-slash-nbn-complaint-wait-times-481205', '2026-05-04', 'news', 8),
+    (v_case_study_id, 'ServiceNow — Office Locations (Australia)', 'https://www.servicenow.com/au/company/locations.html', '2026-05-04', 'company_blog', 9);
+
+  DELETE FROM public.case_study_quotes WHERE case_study_id = v_case_study_id;
+  INSERT INTO public.case_study_quotes
+    (case_study_id, section_id, quote, attributed_to, role, source_url, source_label, display_order) VALUES
+    (v_case_study_id, v_sec_entry,
+     'We save organisations time and money by automating their essential tasks and processes to reduce human intervention, eliminating bottlenecks and delivering better service experiences.',
+     'David Oakley', 'Managing Director, ANZ, ServiceNow',
+     'https://www.cio.com/article/3509002/doing-business-with-david-oakley-of-servicenow-digital-disruption-is-a-silicon-valley-term-for-final.html',
+     'CIO', 1),
+    (v_case_study_id, v_sec_success,
+     'ServiceNow has a strong and loyal customer base in New Zealand and with our growing success in this market the timing is right to double down and accelerate the journey.',
+     'David Oakley', 'Managing Director, ANZ, ServiceNow',
+     'https://channellife.co.nz/story/servicenow-ramps-kiwi-focus-first-local-country-manager',
+     'ChannelLife NZ', 2),
+    (v_case_study_id, v_sec_lessons,
+     'Get out and engage with the market – visit other organisations to see and touch what they''re doing.',
+     'David Oakley', 'Managing Director, ANZ, ServiceNow',
+     'https://www.cio.com/article/3509002/doing-business-with-david-oakley-of-servicenow-digital-disruption-is-a-silicon-valley-term-for-final.html',
+     'CIO', 3),
+    (v_case_study_id, v_sec_challenges,
+     'For one of our staff to interact with an NBN fixed line customer, historically they would have to interact with nine different systems.',
+     'John Romano', 'CIO, Telstra',
+     'https://www.itnews.com.au/news/inside-telstras-effort-to-slash-nbn-complaint-wait-times-481205',
+     'iTnews', 4),
+    (v_case_study_id, v_sec_metrics,
+     'The government procurement space is complex. ServiceNow helps us build a platform that is simple, fair, and fast to manage buying and selling, and also comply with rules and legislation.',
+     'Anthony Conway', 'Product Manager and Director, Digital Sourcing Platforms, DTA',
+     'https://www.servicenow.com/customers/dta.html',
+     'ServiceNow Customer Story', 5),
+    (v_case_study_id, v_sec_metrics,
+     'We have seen an 82% increase in contract value, from AUD700 million to almost AUD3.9 billion in 2021.',
+     'Anthony Conway', 'Product Manager and Director, Digital Sourcing Platforms, DTA',
+     'https://www.servicenow.com/customers/dta.html',
+     'ServiceNow Customer Story', 6);
+END $$;

--- a/supabase/migrations/20260504130800_backfill_docusign_au.sql
+++ b/supabase/migrations/20260504130800_backfill_docusign_au.sql
@@ -1,0 +1,88 @@
+-- Phase 5.3 Batch 1 (6/10): DocuSign AU market entry backfill
+
+DO $$
+DECLARE
+  v_case_study_id  uuid;
+  v_sec_entry      uuid;
+  v_sec_success    uuid;
+  v_sec_metrics    uuid;
+  v_sec_challenges uuid;
+BEGIN
+  SELECT id INTO v_case_study_id FROM public.content_items WHERE slug = 'docusign-australia-market-entry';
+  IF v_case_study_id IS NULL THEN RAISE EXCEPTION 'docusign-australia-market-entry not found'; END IF;
+
+  SELECT id INTO v_sec_entry      FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'entry-strategy';
+  SELECT id INTO v_sec_success    FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'success-factors';
+  SELECT id INTO v_sec_metrics    FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'key-metrics';
+  SELECT id INTO v_sec_challenges FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'challenges-faced';
+
+  UPDATE public.content_items
+  SET
+    tldr = ARRAY[
+      'DocuSign opened Sydney APAC office in September 2013',
+      'Brad Newton served six years as APAC Vice President',
+      'CBA, AIA Australia, Adecco named DocuSign customers',
+      'InfoTrack SignIT integration powered Australian e-conveyancing contracts',
+      'Onshore data centres followed IRAP assessment for government compliance'
+    ],
+    quick_facts = '[
+      {"label": "ANZ Entry Year", "value": "2013 (Sydney APAC office)",          "icon": "Calendar"},
+      {"label": "APAC VP",        "value": "Brad Newton (~2015–2021)",            "icon": "User"},
+      {"label": "AU/APAC HQ",     "value": "Sydney, NSW",                         "icon": "MapPin"},
+      {"label": "AU Customers",   "value": "CBA, AIA Australia, Adecco, InfoTrack","icon": "Building"},
+      {"label": "Regulatory",     "value": "IRAP + DTA Cloud Services Panel",     "icon": "Shield"},
+      {"label": "Origin",         "value": "San Francisco, USA",                  "icon": "Globe2"}
+    ]'::jsonb,
+    last_verified_at = '2026-05-04T00:00:00Z'::timestamptz,
+    researched_by    = 'Stephen Browne',
+    style_version    = 2
+  WHERE id = v_case_study_id;
+
+  DELETE FROM public.case_study_sources WHERE case_study_id = v_case_study_id;
+  INSERT INTO public.case_study_sources
+    (case_study_id, label, url, accessed_at, source_type, citation_number) VALUES
+    (v_case_study_id, 'IDM Magazine — DocuSign heads downunder', 'https://idm.net.au/article/009760-docusign-heads-downunder', '2026-05-04', 'news', 1),
+    (v_case_study_id, 'Telecom Times — DocuSign ups Australian market play with local DCs, Sydney as APAC HQ', 'http://telecomtimes.com.au/files/2018/06/17/docusign-steps-up-australian-market-play-flags-first-local-dcs-confirms-sydney-as-apac-hq/', '2026-05-04', 'news', 2),
+    (v_case_study_id, 'ITnews — CBA targets DocuSign for all its commercial loans', 'https://www.itnews.com.au/news/cba-targets-docusign-for-all-its-commercial-loans-578621', '2026-05-04', 'news', 3),
+    (v_case_study_id, 'DocuSign Customer Story — DocuSign helps CBA accelerate its digital strategy', 'https://www.docusign.com/en-au/customer-stories/docusign-helps-cba-accelerate-its-digital-strategy', '2026-05-04', 'company_blog', 4),
+    (v_case_study_id, 'ARN — DocuSign''s Brad Newton takes over as head of Cohesity A/NZ', 'https://www.arnnet.com.au/article/686528/docusign-brad-newton-takes-over-head-cohesity-nz/', '2026-05-04', 'news', 5),
+    (v_case_study_id, 'Cohesity — Cohesity Appoints Brad Newton as Head of ANZ', 'https://www.cohesity.com/newsroom/press/cohesity-appoints-brad-newton-as-head-of-australia-and-new-zealand/', '2026-05-04', 'press_release', 6),
+    (v_case_study_id, 'DocuSign AU Blog — eSignatures a compelling opportunity for the Australian government', 'https://www.docusign.com/en-au/blog/esignatures-a-compelling-opportunity-for-the-australian-government', '2026-05-04', 'company_blog', 7),
+    (v_case_study_id, 'PR Newswire APAC — Docusign plans Australian data centre', 'https://www.prnewswire.com/apac/news-releases/docusign-plans-australian-data-centre-answering-national-push-for-digital-sovereignty-and-data-security-302528681.html', '2026-05-04', 'press_release', 8),
+    (v_case_study_id, 'GovTechReview — DocuSign launches Australian data centres', 'https://www.govtechreview.com.au/content/gov-datacentre/news/docusign-launches-australian-data-centres-730674429', '2026-05-04', 'news', 9),
+    (v_case_study_id, 'IT Brief Australia — DocuSign launches three new data centre locations', 'https://itbrief.com.au/story/docusign-launches-three-new-data-centre-locations-australia', '2026-05-04', 'news', 10);
+
+  DELETE FROM public.case_study_quotes WHERE case_study_id = v_case_study_id;
+  INSERT INTO public.case_study_quotes
+    (case_study_id, section_id, quote, attributed_to, role, source_url, source_label, display_order) VALUES
+    (v_case_study_id, v_sec_entry,
+     'After seeing eleven of the top fifteen insurance companies, ten of the top fifteen wealth management companies, and high tech companies like salesforce.com, Microsoft, HP, NetSuite, and LinkedIn all standardise on DocuSign in hundreds of departments and use cases, I had to join the industry leader.',
+     'Eitan Saban', 'APAC General Manager, DocuSign',
+     'https://idm.net.au/article/009760-docusign-heads-downunder',
+     'IDM Magazine', 1),
+    (v_case_study_id, v_sec_challenges,
+     'A lot of our customers - at the moment - have been running off our European data centers, mainly because the patriot act in the US doesn''t make sense for our Australian customers.',
+     'Brad Newton', 'APAC Vice President, DocuSign',
+     'https://itbrief.com.au/story/docusign-launches-three-new-data-centre-locations-australia',
+     'IT Brief Australia', 2),
+    (v_case_study_id, v_sec_success,
+     'The fantastic news now is that any new customer that buys DocuSign in Australia is established onshore, which will be a great thing for both parties.',
+     'Brad Newton', 'APAC Vice President, DocuSign',
+     'https://itbrief.com.au/story/docusign-launches-three-new-data-centre-locations-australia',
+     'IT Brief Australia', 3),
+    (v_case_study_id, v_sec_entry,
+     'The Federal Government is focused on delivering data accessibility and unmatched privacy to its internal and external stakeholders—and we believe that preparing, sharing, signing and managing agreements is a key part of this.',
+     'Brad Newton', 'Vice President, ANZ, DocuSign',
+     'https://www.govtechreview.com.au/content/gov-datacentre/news/docusign-launches-australian-data-centres-730674429',
+     'GovTechReview', 4),
+    (v_case_study_id, v_sec_metrics,
+     'We now use Docusign for over 95% of loans.',
+     'Tim Roberts', 'Executive Manager, Digitisation, Commonwealth Bank of Australia',
+     'https://www.docusign.com/en-au/customer-stories/docusign-helps-cba-accelerate-its-digital-strategy',
+     'DocuSign Customer Stories', 5),
+    (v_case_study_id, v_sec_success,
+     'Some of our commercial lending deals involve 20 different documents. There might be five or six different envelopes that need sending to different combinations of borrowers and guarantors. It''s a complex process that could take considerable time, now it takes just hours with Docusign.',
+     'Tim Roberts', 'Executive Manager, Digitisation, Commonwealth Bank of Australia',
+     'https://www.docusign.com/en-au/customer-stories/docusign-helps-cba-accelerate-its-digital-strategy',
+     'DocuSign Customer Stories', 6);
+END $$;

--- a/supabase/migrations/20260504130900_backfill_twilio_au.sql
+++ b/supabase/migrations/20260504130900_backfill_twilio_au.sql
@@ -1,0 +1,75 @@
+-- Phase 5.3 Batch 1 (7/10): Twilio AU market entry backfill
+
+DO $$
+DECLARE
+  v_case_study_id uuid;
+  v_sec_entry     uuid;
+  v_sec_success   uuid;
+  v_sec_lessons   uuid;
+BEGIN
+  SELECT id INTO v_case_study_id FROM public.content_items WHERE slug = 'twilio-australia-market-entry';
+  IF v_case_study_id IS NULL THEN RAISE EXCEPTION 'twilio-australia-market-entry not found'; END IF;
+
+  SELECT id INTO v_sec_entry   FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'entry-strategy';
+  SELECT id INTO v_sec_success FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'success-factors';
+  SELECT id INTO v_sec_lessons FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'lessons-learned';
+
+  UPDATE public.content_items
+  SET
+    tldr = ARRAY[
+      'Twilio opened first Australian offices in April 2018',
+      'Sydney HQ plus Melbourne office launched simultaneously',
+      'Richard Watson appointed first AU country director',
+      'Early AU customers: Atlassian, Domino''s, Airtasker, zipMoney',
+      'SIGNAL Sydney 2025 marked sold-out APJ debut event'
+    ],
+    quick_facts = '[
+      {"label": "ANZ Entry Year",       "value": "April 2018",                       "icon": "Calendar"},
+      {"label": "First AU Country Dir", "value": "Richard Watson",                   "icon": "User"},
+      {"label": "AU Offices",           "value": "Sydney and Melbourne",             "icon": "MapPin"},
+      {"label": "AU Customers",         "value": "Atlassian, Domino''s, Airtasker",  "icon": "Building"},
+      {"label": "International Office", "value": "11th outside the US",              "icon": "Globe2"},
+      {"label": "Origin",               "value": "San Francisco, USA",               "icon": "Briefcase"}
+    ]'::jsonb,
+    last_verified_at = '2026-05-04T00:00:00Z'::timestamptz,
+    researched_by    = 'Stephen Browne',
+    style_version    = 2
+  WHERE id = v_case_study_id;
+
+  DELETE FROM public.case_study_sources WHERE case_study_id = v_case_study_id;
+  INSERT INTO public.case_study_sources
+    (case_study_id, label, url, accessed_at, source_type, citation_number) VALUES
+    (v_case_study_id, 'Twilio Press Release — Twilio Establishes Presence in Australia', 'https://www.twilio.com/en-us/press/releases/cloud-communications-platform-twilio-establishes-presence-in-australia-and-appoints-new-regional-director', '2026-05-04', 'press_release', 1),
+    (v_case_study_id, 'SmartCompany — Silicon Valley giant Twilio opens two offices in Australia', 'https://www.smartcompany.com.au/startupsmart/news/cloud-communications-giant-twilio-opens-two-offices-in-australia/', '2026-05-04', 'news', 2),
+    (v_case_study_id, 'ChannelLife AU — Twilio boosts local presence with first Aussie office', 'https://channellife.com.au/story/twilio-boosts-local-presence-first-aussie-office', '2026-05-04', 'news', 3),
+    (v_case_study_id, 'Startup Daily — Twilio opens Australian office to push growth', 'https://www.startupdaily.net/topic/cloud-communications-provider-twilio-opens-australian-office-push-growth/', '2026-05-04', 'news', 4),
+    (v_case_study_id, 'ARN — Twilio makes Aussie push with former Symantec channel talent', 'https://www.arnnet.com.au/article/1265899/twilio-makes-aussie-push-with-former-symantec-channel-talent.html', '2026-05-04', 'news', 5),
+    (v_case_study_id, 'Twilio Blog — SIGNAL Sydney 2025: A Sold-out Debut on the Harbour', 'https://www.twilio.com/en-us/blog/events/signal-sydney-2025-recap', '2026-05-04', 'company_blog', 6),
+    (v_case_study_id, 'Twilio Blog — Welcome to the Builder''s Arcade at SIGNAL Sydney 2025', 'https://www.twilio.com/en-us/blog/events/twilio-builders-arcade-syd25', '2026-05-04', 'company_blog', 7),
+    (v_case_study_id, 'SIGNAL Sydney 2025 Event Page', 'https://signal.twilio.com/sydney2025', '2026-05-04', 'company_blog', 8),
+    (v_case_study_id, 'M Moser Associates — Twilio Sydney Office Project', 'https://www.mmoser.com/projects/twilio-sydney/', '2026-05-04', 'other', 9);
+
+  DELETE FROM public.case_study_quotes WHERE case_study_id = v_case_study_id;
+  INSERT INTO public.case_study_quotes
+    (case_study_id, section_id, quote, attributed_to, role, source_url, source_label, display_order) VALUES
+    (v_case_study_id, v_sec_entry,
+     'We have had a fantastic amount of organic traction here in Australia, with leading companies including Atlassian, zipMoney, Domino''s and Airtasker already building and scaling their applications using the Twilio platform.',
+     'Richard Watson', 'Country Director, Australia, Twilio',
+     'https://channellife.com.au/story/twilio-boosts-local-presence-first-aussie-office',
+     'ChannelLife Australia', 1),
+    (v_case_study_id, v_sec_success,
+     'This is a testament to the quality of Twilio''s product offering and also to the maturity of the Australian market.',
+     'Richard Watson', 'Country Director, Australia, Twilio',
+     'https://channellife.com.au/story/twilio-boosts-local-presence-first-aussie-office',
+     'ChannelLife Australia', 2),
+    (v_case_study_id, v_sec_lessons,
+     'Engagement between businesses and their customers continues to be a pain point and I believe Twilio will go a long way to help solve this problem.',
+     'Richard Watson', 'Country Director, Australia, Twilio',
+     'https://channellife.com.au/story/twilio-boosts-local-presence-first-aussie-office',
+     'ChannelLife Australia', 3),
+    (v_case_study_id, v_sec_entry,
+     'International expansion represents a significant long-term growth opportunity for Twilio. This move builds on our existing customer and developer momentum in Australia.',
+     'George Hu', 'Chief Operating Officer, Twilio',
+     'https://www.arnnet.com.au/article/1265899/twilio-makes-aussie-push-with-former-symantec-channel-talent.html',
+     'ARN Australia', 4);
+END $$;

--- a/supabase/migrations/20260504131000_backfill_aws_au.sql
+++ b/supabase/migrations/20260504131000_backfill_aws_au.sql
@@ -1,0 +1,87 @@
+-- Phase 5.3 Batch 1 (8/10): AWS AU market entry backfill
+
+DO $$
+DECLARE
+  v_case_study_id uuid;
+  v_sec_entry     uuid;
+  v_sec_success   uuid;
+  v_sec_metrics   uuid;
+  v_sec_lessons   uuid;
+BEGIN
+  SELECT id INTO v_case_study_id FROM public.content_items WHERE slug = 'aws-australia-market-entry';
+  IF v_case_study_id IS NULL THEN RAISE EXCEPTION 'aws-australia-market-entry not found'; END IF;
+
+  SELECT id INTO v_sec_entry   FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'entry-strategy';
+  SELECT id INTO v_sec_success FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'success-factors';
+  SELECT id INTO v_sec_metrics FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'key-metrics';
+  SELECT id INTO v_sec_lessons FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'lessons-learned';
+
+  UPDATE public.content_items
+  SET
+    tldr = ARRAY[
+      'AWS launched Sydney region in November 2012, Melbourne January 2023',
+      'Iain Rouse leads ANZ Public Sector; Rianne Van Veldhuizen is ANZ MD',
+      'Customers include CBA, NAB, ANZ, Telstra, Atlassian, Canva',
+      'AU$20B investment announced for 2025–2029 data centre expansion',
+      'Dual-region strategy delivered data sovereignty plus disaster recovery'
+    ],
+    quick_facts = '[
+      {"label": "ANZ Entry Year",          "value": "2012 (Sydney region)",                  "icon": "Calendar"},
+      {"label": "Sydney Region Launch",    "value": "12 November 2012",                      "icon": "MapPin"},
+      {"label": "Melbourne Region Launch", "value": "23 January 2023",                       "icon": "Building"},
+      {"label": "ANZ Leadership",          "value": "Iain Rouse (Public); Van Veldhuizen (MD)","icon": "User"},
+      {"label": "AU Customers",            "value": "CBA, NAB, ANZ, Telstra, Atlassian, Canva","icon": "Users"},
+      {"label": "Investment",              "value": "AU$20B by 2029",                        "icon": "DollarSign"}
+    ]'::jsonb,
+    last_verified_at = '2026-05-04T00:00:00Z'::timestamptz,
+    researched_by    = 'Stephen Browne',
+    style_version    = 2
+  WHERE id = v_case_study_id;
+
+  DELETE FROM public.case_study_sources WHERE case_study_id = v_case_study_id;
+  INSERT INTO public.case_study_sources
+    (case_study_id, label, url, accessed_at, source_type, citation_number) VALUES
+    (v_case_study_id, 'AWS Blog — Now Open AWS Asia Pacific (Melbourne) Region', 'https://aws.amazon.com/blogs/aws/now-open-aws-asia-pacific-melbourne-region-in-australia/', '2026-05-04', 'company_blog', 1),
+    (v_case_study_id, 'Amazon Press — AWS Launches Second Infrastructure Region in Australia', 'https://press.aboutamazon.com/2023/1/aws-launches-second-infrastructure-region-in-australia', '2026-05-04', 'press_release', 2),
+    (v_case_study_id, 'About Amazon AU — AWS Launches Region in Melbourne, Invests $6.8B by 2037', 'https://www.aboutamazon.com.au/aws-launches-aws-region-in-melbourne-invests-6-8-billion-by-2037', '2026-05-04', 'press_release', 3),
+    (v_case_study_id, 'About Amazon — Amazon Investing AU$20B in Australian Data Centres', 'https://www.aboutamazon.com/news/aws/amazon-data-center-investment-in-australia', '2026-05-04', 'press_release', 4),
+    (v_case_study_id, 'Austrade — AWS to Invest A$13.2B in Cloud Infrastructure in Australia', 'https://international.austrade.gov.au/en/news-and-analysis/news/aws-to-invest-13-2-billion-aud-in-cloud-infrastructure-in-australia', '2026-05-04', 'government', 5),
+    (v_case_study_id, 'AWS — Announcing the Asia Pacific (Sydney) Region (2012)', 'https://aws.amazon.com/about-aws/whats-new/2012/11/12/announcing-the-aws-asia-pacific-sydney-region/', '2026-05-04', 'company_blog', 6),
+    (v_case_study_id, 'All Things Distributed — Expanding the Cloud: Sydney Region', 'https://www.allthingsdistributed.com/2012/11/asia-pacifc-sydney-region.html', '2026-05-04', 'company_blog', 7),
+    (v_case_study_id, 'Breaking Defense — A$2B Top Secret Aussie Cloud Deal with AWS', 'https://breakingdefense.com/2024/07/2-billion-aud-deal-for-top-secret-aussie-cloud-with-aws/', '2026-05-04', 'news', 8),
+    (v_case_study_id, 'AWS Local — AWS in Australia', 'https://aws.amazon.com/local/australia/', '2026-05-04', 'company_blog', 9);
+
+  DELETE FROM public.case_study_quotes WHERE case_study_id = v_case_study_id;
+  INSERT INTO public.case_study_quotes
+    (case_study_id, section_id, quote, attributed_to, role, source_url, source_label, display_order) VALUES
+    (v_case_study_id, v_sec_entry,
+     'This planned investment deepens our long-term commitment to supporting the growth and development of Australian organizations of all sizes.',
+     'Matt Garman', 'CEO, AWS',
+     'https://www.aboutamazon.com/news/aws/amazon-data-center-investment-in-australia',
+     'About Amazon', 1),
+    (v_case_study_id, v_sec_metrics,
+     'This is the largest investment our country has seen from a global technology provider, and is an exciting opportunity for Australia to build AI capability.',
+     'Anthony Albanese', 'Prime Minister of Australia',
+     'https://www.aboutamazon.com/news/aws/amazon-data-center-investment-in-australia',
+     'About Amazon', 2),
+    (v_case_study_id, v_sec_success,
+     'Customers around the world are using AWS Regions to leverage advanced technologies, save costs, accelerate innovation, increase speed to market of new products and services, and expand their geographic infrastructure footprint in minutes.',
+     'Rianne Van Veldhuizen', 'Managing Director, AWS Australia and New Zealand',
+     'https://www.aboutamazon.com.au/aws-launches-aws-region-in-melbourne-invests-6-8-billion-by-2037',
+     'About Amazon Australia', 3),
+    (v_case_study_id, v_sec_entry,
+     'Australian citizens expect seamless and personalized access to government services anywhere and anytime. Today''s launch of an AWS Region in Melbourne will be a key enabler for the Victorian government and other public sector customers to help meet this demand.',
+     'Iain Rouse', 'Country Director for Worldwide Public Sector, AWS ANZ',
+     'https://www.aboutamazon.com.au/aws-launches-aws-region-in-melbourne-invests-6-8-billion-by-2037',
+     'About Amazon Australia', 4),
+    (v_case_study_id, v_sec_success,
+     'Locating key banking applications and critical workloads geographically close to our mainframe compute platform will provide lower latency benefits, streamline our disaster recovery procedures, and further increase our resilience.',
+     'Steve Day', 'Chief Technology Officer, NAB',
+     'https://www.aboutamazon.com.au/aws-launches-aws-region-in-melbourne-invests-6-8-billion-by-2037',
+     'About Amazon Australia', 5),
+    (v_case_study_id, v_sec_lessons,
+     'The launch of a second AWS Region in Australia provides even greater resilience and enables more customers to develop cloud-based applications that help fuel economic development across the country.',
+     'Prasad Kalyanaraman', 'Vice President of Infrastructure Services, AWS',
+     'https://international.austrade.gov.au/en/news-and-analysis/news/aws-to-invest-13-2-billion-aud-in-cloud-infrastructure-in-australia',
+     'Austrade', 6);
+END $$;


### PR DESCRIPTION
## Summary

Backfills Tier B readability data (TL;DR, quick facts, sources, quotes, byline) for 8 of 10 US enterprise SaaS market entries:

- **Anthropic** — Sydney office April 2026, Theo Hourmouzis as GM ANZ
- **OpenAI** — Sydney office Aug 2025, NEXTDC A$7B partnership, CommBank
- **Snowflake** — Sydney/Melbourne offices Feb 2018, Peter O'Connor as APAC VP
- **Databricks** — Sydney office June 2020, Adam Beavis as VP/CM ANZ
- **ServiceNow** — APAC support centre March 2014, David Oakley led ANZ ~8 yrs
- **DocuSign** — Sydney APAC office Sept 2013, Brad Newton as APAC VP
- **Twilio** — Sydney + Melbourne April 2018, Richard Watson as first AU country director
- **AWS** — Sydney region 2012, Melbourne region 2023, AU$20B by 2029

Each migration is idempotent (DELETE + INSERT for sources/quotes, UPDATE for content_items), already applied to production via Supabase MCP and verified — every entry has `tldr=5`, `quick_facts=6`, `style_version=2`, `sources` 9–10, `quotes` 4–6.

Hero images intentionally left NULL pending verifiable brand assets — the `HeroImage` component renders nothing when url is null, so pages work unchanged.

## Salesforce + Palantir

Still pending — research agents are running. Will follow in a separate PR.

## Test plan

- [ ] Visit each `/case-studies/<slug>` and confirm: TL;DR shows 5 bullets, quick-facts strip shows 6 facts with Lucide icons, byline shows "Stephen Browne · 4 May 2026", pull-quotes appear inside the right sections, sources list at bottom shows the right number of citations
- [ ] Untouched case studies still render identically (e.g. Canva, any AU origin study) — no regression

https://claude.ai/code/session_01AhPPWhM77SejR69ePuPrV4

---
_Generated by [Claude Code](https://claude.ai/code/session_01AhPPWhM77SejR69ePuPrV4)_