### PR TITLE
Soften case-study backfill guards so Supabase Preview CI passes

### DIFF
--- a/supabase/migrations/20260504130000_backfill_buildkite_pilot.sql
+++ b/supabase/migrations/20260504130000_backfill_buildkite_pilot.sql
@@ -23,7 +23,7 @@ BEGIN
   WHERE slug = 'buildkite-australia-startup';
 
   IF v_case_study_id IS NULL THEN
-    RAISE EXCEPTION 'buildkite-australia-startup case study not found';
+    RETURN;
   END IF;
 
   SELECT id INTO v_section_entry_strategy

--- a/supabase/migrations/20260504130100_backfill_go1_pilot.sql
+++ b/supabase/migrations/20260504130100_backfill_go1_pilot.sql
@@ -22,7 +22,7 @@ BEGIN
   WHERE slug = 'go1-australia-startup';
 
   IF v_case_study_id IS NULL THEN
-    RAISE EXCEPTION 'go1-australia-startup case study not found';
+    RETURN;
   END IF;
 
   SELECT id INTO v_section_entry_strategy   FROM public.content_sections

--- a/supabase/migrations/20260504130200_backfill_zoom_pilot.sql
+++ b/supabase/migrations/20260504130200_backfill_zoom_pilot.sql
@@ -30,7 +30,7 @@ BEGIN
   WHERE slug = 'zoom-australia-market-entry';
 
   IF v_case_study_id IS NULL THEN
-    RAISE EXCEPTION 'zoom-australia-market-entry case study not found';
+    RETURN;
   END IF;
 
   SELECT id INTO v_section_entry_strategy  FROM public.content_sections

--- a/supabase/migrations/20260504130300_backfill_anthropic_au.sql
+++ b/supabase/migrations/20260504130300_backfill_anthropic_au.sql
@@ -14,7 +14,7 @@ BEGIN
   FROM public.content_items
   WHERE slug = 'anthropic-australia-market-entry';
   IF v_case_study_id IS NULL THEN
-    RAISE EXCEPTION 'anthropic-australia-market-entry not found';
+    RETURN;
   END IF;
 
   SELECT id INTO v_sec_entry   FROM public.content_sections

--- a/supabase/migrations/20260504130400_backfill_openai_au.sql
+++ b/supabase/migrations/20260504130400_backfill_openai_au.sql
@@ -11,7 +11,7 @@ DECLARE
 BEGIN
   SELECT id INTO v_case_study_id FROM public.content_items
    WHERE slug = 'openai-australia-market-entry';
-  IF v_case_study_id IS NULL THEN RAISE EXCEPTION 'openai-australia-market-entry not found'; END IF;
+  IF v_case_study_id IS NULL THEN RETURN; END IF;
 
   SELECT id INTO v_sec_entry   FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'entry-strategy';
   SELECT id INTO v_sec_success FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'success-factors';

--- a/supabase/migrations/20260504130500_backfill_snowflake_au.sql
+++ b/supabase/migrations/20260504130500_backfill_snowflake_au.sql
@@ -8,7 +8,7 @@ DECLARE
   v_sec_challenges uuid;
 BEGIN
   SELECT id INTO v_case_study_id FROM public.content_items WHERE slug = 'snowflake-australia-market-entry';
-  IF v_case_study_id IS NULL THEN RAISE EXCEPTION 'snowflake-australia-market-entry not found'; END IF;
+  IF v_case_study_id IS NULL THEN RETURN; END IF;
 
   SELECT id INTO v_sec_entry      FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'entry-strategy';
   SELECT id INTO v_sec_success    FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'success-factors';

--- a/supabase/migrations/20260504130600_backfill_databricks_au.sql
+++ b/supabase/migrations/20260504130600_backfill_databricks_au.sql
@@ -9,7 +9,7 @@ DECLARE
   v_sec_lessons   uuid;
 BEGIN
   SELECT id INTO v_case_study_id FROM public.content_items WHERE slug = 'databricks-australia-market-entry';
-  IF v_case_study_id IS NULL THEN RAISE EXCEPTION 'databricks-australia-market-entry not found'; END IF;
+  IF v_case_study_id IS NULL THEN RETURN; END IF;
 
   SELECT id INTO v_sec_entry   FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'entry-strategy';
   SELECT id INTO v_sec_success FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'success-factors';

--- a/supabase/migrations/20260504130700_backfill_servicenow_au.sql
+++ b/supabase/migrations/20260504130700_backfill_servicenow_au.sql
@@ -10,7 +10,7 @@ DECLARE
   v_sec_lessons    uuid;
 BEGIN
   SELECT id INTO v_case_study_id FROM public.content_items WHERE slug = 'servicenow-australia-market-entry';
-  IF v_case_study_id IS NULL THEN RAISE EXCEPTION 'servicenow-australia-market-entry not found'; END IF;
+  IF v_case_study_id IS NULL THEN RETURN; END IF;
 
   SELECT id INTO v_sec_entry      FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'entry-strategy';
   SELECT id INTO v_sec_success    FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'success-factors';

--- a/supabase/migrations/20260504130800_backfill_docusign_au.sql
+++ b/supabase/migrations/20260504130800_backfill_docusign_au.sql
@@ -9,7 +9,7 @@ DECLARE
   v_sec_challenges uuid;
 BEGIN
   SELECT id INTO v_case_study_id FROM public.content_items WHERE slug = 'docusign-australia-market-entry';
-  IF v_case_study_id IS NULL THEN RAISE EXCEPTION 'docusign-australia-market-entry not found'; END IF;
+  IF v_case_study_id IS NULL THEN RETURN; END IF;
 
   SELECT id INTO v_sec_entry      FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'entry-strategy';
   SELECT id INTO v_sec_success    FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'success-factors';

--- a/supabase/migrations/20260504130900_backfill_twilio_au.sql
+++ b/supabase/migrations/20260504130900_backfill_twilio_au.sql
@@ -8,7 +8,7 @@ DECLARE
   v_sec_lessons   uuid;
 BEGIN
   SELECT id INTO v_case_study_id FROM public.content_items WHERE slug = 'twilio-australia-market-entry';
-  IF v_case_study_id IS NULL THEN RAISE EXCEPTION 'twilio-australia-market-entry not found'; END IF;
+  IF v_case_study_id IS NULL THEN RETURN; END IF;
 
   SELECT id INTO v_sec_entry   FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'entry-strategy';
   SELECT id INTO v_sec_success FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'success-factors';

--- a/supabase/migrations/20260504131000_backfill_aws_au.sql
+++ b/supabase/migrations/20260504131000_backfill_aws_au.sql
@@ -9,7 +9,7 @@ DECLARE
   v_sec_lessons   uuid;
 BEGIN
   SELECT id INTO v_case_study_id FROM public.content_items WHERE slug = 'aws-australia-market-entry';
-  IF v_case_study_id IS NULL THEN RAISE EXCEPTION 'aws-australia-market-entry not found'; END IF;
+  IF v_case_study_id IS NULL THEN RETURN; END IF;
 
   SELECT id INTO v_sec_entry   FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'entry-strategy';
   SELECT id INTO v_sec_success FROM public.content_sections WHERE content_id = v_case_study_id AND slug = 'success-factors';


### PR DESCRIPTION
## Summary

The 11 Phase 5.2 / 5.3 case-study backfill migrations on `main` each guard their work with:

```sql
SELECT id INTO v_case_study_id FROM public.content_items WHERE slug = '<slug>';
IF v_case_study_id IS NULL THEN
  RAISE EXCEPTION '<slug> not found';
END IF;
```

That's been failing the Supabase Preview check on every PR off this repo (#176, #177, #178, #179) — Preview builds a fresh empty DB, runs all migrations, hits Buildkite first, raises, and halts the whole chain. Subsequent backfills never even execute. The PRs were all merged through the red.

This change converts each guard to a no-op `RETURN`. Behaviour:

- **Production:** the rows exist, the migration runs and updates as before. Idempotent re-runs still work.
- **Preview / fresh DBs:** the slug is absent, the migration exits cleanly, subsequent migrations continue.

No data semantics change — the "did the slug exist?" assertion was purely defensive. The actual `UPDATE` and `INSERT … WHERE case_study_id = v_case_study_id` statements would already have been no-ops in the missing-row case. The guards just turned a clean no-op into a thrown exception.

## Files changed (11)

```
supabase/migrations/20260504130000_backfill_buildkite_pilot.sql
supabase/migrations/20260504130100_backfill_go1_pilot.sql
supabase/migrations/20260504130200_backfill_zoom_pilot.sql
supabase/migrations/20260504130300_backfill_anthropic_au.sql
supabase/migrations/20260504130400_backfill_openai_au.sql
supabase/migrations/20260504130500_backfill_snowflake_au.sql
supabase/migrations/20260504130600_backfill_databricks_au.sql
supabase/migrations/20260504130700_backfill_servicenow_au.sql
supabase/migrations/20260504130800_backfill_docusign_au.sql
supabase/migrations/20260504130900_backfill_twilio_au.sql
supabase/migrations/20260504131000_backfill_aws_au.sql
```

Each diff is a single-line edit (e.g. `RAISE EXCEPTION 'aws-australia-market-entry not found'` → `RETURN`).

## Follow-up

PR #179 (Batch 2 backfill, currently open) ships 11 more migrations using the same guard pattern. After this PR merges, I'll push a matching commit to that branch so the same fix lands there.

## Test plan

- [ ] Supabase Preview check goes green for the first time across this branch
- [ ] Existing prod data unchanged after Lovable redeploys (migrations are no-ops on already-populated rows because the `UPDATE … SET researched_by = 'Stephen Browne', style_version = 2` statements set the same values they already hold)

https://claude.ai/code/session_01AhPPWhM77SejR69ePuPrV4

---
_Generated by [Claude Code](https://claude.ai/code/session_01AhPPWhM77SejR69ePuPrV4)_