### PR TITLE
Import 6 Irish Tier 1 ANZ case studies (Clanwilliam, Spectrum.Life, T-Pro, Fexco, LearnUpon, Kyckr)

### DIFF
--- a/data/case-studies/irish_tier1_anz_research.html
+++ b/data/case-studies/irish_tier1_anz_research.html
@@ -1,0 +1,980 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MES Irish Tier 1 — Supabase-Ready Case Studies</title>
+<style>
+  :root {
+    --bg: #f7f6f2; --surface: #ffffff; --text: #1a1814;
+    --muted: #6b6960; --line: #e2ddd6; --accent: #016b6e;
+    --accent-light: #e6f4f3; --tag-bg: #f0ede7;
+    --radius: 14px; --max: 1060px;
+    --font: 'Segoe UI', system-ui, sans-serif;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: var(--font); background: var(--bg); color: var(--text); font-size: 16px; line-height: 1.65; }
+  a { color: var(--accent); }
+
+  /* ── HEADER ── */
+  header {
+    background: var(--accent); color: #fff; padding: 48px 24px 40px;
+    text-align: center;
+  }
+  header .badge {
+    display: inline-block; background: rgba(255,255,255,0.18);
+    border: 1px solid rgba(255,255,255,0.35); border-radius: 999px;
+    padding: 5px 14px; font-size: 12px; font-weight: 600;
+    letter-spacing: .06em; text-transform: uppercase; margin-bottom: 18px;
+  }
+  header h1 { font-size: clamp(28px,5vw,48px); font-weight: 700; margin-bottom: 12px; }
+  header p { font-size: 17px; opacity: .82; max-width: 620px; margin: 0 auto 20px; }
+  header .meta-row {
+    display: flex; flex-wrap: wrap; justify-content: center; gap: 10px; margin-top: 18px;
+  }
+  header .chip {
+    background: rgba(255,255,255,0.15); border: 1px solid rgba(255,255,255,0.3);
+    border-radius: 999px; padding: 6px 14px; font-size: 13px;
+  }
+
+  /* ── INSTRUCTIONS BOX ── */
+  .instructions {
+    max-width: var(--max); margin: 28px auto; padding: 0 20px;
+  }
+  .instr-box {
+    background: #fffbec; border: 1px solid #e8d97a; border-radius: var(--radius);
+    padding: 20px 24px;
+  }
+  .instr-box h2 { font-size: 15px; font-weight: 700; margin-bottom: 10px; }
+  .instr-box p, .instr-box li { font-size: 14px; color: var(--muted); }
+  .instr-box ul { padding-left: 18px; }
+  .instr-box li { margin-bottom: 5px; }
+
+  /* ── CASE STUDY CARD ── */
+  .case-study {
+    max-width: var(--max); margin: 0 auto 32px; padding: 0 20px;
+  }
+  .card {
+    background: var(--surface); border: 1px solid var(--line);
+    border-radius: 20px; overflow: hidden;
+    box-shadow: 0 4px 24px rgba(0,0,0,0.06);
+  }
+
+  /* card header band */
+  .card-header {
+    border-bottom: 1px solid var(--line);
+    padding: 28px 32px 24px;
+    display: grid; gap: 14px;
+  }
+  .card-header-top {
+    display: flex; align-items: flex-start; justify-content: space-between; gap: 16px;
+    flex-wrap: wrap;
+  }
+  .case-num {
+    font-size: 11px; font-weight: 700; text-transform: uppercase;
+    letter-spacing: .1em; color: var(--accent);
+    background: var(--accent-light); padding: 4px 10px; border-radius: 999px;
+    white-space: nowrap;
+  }
+  .slug-code {
+    font-family: monospace; font-size: 12px; color: var(--muted);
+    background: var(--tag-bg); padding: 4px 10px; border-radius: 6px; white-space: nowrap;
+  }
+  .card-header h2 { font-size: clamp(20px,3vw,26px); font-weight: 700; line-height: 1.2; }
+  .card-header .tagline { font-size: 15px; color: var(--muted); max-width: 72ch; }
+
+  /* meta strip */
+  .meta-strip {
+    display: grid; grid-template-columns: repeat(auto-fit, minmax(170px,1fr)); gap: 1px;
+    background: var(--line); border-top: 1px solid var(--line); border-bottom: 1px solid var(--line);
+  }
+  .meta-cell {
+    background: var(--surface); padding: 14px 18px;
+  }
+  .meta-cell .label {
+    font-size: 10px; text-transform: uppercase; letter-spacing: .08em;
+    color: var(--muted); margin-bottom: 4px; font-weight: 600;
+  }
+  .meta-cell .value { font-size: 14px; font-weight: 600; }
+
+  /* card body */
+  .card-body { padding: 28px 32px; display: grid; gap: 28px; }
+
+  .section-block { display: grid; gap: 10px; }
+  .section-title {
+    font-size: 12px; text-transform: uppercase; letter-spacing: .08em;
+    font-weight: 700; color: var(--accent); border-bottom: 2px solid var(--accent-light);
+    padding-bottom: 6px; margin-bottom: 2px;
+  }
+  .section-block p { max-width: 78ch; }
+  .section-block ul { padding-left: 20px; }
+  .section-block li { margin-bottom: 7px; }
+
+  /* tables */
+  .tbl-wrap { overflow-x: auto; }
+  table { width: 100%; border-collapse: collapse; min-width: 560px; }
+  th {
+    background: var(--tag-bg); font-size: 11px; text-transform: uppercase;
+    letter-spacing: .05em; color: var(--muted); padding: 9px 12px; text-align: left;
+    border-bottom: 2px solid var(--line);
+  }
+  td {
+    padding: 11px 12px; border-bottom: 1px solid var(--line);
+    font-size: 14px; vertical-align: top;
+  }
+  tr:last-child td { border-bottom: none; }
+
+  /* quote */
+  .callout {
+    background: var(--accent-light); border-left: 4px solid var(--accent);
+    border-radius: 0 10px 10px 0; padding: 16px 18px;
+    font-size: 15px; font-style: italic; color: #1a4548;
+  }
+  .callout cite { display: block; margin-top: 8px; font-style: normal; font-size: 13px; font-weight: 600; color: var(--accent); }
+
+  /* tags */
+  .tag-row { display: flex; flex-wrap: wrap; gap: 7px; }
+  .tag {
+    background: var(--tag-bg); border: 1px solid var(--line);
+    border-radius: 999px; padding: 5px 12px; font-size: 12px; font-weight: 600;
+    color: var(--muted);
+  }
+
+  /* sources */
+  .sources-block {
+    background: var(--tag-bg); border-radius: 12px; padding: 18px 20px;
+  }
+  .sources-block h4 { font-size: 12px; text-transform: uppercase; letter-spacing: .07em; color: var(--muted); margin-bottom: 12px; }
+  .src-list { display: grid; gap: 8px; }
+  .src-item {
+    display: grid; grid-template-columns: 22px 1fr; gap: 6px; align-items: start;
+    font-size: 13px;
+  }
+  .src-num { color: var(--accent); font-weight: 700; padding-top: 1px; }
+  .src-item a { word-break: break-all; }
+  .src-label { color: var(--muted); font-size: 12px; }
+
+  /* db schema preview */
+  .schema-box {
+    background: #1a1814; color: #d4cfbe; border-radius: 12px;
+    padding: 18px 20px; font-family: monospace; font-size: 13px;
+    overflow-x: auto; line-height: 1.5;
+  }
+  .schema-box .key { color: #63b3ed; }
+  .schema-box .str { color: #9ae6b4; }
+  .schema-box .arr { color: #fbd38d; }
+
+  /* footer */
+  footer {
+    text-align: center; padding: 40px 20px;
+    color: var(--muted); font-size: 14px; border-top: 1px solid var(--line);
+    margin-top: 16px;
+  }
+
+  @media (max-width: 680px) {
+    .card-header, .card-body { padding: 20px; }
+    .meta-strip { grid-template-columns: 1fr 1fr; }
+  }
+</style>
+</head>
+<body>
+
+<header>
+  <div class="badge">Market Entry Secrets · Irish Tier 1</div>
+  <h1>6 Irish Tier 1 ANZ Case Studies</h1>
+  <p>Structured for CC-assisted ingestion into the MES Supabase database. Each record includes slug, tags, body text, sources with citation URLs, and a schema preview.</p>
+  <div class="meta-row">
+    <span class="chip">6 case studies</span>
+    <span class="chip">Source URLs embedded</span>
+    <span class="chip">Supabase-ready structure</span>
+    <span class="chip">MES tagging included</span>
+  </div>
+</header>
+
+<div class="instructions">
+  <div class="instr-box">
+    <h2>Instructions for CC / Supabase ingestion</h2>
+    <ul>
+      <li>Each case study block below is a self-contained record. Use the <strong>slug</strong> as the primary key.</li>
+      <li>The <strong>Schema preview</strong> inside each card shows the exact JSON field mapping for Supabase insert.</li>
+      <li>Source URLs are labelled and hyperlinked — map each to a <code>sources[]</code> array field.</li>
+      <li>Tags are ready to map into a <code>tags[]</code> array or a relational join table.</li>
+      <li>Body sections (overview, entry_journey, outcomes, lessons) are labelled for CMS rich-text fields.</li>
+    </ul>
+  </div>
+</div>
+
+<!-- ════════════════════════════════════════════
+     CASE STUDY 1 — CLANWILLIAM
+════════════════════════════════════════════ -->
+<section class="case-study" id="cs-clanwilliam">
+<div class="card">
+  <div class="card-header">
+    <div class="card-header-top">
+      <span class="case-num">Case Study 01 · Healthtech</span>
+      <span class="slug-code">slug: clanwilliam-anz</span>
+    </div>
+    <h2>Clanwilliam: building ANZ healthcare infrastructure through staged acquisition and category consolidation</h2>
+    <p class="tagline">How a Dublin-founded healthtech group turned a series of ANZ acquisitions into a dominant clinical communications and connected-care platform spanning Australia and New Zealand.</p>
+  </div>
+
+  <div class="meta-strip">
+    <div class="meta-cell"><div class="label">Founded</div><div class="value">1996, Ireland</div></div>
+    <div class="meta-cell"><div class="label">Entry mode</div><div class="value">Acquisition-led</div></div>
+    <div class="meta-cell"><div class="label">First ANZ asset</div><div class="value">HealthLink (2017)</div></div>
+    <div class="meta-cell"><div class="label">ANZ division launched</div><div class="value">March 2024</div></div>
+    <div class="meta-cell"><div class="label">Major 2024 deal</div><div class="value">Telstra Health Argus/eReferrals</div></div>
+  </div>
+
+  <div class="card-body">
+
+    <div class="section-block">
+      <div class="section-title">Overview</div>
+      <p>Clanwilliam is an Irish healthcare technology group founded in 1996 by Howard Beggs. Its ANZ story is one of the clearest examples in the MES library of a company using acquisition to buy embedded market trust rather than attempting to build it from scratch against entrenched local competitors.</p>
+      <p>Rather than launch a sales operation into an unfamiliar healthcare system, Clanwilliam acquired businesses that were already woven into clinical workflows across Australian and New Zealand healthcare. That strategy gave it immediate network effects, customer relationships, and regulatory familiarity that would have taken years to replicate organically.</p>
+    </div>
+
+    <div class="section-block">
+      <div class="section-title">Why ANZ was the right market</div>
+      <p>Australian and New Zealand healthcare offered a compelling structural opportunity: both markets were digitising clinical communications but remained fragmented, with legacy secure messaging providers sitting alongside newer referral and data-exchange tools. Clanwilliam identified that connecting these silos was a solvable problem — but only if you owned or operated key pieces of the exchange infrastructure.</p>
+      <p>The English-language operating environment, a shared regulatory philosophy with Ireland, and strong government investment in digital health infrastructure made ANZ particularly accessible for an Irish company with deep healthcare workflow expertise.</p>
+    </div>
+
+    <div class="section-block">
+      <div class="section-title">Market entry journey</div>
+      <div class="tbl-wrap">
+        <table>
+          <thead><tr><th>Year</th><th>Move</th><th>Strategic significance</th></tr></thead>
+          <tbody>
+            <tr><td>2017</td><td>Acquired HealthLink (NZ-founded, ANZ coverage)</td><td>Gained an established health messaging network across ANZ, including 15,000+ connected medical organisations.</td></tr>
+            <tr><td>2017–18</td><td>Acquired Konnect NET</td><td>Added pharmacy connectivity and additional healthcare workflow capability in Australia.</td></tr>
+            <tr><td>Dec 2020</td><td>Merged HealthLink and Konnect NET</td><td>Reduced regional operational fragmentation and created a cleaner ANZ platform structure ahead of further growth.</td></tr>
+            <tr><td>Mar 2024</td><td>Launched formal ANZ Division</td><td>Formalised regional leadership (David Young as MD Australia, Mike Weiss as MD NZ) with four products: HealthLink, Konnect NET, Toniq, MBS.</td></tr>
+            <tr><td>Jan 2024</td><td>HealthLink acquired Telstra Health's Argus, Connecting Care and eReferrals assets</td><td>Consolidated a major competitor/complementary player; deepened secure messaging and e-referral market share across Australian healthcare.</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="section-block">
+      <div class="section-title">Key outcomes</div>
+      <div class="tbl-wrap">
+        <table>
+          <thead><tr><th>Metric</th><th>Verified figure</th><th>Source</th></tr></thead>
+          <tbody>
+            <tr><td>Medical organisations connected</td><td>15,000+ across Australasia</td><td>HealthLink network data (healthlink.com.au)</td></tr>
+            <tr><td>Clinical messages per year</td><td>100 million+</td><td>HealthLink network data</td></tr>
+            <tr><td>ANZ Division product count</td><td>4 (HealthLink, Konnect NET, Toniq, MBS)</td><td>ANZ Division launch announcement, March 2024</td></tr>
+            <tr><td>Telstra Health assets acquired</td><td>Argus, Connecting Care, eReferrals</td><td>MinterEllison deal announcement, Jan 2024</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="callout">
+      "In regulated health markets, the fastest route to credibility is to buy trust that is already embedded in the workflow — then consolidate around interoperability."
+      <cite>— MES editorial lesson, Clanwilliam case</cite>
+    </div>
+
+    <div class="section-block">
+      <div class="section-title">What founders can copy (MES Playbook)</div>
+      <div class="tbl-wrap">
+        <table>
+          <thead><tr><th>Play</th><th>How Clanwilliam used it</th><th>Founder takeaway</th></tr></thead>
+          <tbody>
+            <tr><td>Buy installed trust</td><td>Acquired HealthLink's embedded clinical messaging network rather than building one.</td><td>In complex systems, distribution is often acquired, not invented. Look for businesses with workflow lock-in.</td></tr>
+            <tr><td>Integrate before scaling</td><td>Merged HealthLink and Konnect NET before launching a formal ANZ division.</td><td>Operational coherence should precede expansion messaging. Don't promote fragmented assets.</td></tr>
+            <tr><td>Consolidate adjacencies</td><td>Acquired Telstra Health's overlapping secure messaging and e-referrals footprint.</td><td>Once inside a workflow category, strengthen the moat by absorbing complementary infrastructure before a competitor does.</td></tr>
+            <tr><td>Formalise with leadership</td><td>Appointed dedicated MD for Australia and MD for NZ as part of division launch.</td><td>A named regional leader signals permanence to customers, partners and regulators more than any press release.</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="section-block">
+      <div class="section-title">MES Tags</div>
+      <div class="tag-row">
+        <span class="tag">Healthtech</span>
+        <span class="tag">Acquisition-led entry</span>
+        <span class="tag">Healthcare infrastructure</span>
+        <span class="tag">Australia</span>
+        <span class="tag">New Zealand</span>
+        <span class="tag">ANZ Division build-out</span>
+        <span class="tag">Category consolidation</span>
+        <span class="tag">B2B</span>
+        <span class="tag">Ireland → ANZ</span>
+        <span class="tag">Enterprise</span>
+      </div>
+    </div>
+
+    <div class="sources-block">
+      <h4>Citation sources (URL list)</h4>
+      <div class="src-list">
+        <div class="src-item"><div class="src-num">1</div><div><div class="src-label">ANZ Division launch announcement</div><a href="https://insurtechnz.org.nz/2024/03/12/clanwilliam-launches-anz-division-in-a-commitment-to-the-future-of-healthcare-across-australia-and-new-zealand/" target="_blank" rel="noopener noreferrer">https://insurtechnz.org.nz/2024/03/12/clanwilliam-launches-anz-division</a></div></div>
+        <div class="src-item"><div class="src-num">2</div><div><div class="src-label">MinterEllison on Telstra Health acquisition</div><a href="https://www.minterellison.com/articles/minterellison-advises-clanwilliam-on-telstra-health-acquisition" target="_blank" rel="noopener noreferrer">https://www.minterellison.com/articles/minterellison-advises-clanwilliam-on-telstra-health-acquisition</a></div></div>
+        <div class="src-item"><div class="src-num">3</div><div><div class="src-label">Telstra Health sale announcement</div><a href="https://www.telstrahealth.com/healthlink-acquires-telstra-health-argus-connecting-care-and-ereferrals-business/" target="_blank" rel="noopener noreferrer">https://www.telstrahealth.com/healthlink-acquires-telstra-health-argus-connecting-care-and-ereferrals-business/</a></div></div>
+        <div class="src-item"><div class="src-num">4</div><div><div class="src-label">HealthLink acquisition background (Waterman)</div><a href="https://www.waterman.co.nz/news/healthlink-acquired-by-global-healthcare-technology-specialist/" target="_blank" rel="noopener noreferrer">https://www.waterman.co.nz/news/healthlink-acquired-by-global-healthcare-technology-specialist/</a></div></div>
+        <div class="src-item"><div class="src-num">5</div><div><div class="src-label">Pulse IT on Telstra Health Argus deal</div><a href="https://www.pulseit.news/australian-digital-health/healthlink-swoops-on-telstra-healths-secure-messaging-and-ereferrals-business/" target="_blank" rel="noopener noreferrer">https://www.pulseit.news/australian-digital-health/healthlink-swoops-on-telstra-healths-secure-messaging-and-ereferrals-business/</a></div></div>
+        <div class="src-item"><div class="src-num">6</div><div><div class="src-label">HealthLink network scale (corporate site)</div><a href="https://www.healthlink.com.au/clanwilliams-healthlink-acquires-telstra-healths-argus-connecting-care-and-ereferrals-business/" target="_blank" rel="noopener noreferrer">https://www.healthlink.com.au/clanwilliams-healthlink-acquires-telstra-healths-argus-connecting-care-and-ereferrals-business/</a></div></div>
+      </div>
+    </div>
+
+    <div class="section-block">
+      <div class="section-title">Supabase Schema Preview</div>
+      <div class="schema-box">
+{<br>
+&nbsp;&nbsp;<span class="key">"slug"</span>: <span class="str">"clanwilliam-anz"</span>,<br>
+&nbsp;&nbsp;<span class="key">"title"</span>: <span class="str">"Clanwilliam: ANZ healthcare infrastructure through staged acquisition"</span>,<br>
+&nbsp;&nbsp;<span class="key">"origin_country"</span>: <span class="str">"Ireland"</span>,<br>
+&nbsp;&nbsp;<span class="key">"target_market"</span>: <span class="str">"Australia, New Zealand"</span>,<br>
+&nbsp;&nbsp;<span class="key">"sector"</span>: <span class="str">"Healthtech"</span>,<br>
+&nbsp;&nbsp;<span class="key">"entry_mode"</span>: <span class="str">"Acquisition-led"</span>,<br>
+&nbsp;&nbsp;<span class="key">"entry_year"</span>: <span class="str">"2017"</span>,<br>
+&nbsp;&nbsp;<span class="key">"company_founded"</span>: <span class="str">"1996"</span>,<br>
+&nbsp;&nbsp;<span class="key">"tags"</span>: <span class="arr">["healthtech","acquisition","ANZ","B2B","infrastructure","category-consolidation"]</span>,<br>
+&nbsp;&nbsp;<span class="key">"tier"</span>: <span class="str">"tier1-irish"</span>,<br>
+&nbsp;&nbsp;<span class="key">"status"</span>: <span class="str">"published"</span>,<br>
+&nbsp;&nbsp;<span class="key">"sources_count"</span>: 6<br>
+}
+      </div>
+    </div>
+
+  </div>
+</div>
+</section>
+
+<!-- ════════════════════════════════════════════
+     CASE STUDY 2 — SPECTRUM.LIFE
+════════════════════════════════════════════ -->
+<section class="case-study" id="cs-spectrumlife">
+<div class="card">
+  <div class="card-header">
+    <div class="card-header-top">
+      <span class="case-num">Case Study 02 · Digital Mental Health</span>
+      <span class="slug-code">slug: spectrumlife-australia</span>
+    </div>
+    <h2>Spectrum.Life: entering Australia through a triple acquisition rather than an organic launch</h2>
+    <p class="tagline">How a Dublin-founded digital wellbeing platform skipped the greenfield build and entered Australia simultaneously across three complementary verticals — workplace mental health, EAP, and specialist virtual care — by acquiring three local businesses on the same day.</p>
+  </div>
+
+  <div class="meta-strip">
+    <div class="meta-cell"><div class="label">Founded</div><div class="value">2018, Dublin</div></div>
+    <div class="meta-cell"><div class="label">Founders</div><div class="value">Stuart McGoldrick + Stephen Costello</div></div>
+    <div class="meta-cell"><div class="label">Australia entry date</div><div class="value">17 March 2026</div></div>
+    <div class="meta-cell"><div class="label">Entry mode</div><div class="value">Triple acquisition</div></div>
+    <div class="meta-cell"><div class="label">AU launch headcount</div><div class="value">35 staff → 100+ roles planned</div></div>
+    <div class="meta-cell"><div class="label">Funding raised</div><div class="value">€17M Series B (May 2024)</div></div>
+  </div>
+
+  <div class="card-body">
+
+    <div class="section-block">
+      <div class="section-title">Company overview</div>
+      <p>Spectrum.Life was founded in Dublin in 2018 by Stuart McGoldrick and Stephen Costello. It operates a digital-first mental health and wellbeing platform serving employers, insurers and universities. The platform covers proactive wellbeing tools, digital therapy, EAP, and clinical triage through a single access point — making it well positioned to replace the fragmented point-solutions most employers and insurers were managing.</p>
+      <p>By 2024, the company served more than 4,000 corporate clients and 7.5 million insurance members. It raised a €17 million Series B round in May 2024 from Act Venture Capital and existing investors to fund international expansion — naming Australia as a target. In October 2024, it crossed 300 staff globally, and publicly targeted 500 by end of 2025 and revenue of €100 million by 2028.</p>
+    </div>
+
+    <div class="section-block">
+      <div class="section-title">Why Australia was the right market</div>
+      <p>Australia presented a near-perfect storm of demand drivers. Mental health-related workers' compensation claims had risen 37 percent since 2017–18. Life insurance TPD claims for mental health among people in their 30s had risen by 732 percent over a decade. Employers were under pressure from new psychosocial safety obligations introduced in Australian WHS laws. And the EAP provider market remained fragmented, largely phone-based, and resistant to digital change.</p>
+      <p>Spectrum.Life had already demonstrated in Ireland and the UK that a digitally-led, outcomes-focused model could win enterprise clients quickly. Australia replicated those macro conditions — regulatory tailwind, insurer pressure, employer demand — and offered a large enough addressable market to justify major investment.</p>
+    </div>
+
+    <div class="section-block">
+      <div class="section-title">Market entry journey</div>
+      <p>On 17 March 2026, Spectrum.Life announced the simultaneous acquisition of three Australian businesses: MindFit at Work (Melbourne), We Lysn (Sydney) and Valion Health (Sydney). The company was explicit that it chose not to enter organically — it wanted immediate clinical depth, local regulatory familiarity and customer relationships that only established local operators could provide.</p>
+      <div class="tbl-wrap">
+        <table>
+          <thead><tr><th>Acquired business</th><th>Location</th><th>What it added</th><th>Strategic role</th></tr></thead>
+          <tbody>
+            <tr><td><strong>MindFit at Work</strong></td><td>Melbourne</td><td>Evidence-based workplace mental health and psychosocial risk programmes; APAC coverage including Singapore</td><td>Employer and OHS compliance gateway</td></tr>
+            <tr><td><strong>We Lysn</strong></td><td>Sydney</td><td>Digital mental health, EAP, telehealth counselling (same/next-day access)</td><td>Frontline access and employee-facing digital product</td></tr>
+            <tr><td><strong>Valion Health</strong></td><td>Sydney</td><td>ACHS-accredited specialist virtual care (cancer, metabolic, chronic conditions)</td><td>Insurer and complex-case pathway for life and health cover</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p>The three businesses were highly complementary. Together they gave Spectrum.Life an employer-facing prevention product, a frontline digital counselling service, and a specialist insurer pathway — covering the full spectrum from early intervention to complex case management.</p>
+    </div>
+
+    <div class="section-block">
+      <div class="section-title">Key outcomes</div>
+      <div class="tbl-wrap">
+        <table>
+          <thead><tr><th>Metric</th><th>Figure</th><th>Source</th></tr></thead>
+          <tbody>
+            <tr><td>Australian employees at launch</td><td>35</td><td>Healthcare &amp; Protection, March 2026</td></tr>
+            <tr><td>New AU roles planned (12 months)</td><td>100+</td><td>CFO Tech / Spectrum.Life press release</td></tr>
+            <tr><td>Global members at entry</td><td>15 million+</td><td>Spectrum.Life funding announcement 2024</td></tr>
+            <tr><td>Global corporate clients</td><td>4,000+ corporate / 7.5M insurance members</td><td>InsurTech Insights interview, Nov 2024</td></tr>
+            <tr><td>Deloitte Fast 50 Ireland 2024 rank</td><td>41st</td><td>WireNews, November 2024</td></tr>
+            <tr><td>Revenue target</td><td>€100M by 2028</td><td>Business &amp; Finance Q&amp;A, June 2025</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="callout">
+      "We chose to make a long-term strategic commitment to Australia. One platform. One clinical pathway. 24/7 clinical access. Measurable outcomes."
+      <cite>— Stephen Costello, CEO, Spectrum.Life (March 2026)</cite>
+    </div>
+
+    <div class="section-block">
+      <div class="section-title">What founders can copy (MES Playbook)</div>
+      <div class="tbl-wrap">
+        <table>
+          <thead><tr><th>Play</th><th>How Spectrum.Life used it</th><th>Founder takeaway</th></tr></thead>
+          <tbody>
+            <tr><td>Use one expansion market to validate the next</td><td>Built UK scale and proof points before targeting Australia. UK became the case study that made the Australia investment case.</td><td>Sequence markets deliberately. Your second market is easier to enter if your first market has already proved the model works internationally.</td></tr>
+            <tr><td>Bundle complementary acquisitions</td><td>Bought three firms covering different parts of the care pathway simultaneously — employer prevention, frontline access, specialist care.</td><td>When a category is fragmented, acquire breadth rather than build each component. Speed and coverage compound faster than organic build.</td></tr>
+            <tr><td>Use market data to justify the entry</td><td>Cited the 37% rise in AU mental health claims to underpin the commercial rationale in media and to prospects.</td><td>Lead with the market problem, not the company. Local data makes your entry story immediately relevant to customers, partners and press.</td></tr>
+            <tr><td>Announce jobs alongside acquisitions</td><td>Committed to 100+ new roles within 12 months at the time of the acquisition announcement.</td><td>Hiring commitments signal permanence to customers, regulators and local government. They also generate media coverage beyond the deal itself.</td></tr>
+            <tr><td>Lead with outcomes language</td><td>Positioned the combined platform around measurable outcomes and 24/7 clinical access — not features.</td><td>In health and insurance, procurement teams respond to outcome architecture and accountability language, not feature lists.</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="section-block">
+      <div class="section-title">MES Tags</div>
+      <div class="tag-row">
+        <span class="tag">Digital health</span>
+        <span class="tag">Mental health</span>
+        <span class="tag">EAP</span>
+        <span class="tag">Insurtech</span>
+        <span class="tag">Acquisition-led entry</span>
+        <span class="tag">Australia</span>
+        <span class="tag">Triple acquisition</span>
+        <span class="tag">B2B</span>
+        <span class="tag">Ireland → ANZ</span>
+        <span class="tag">Series B</span>
+        <span class="tag">Employer wellbeing</span>
+      </div>
+    </div>
+
+    <div class="sources-block">
+      <h4>Citation sources (URL list)</h4>
+      <div class="src-list">
+        <div class="src-item"><div class="src-num">1</div><div><div class="src-label">Healthcare &amp; Protection — triple acquisition announcement</div><a href="https://healthcareandprotection.com/spectrum-life-expands-into-australia-through-mindfit-we-lysn-and-valion-acquisitions/" target="_blank" rel="noopener noreferrer">https://healthcareandprotection.com/spectrum-life-expands-into-australia-through-mindfit-we-lysn-and-valion-acquisitions/</a></div></div>
+        <div class="src-item"><div class="src-num">2</div><div><div class="src-label">Spectrum.Life official press release</div><a href="https://www.spectrum.life/resources/press-releases/spectrum-life-expands-into-australia-with-long-term-strategic-commitment/" target="_blank" rel="noopener noreferrer">https://www.spectrum.life/resources/press-releases/spectrum-life-expands-into-australia-with-long-term-strategic-commitment/</a></div></div>
+        <div class="src-item"><div class="src-num">3</div><div><div class="src-label">CFO Tech Australia — triple acquisition coverage</div><a href="https://cfotech.com.au/story/spectrum-life-buys-three-aussie-digital-health-firms" target="_blank" rel="noopener noreferrer">https://cfotech.com.au/story/spectrum-life-buys-three-aussie-digital-health-firms</a></div></div>
+        <div class="src-item"><div class="src-num">4</div><div><div class="src-label">Melbourne Insider — Australia expansion story</div><a href="https://melbourne-insider.au/spectrum-life-australia-expansion/" target="_blank" rel="noopener noreferrer">https://melbourne-insider.au/spectrum-life-australia-expansion/</a></div></div>
+        <div class="src-item"><div class="src-num">5</div><div><div class="src-label">Silicon Republic — Series B funding announcement</div><a href="https://www.siliconrepublic.com/start-ups/spectrum-life-funding-digital-health-ireland-uk" target="_blank" rel="noopener noreferrer">https://www.siliconrepublic.com/start-ups/spectrum-life-funding-digital-health-ireland-uk</a></div></div>
+        <div class="src-item"><div class="src-num">6</div><div><div class="src-label">Spectrum.Life €17M funding announcement (official)</div><a href="https://www.spectrum.life/resources/spectrum-life-funding-announcement-may-2024/" target="_blank" rel="noopener noreferrer">https://www.spectrum.life/resources/spectrum-life-funding-announcement-may-2024/</a></div></div>
+        <div class="src-item"><div class="src-num">7</div><div><div class="src-label">EIN Presswire — €17M round details and international growth plans</div><a href="https://www.einpresswire.com/article/714935154/spectrum-life-closes-17m-investment-round-to-accelerate-international-growth" target="_blank" rel="noopener noreferrer">https://www.einpresswire.com/article/714935154/spectrum-life-closes-17m-investment-round-to-accelerate-international-growth</a></div></div>
+        <div class="src-item"><div class="src-num">8</div><div><div class="src-label">InsurTech Insights — CEO Stephen Costello interview</div><a href="https://www.insurtechinsights.com/startup-story-spectrum-life-ceo-and-co-founder-stephen-costello-talks-technology-and-wellbeing/" target="_blank" rel="noopener noreferrer">https://www.insurtechinsights.com/startup-story-spectrum-life-ceo-and-co-founder-stephen-costello-talks-technology-and-wellbeing/</a></div></div>
+        <div class="src-item"><div class="src-num">9</div><div><div class="src-label">TechBuzz Ireland — 300 staff milestone</div><a href="https://techbuzzireland.com/2024/10/09/spectrum-life-surpasses-300-employees-and-eyes-growth-to-500-by-end-of-2025/" target="_blank" rel="noopener noreferrer">https://techbuzzireland.com/2024/10/09/spectrum-life-surpasses-300-employees-and-eyes-growth-to-500-by-end-of-2025/</a></div></div>
+        <div class="src-item"><div class="src-num">10</div><div><div class="src-label">WireNews — Deloitte Fast 50 Ireland 2024 ranking</div><a href="https://www.wirenn.com/post/spectrum-life-ranked-41st-in-the-deloitte-ireland-2024-technology-fast-50-awards" target="_blank" rel="noopener noreferrer">https://www.wirenn.com/post/spectrum-life-ranked-41st-in-the-deloitte-ireland-2024-technology-fast-50-awards</a></div></div>
+        <div class="src-item"><div class="src-num">11</div><div><div class="src-label">Business &amp; Finance Q&amp;A — Stephen Costello on mission and €100M target</div><a href="https://businessandfinance.com/news/my-primary-focus-is-delivering-on-our-mission-to-save-and-change-as-many-lives-as-possible-qanda-with-stephen-costello/" target="_blank" rel="noopener noreferrer">https://businessandfinance.com/news/my-primary-focus-is-delivering-on-our-mission-to-save-and-change-as-many-lives-as-possible-qanda-with-stephen-costello/</a></div></div>
+        <div class="src-item"><div class="src-num">12</div><div><div class="src-label">AIHS.org.au — 37% mental health claims rise in Australian workers' compensation</div><a href="https://aihs.org.au/Web/Web/Advocacy-Media/All-News/2024/03-March/Mental-health-conditions-jump-37-per-cent-in-workers-compensation-claims.aspx" target="_blank" rel="noopener noreferrer">https://aihs.org.au/Web/Web/Advocacy-Media/All-News/2024/03-March/Mental-health-conditions-jump-37-per-cent-in-workers-compensation-claims.aspx</a></div></div>
+        <div class="src-item"><div class="src-num">13</div><div><div class="src-label">Valion Health — about page (founded by Michael Marthick)</div><a href="https://valionhealth.com.au/about-valion/" target="_blank" rel="noopener noreferrer">https://valionhealth.com.au/about-valion/</a></div></div>
+        <div class="src-item"><div class="src-num">14</div><div><div class="src-label">SBS News — We Lysn founding story</div><a href="https://www.sbs.com.au/news/small-business-secrets/article/how-start-up-lysn-is-removing-the-stigma-surrounding-seeking-mental-health-support/0x1cd1dtu" target="_blank" rel="noopener noreferrer">https://www.sbs.com.au/news/small-business-secrets/article/how-start-up-lysn-is-removing-the-stigma-surrounding-seeking-mental-health-support/0x1cd1dtu</a></div></div>
+      </div>
+    </div>
+
+    <div class="section-block">
+      <div class="section-title">Supabase Schema Preview</div>
+      <div class="schema-box">
+{<br>
+&nbsp;&nbsp;<span class="key">"slug"</span>: <span class="str">"spectrumlife-australia"</span>,<br>
+&nbsp;&nbsp;<span class="key">"title"</span>: <span class="str">"Spectrum.Life: triple acquisition entry into Australian digital mental health"</span>,<br>
+&nbsp;&nbsp;<span class="key">"origin_country"</span>: <span class="str">"Ireland"</span>,<br>
+&nbsp;&nbsp;<span class="key">"target_market"</span>: <span class="str">"Australia"</span>,<br>
+&nbsp;&nbsp;<span class="key">"sector"</span>: <span class="str">"Digital Health / Mental Health / Insurtech"</span>,<br>
+&nbsp;&nbsp;<span class="key">"entry_mode"</span>: <span class="str">"Triple acquisition"</span>,<br>
+&nbsp;&nbsp;<span class="key">"entry_year"</span>: <span class="str">"2026"</span>,<br>
+&nbsp;&nbsp;<span class="key">"company_founded"</span>: <span class="str">"2018"</span>,<br>
+&nbsp;&nbsp;<span class="key">"founders"</span>: <span class="arr">["Stuart McGoldrick","Stephen Costello"]</span>,<br>
+&nbsp;&nbsp;<span class="key">"tags"</span>: <span class="arr">["mental-health","EAP","insurtech","acquisition","australia","B2B","series-b"]</span>,<br>
+&nbsp;&nbsp;<span class="key">"tier"</span>: <span class="str">"tier1-irish"</span>,<br>
+&nbsp;&nbsp;<span class="key">"status"</span>: <span class="str">"published"</span>,<br>
+&nbsp;&nbsp;<span class="key">"sources_count"</span>: 14<br>
+}
+      </div>
+    </div>
+
+  </div>
+</div>
+</section>
+
+<!-- ════════════════════════════════════════════
+     CASE STUDY 3 — T-PRO
+════════════════════════════════════════════ -->
+<section class="case-study" id="cs-tpro">
+<div class="card">
+  <div class="card-header">
+    <div class="card-header-top">
+      <span class="case-num">Case Study 03 · Healthcare AI</span>
+      <span class="slug-code">slug: tpro-apac</span>
+    </div>
+    <h2>T-Pro: serial acquisitions to build an APAC healthcare documentation AI footprint</h2>
+    <p class="tagline">How a Dublin-founded healthcare speech and documentation company expanded across Australia and New Zealand through three targeted acquisitions — buying local customer relationships and clinical workflow knowledge faster than any organic sales team could build them.</p>
+  </div>
+
+  <div class="meta-strip">
+    <div class="meta-cell"><div class="label">Founded</div><div class="value">Ireland</div></div>
+    <div class="meta-cell"><div class="label">Entry mode</div><div class="value">Serial acquisition</div></div>
+    <div class="meta-cell"><div class="label">Acquisition 1</div><div class="value">SyberScribe, Melbourne (2022)</div></div>
+    <div class="meta-cell"><div class="label">Acquisition 2</div><div class="value">NTS Transcriptions, AU (2023)</div></div>
+    <div class="meta-cell"><div class="label">Acquisition 3</div><div class="value">Sound Business Systems, NZ/AU (2025)</div></div>
+    <div class="meta-cell"><div class="label">PE backing</div><div class="value">Livingbridge (2022)</div></div>
+  </div>
+
+  <div class="card-body">
+
+    <div class="section-block">
+      <div class="section-title">Company overview</div>
+      <p>T-Pro is an Irish healthcare technology company specialising in speech recognition, clinical documentation and AI-enabled workflow tools for healthcare providers. Its technology reduces the administrative burden on clinicians by automating documentation tasks from dictation to structured clinical notes.</p>
+      <p>T-Pro's ANZ expansion strategy was acquisition-led from the outset. Rather than entering with its own sales team or a channel partner, it identified established local documentation and transcription businesses that already had deep relationships with hospitals, clinics and healthcare networks — then acquired them and layered its AI documentation platform over the existing operations.</p>
+    </div>
+
+    <div class="section-block">
+      <div class="section-title">Market entry journey</div>
+      <div class="tbl-wrap">
+        <table>
+          <thead><tr><th>Year</th><th>Acquisition</th><th>Location</th><th>What it added</th></tr></thead>
+          <tbody>
+            <tr><td>2022</td><td>SyberScribe</td><td>Melbourne, Australia</td><td>Established medical transcription and documentation business with Australian hospital and clinical relationships. Founded 2003.</td></tr>
+            <tr><td>2022</td><td>Livingbridge investment</td><td>UK PE backing</td><td>Private equity backing to fund ANZ acquisition strategy.</td></tr>
+            <tr><td>2023</td><td>NTS Transcriptions</td><td>Australia</td><td>Additional medical transcription capability and customer base in Australia.</td></tr>
+            <tr><td>2025</td><td>Sound Business Systems (SBS)</td><td>New Zealand + Australia</td><td>Long-established ANZ-focused clinical dictation and documentation provider. Extended T-Pro's reach into NZ healthcare systems.</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="section-block">
+      <div class="section-title">Why this approach worked</div>
+      <p>Healthcare documentation sits at the intersection of clinician behaviour, data compliance and hospital IT infrastructure. Local relationships matter enormously because switching documentation tools requires clinical workflow change management — something hospitals only do when they trust the vendor deeply. T-Pro's acquisition strategy meant it inherited trusted local operators rather than asking customers to take a risk on a remote Irish startup.</p>
+      <p>By acquiring three ANZ businesses rather than one, T-Pro built a narrative of regional commitment and demonstrated to healthcare networks that it was building a long-term APAC presence rather than testing the market opportunistically.</p>
+    </div>
+
+    <div class="callout">
+      "T-Pro's ANZ story shows that in specialist enterprise categories, acquisitions function simultaneously as distribution, localisation and trust-building — compressing years of relationship development into a single transaction."
+      <cite>— MES editorial lesson, T-Pro case</cite>
+    </div>
+
+    <div class="section-block">
+      <div class="section-title">What founders can copy (MES Playbook)</div>
+      <div class="tbl-wrap">
+        <table>
+          <thead><tr><th>Play</th><th>How T-Pro used it</th><th>Founder takeaway</th></tr></thead>
+          <tbody>
+            <tr><td>Let acquisitions replace the sales team</td><td>Each acquired business brought its own hospital and clinic relationships.</td><td>In enterprise healthcare, distribution IS the product. Buying an established operator often beats hiring a country manager and starting from zero.</td></tr>
+            <tr><td>Layer technology over trusted operations</td><td>T-Pro applied its AI documentation platform over acquired businesses rather than replacing them.</td><td>Don't replace what works locally. Add your IP on top of existing customer trust.</td></tr>
+            <tr><td>Build a serial acquisition narrative</td><td>Three acquisitions created a regional expansion story that one deal could not.</td><td>Announcing a second and third acquisition compounds the credibility signal from the first. You stop looking like an experiment and start looking like a regional player.</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="section-block">
+      <div class="section-title">MES Tags</div>
+      <div class="tag-row">
+        <span class="tag">Healthcare AI</span>
+        <span class="tag">Clinical documentation</span>
+        <span class="tag">Speech recognition</span>
+        <span class="tag">Serial acquisition</span>
+        <span class="tag">Australia</span>
+        <span class="tag">New Zealand</span>
+        <span class="tag">B2B</span>
+        <span class="tag">Ireland → APAC</span>
+        <span class="tag">PE-backed</span>
+      </div>
+    </div>
+
+    <div class="sources-block">
+      <h4>Citation sources (URL list)</h4>
+      <div class="src-list">
+        <div class="src-item"><div class="src-num">1</div><div><div class="src-label">Silicon Republic — T-Pro acquires SyberScribe (2022)</div><a href="https://www.siliconrepublic.com/business/t-pro-syberscribe-acquisition-australia-speech-transcription-technology" target="_blank" rel="noopener noreferrer">https://www.siliconrepublic.com/business/t-pro-syberscribe-acquisition-australia-speech-transcription-technology</a></div></div>
+        <div class="src-item"><div class="src-num">2</div><div><div class="src-label">ThinkBusiness — T-Pro voice AI and NTS (2024 profile)</div><a href="https://www.thinkbusiness.ie/articles/tpro-voice-ai-speech-technology/" target="_blank" rel="noopener noreferrer">https://www.thinkbusiness.ie/articles/tpro-voice-ai-speech-technology/</a></div></div>
+        <div class="src-item"><div class="src-num">3</div><div><div class="src-label">T-Pro blog — Sound Business Systems joins the group</div><a href="https://blog.tpro.io/sbs-part-of-tpro" target="_blank" rel="noopener noreferrer">https://blog.tpro.io/sbs-part-of-tpro</a></div></div>
+        <div class="src-item"><div class="src-num">4</div><div><div class="src-label">Livingbridge — T-Pro acquires SBS (PE announcement)</div><a href="https://www.livingbridge.com/livingroom/t-pro-acquires-sound-business-systems-expanding-global-healthcare-ai-reach" target="_blank" rel="noopener noreferrer">https://www.livingbridge.com/livingroom/t-pro-acquires-sound-business-systems-expanding-global-healthcare-ai-reach</a></div></div>
+        <div class="src-item"><div class="src-num">5</div><div><div class="src-label">Sound Business Systems — corporate site</div><a href="https://soundbusiness.co.nz" target="_blank" rel="noopener noreferrer">https://soundbusiness.co.nz</a></div></div>
+      </div>
+    </div>
+
+    <div class="section-block">
+      <div class="section-title">Supabase Schema Preview</div>
+      <div class="schema-box">
+{<br>
+&nbsp;&nbsp;<span class="key">"slug"</span>: <span class="str">"tpro-apac"</span>,<br>
+&nbsp;&nbsp;<span class="key">"title"</span>: <span class="str">"T-Pro: serial acquisitions to build APAC healthcare documentation AI"</span>,<br>
+&nbsp;&nbsp;<span class="key">"origin_country"</span>: <span class="str">"Ireland"</span>,<br>
+&nbsp;&nbsp;<span class="key">"target_market"</span>: <span class="str">"Australia, New Zealand"</span>,<br>
+&nbsp;&nbsp;<span class="key">"sector"</span>: <span class="str">"Healthcare AI / Clinical Documentation"</span>,<br>
+&nbsp;&nbsp;<span class="key">"entry_mode"</span>: <span class="str">"Serial acquisition"</span>,<br>
+&nbsp;&nbsp;<span class="key">"entry_year"</span>: <span class="str">"2022"</span>,<br>
+&nbsp;&nbsp;<span class="key">"tags"</span>: <span class="arr">["healthcare-ai","documentation","serial-acquisition","australia","new-zealand","PE-backed","B2B"]</span>,<br>
+&nbsp;&nbsp;<span class="key">"tier"</span>: <span class="str">"tier1-irish"</span>,<br>
+&nbsp;&nbsp;<span class="key">"status"</span>: <span class="str">"published"</span>,<br>
+&nbsp;&nbsp;<span class="key">"sources_count"</span>: 5<br>
+}
+      </div>
+    </div>
+
+  </div>
+</div>
+</section>
+
+<!-- ════════════════════════════════════════════
+     CASE STUDY 4 — FEXCO
+════════════════════════════════════════════ -->
+<section class="case-study" id="cs-fexco">
+<div class="card">
+  <div class="card-header">
+    <div class="card-header-top">
+      <span class="case-num">Case Study 04 · Fintech / FX</span>
+      <span class="slug-code">slug: fexco-pacific-australia</span>
+    </div>
+    <h2>Fexco: building a Pacific network through New Zealand, then expanding into Australia with proven regional economics</h2>
+    <p class="tagline">How a Kerry-founded payments and FX group used New Zealand as its Pacific base for over a decade, built a 400-person regional operation, and then used that platform to launch into Australian retail with hard numbers behind the expansion story.</p>
+  </div>
+
+  <div class="meta-strip">
+    <div class="meta-cell"><div class="label">Founded</div><div class="value">1981, Killorglin, Kerry</div></div>
+    <div class="meta-cell"><div class="label">NZ entry</div><div class="value">2009 (Federal Pacific acquisition)</div></div>
+    <div class="meta-cell"><div class="label">Pacific staff</div><div class="value">400+</div></div>
+    <div class="meta-cell"><div class="label">NZ stores</div><div class="value">24</div></div>
+    <div class="meta-cell"><div class="label">AU entry</div><div class="value">Sept 2024 (2 Sydney stores)</div></div>
+    <div class="meta-cell"><div class="label">AU plan</div><div class="value">20+ outlets, 80+ jobs</div></div>
+  </div>
+
+  <div class="card-body">
+
+    <div class="section-block">
+      <div class="section-title">Company overview</div>
+      <p>Fexco is one of Ireland's largest private companies, founded in 1981 in Killorglin, County Kerry by Brian McCarthy. It operates across payments, foreign exchange, financial services and business outsourcing. In the Pacific, its brand is anchored around currency exchange and remittance services under the No1 Currency banner, operating as a major Western Union master agent across the region.</p>
+    </div>
+
+    <div class="section-block">
+      <div class="section-title">ANZ market entry journey</div>
+      <p>Fexco's ANZ story begins in New Zealand. In 2009 it acquired Federal Pacific in Auckland, which it later renamed Fexco Pacific. From that base it expanded across New Zealand and Pacific island markets — building a network of 24 stores in New Zealand, over 100 offices and outlets across the Pacific, and a team of more than 400 staff. With more than two million transactions per year, Fexco Pacific became a significant financial services operation in its own right.</p>
+      <p>In September 2024, Fexco took the next logical step and opened two No1 Currency stores in Sydney — at Westfield Hurstville and Westfield Liverpool. The company explicitly framed this as the start of a broader Australian rollout, with plans for more than 20 outlets and 80-plus local jobs.</p>
+    </div>
+
+    <div class="section-block">
+      <div class="section-title">Why this pattern matters for MES</div>
+      <p>Most market-entry advice assumes Australia is the primary target and New Zealand is an afterthought. Fexco inverts this entirely. It built 15 years of Pacific operating experience before entering Australian retail — and when it did, it arrived with proven unit economics, brand recognition among Pacific diaspora communities, and a credible expansion narrative backed by real numbers.</p>
+      <p>Fexco also had an indirect Australian connection through its co-ownership of PICA Group, one of Australia's largest strata property services companies. This gave the Fexco leadership team long-running familiarity with the Australian operating and regulatory environment before the currency retail rollout.</p>
+    </div>
+
+    <div class="callout">
+      "New Zealand doesn't have to be a test market or a secondary afterthought. For the right business, it can be the foundation of a decade-long Pacific operation that makes Australia a more confident expansion, not a speculative one."
+      <cite>— MES editorial lesson, Fexco case</cite>
+    </div>
+
+    <div class="section-block">
+      <div class="section-title">What founders can copy (MES Playbook)</div>
+      <div class="tbl-wrap">
+        <table>
+          <thead><tr><th>Play</th><th>How Fexco used it</th><th>Founder takeaway</th></tr></thead>
+          <tbody>
+            <tr><td>NZ as a genuine operating base</td><td>Built 400+ staff, 24 stores and 2M+ annual transactions before moving into Australia.</td><td>NZ is a real market, not a stepping stone. The operating depth you build there is real credibility when you want to expand.</td></tr>
+            <tr><td>Pacific network as a moat</td><td>Became the largest Western Union master agent in the Pacific — hard to replicate quickly.</td><td>In financial services and adjacent sectors, network infrastructure is a durable moat. Build the network before expanding the brand.</td></tr>
+            <tr><td>Lead the Australia announcement with jobs and footprint</td><td>Announced exact store locations, job creation numbers and a multi-year rollout plan.</td><td>Specific commitments — named locations, headcount, timelines — earn media and government goodwill. Vague expansion plans do not.</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="section-block">
+      <div class="section-title">MES Tags</div>
+      <div class="tag-row">
+        <span class="tag">Fintech</span>
+        <span class="tag">FX / Payments</span>
+        <span class="tag">New Zealand first</span>
+        <span class="tag">Pacific expansion</span>
+        <span class="tag">Australia</span>
+        <span class="tag">Retail rollout</span>
+        <span class="tag">Ireland → Pacific</span>
+        <span class="tag">B2C</span>
+        <span class="tag">Long-term play</span>
+      </div>
+    </div>
+
+    <div class="sources-block">
+      <h4>Citation sources (URL list)</h4>
+      <div class="src-list">
+        <div class="src-item"><div class="src-num">1</div><div><div class="src-label">Fexco — Sydney store launch announcement (Oct 2024)</div><a href="https://www.fexco.com/news-and-insights/fexco-expands-global-presence-with-launch-of-two-new-no1-currency-stores-in-sydney-australia/" target="_blank" rel="noopener noreferrer">https://www.fexco.com/news-and-insights/fexco-expands-global-presence-with-launch-of-two-new-no1-currency-stores-in-sydney-australia/</a></div></div>
+        <div class="src-item"><div class="src-num">2</div><div><div class="src-label">Fexco Pacific LinkedIn — network size and description</div><a href="https://nz.linkedin.com/company/fexco-pacific-ltd" target="_blank" rel="noopener noreferrer">https://nz.linkedin.com/company/fexco-pacific-ltd</a></div></div>
+        <div class="src-item"><div class="src-num">3</div><div><div class="src-label">Fexco corporate homepage</div><a href="https://www.fexco.com" target="_blank" rel="noopener noreferrer">https://www.fexco.com</a></div></div>
+      </div>
+    </div>
+
+    <div class="section-block">
+      <div class="section-title">Supabase Schema Preview</div>
+      <div class="schema-box">
+{<br>
+&nbsp;&nbsp;<span class="key">"slug"</span>: <span class="str">"fexco-pacific-australia"</span>,<br>
+&nbsp;&nbsp;<span class="key">"title"</span>: <span class="str">"Fexco: New Zealand Pacific base to Australian retail expansion"</span>,<br>
+&nbsp;&nbsp;<span class="key">"origin_country"</span>: <span class="str">"Ireland"</span>,<br>
+&nbsp;&nbsp;<span class="key">"target_market"</span>: <span class="str">"New Zealand, Pacific, Australia"</span>,<br>
+&nbsp;&nbsp;<span class="key">"sector"</span>: <span class="str">"Fintech / FX / Payments"</span>,<br>
+&nbsp;&nbsp;<span class="key">"entry_mode"</span>: <span class="str">"Acquisition then organic retail rollout"</span>,<br>
+&nbsp;&nbsp;<span class="key">"entry_year"</span>: <span class="str">"2009 (NZ) / 2024 (AU)"</span>,<br>
+&nbsp;&nbsp;<span class="key">"tags"</span>: <span class="arr">["fintech","FX","payments","new-zealand","pacific","australia","B2C","long-game"]</span>,<br>
+&nbsp;&nbsp;<span class="key">"tier"</span>: <span class="str">"tier1-irish"</span>,<br>
+&nbsp;&nbsp;<span class="key">"status"</span>: <span class="str">"published"</span>,<br>
+&nbsp;&nbsp;<span class="key">"sources_count"</span>: 3<br>
+}
+      </div>
+    </div>
+
+  </div>
+</div>
+</section>
+
+<!-- ════════════════════════════════════════════
+     CASE STUDY 5 — LEARNUPON
+════════════════════════════════════════════ -->
+<section class="case-study" id="cs-learnupon">
+<div class="card">
+  <div class="card-header">
+    <div class="card-header-top">
+      <span class="case-num">Case Study 05 · Edtech / SaaS</span>
+      <span class="slug-code">slug: learnupon-apac</span>
+    </div>
+    <h2>LearnUpon: deepening a Sydney-led APAC operation after building global LMS scale from Dublin</h2>
+    <p class="tagline">How a Dublin-founded learning management system company grew to 100+ APAC enterprise customers, 80% headcount growth in two years, and a bigger Sydney HQ — by proving demand first globally and then investing in regional density when the customer base justified it.</p>
+  </div>
+
+  <div class="meta-strip">
+    <div class="meta-cell"><div class="label">Founded</div><div class="value">June 2012, Dublin</div></div>
+    <div class="meta-cell"><div class="label">Founders</div><div class="value">Brendan Noud + Des Anderson</div></div>
+    <div class="meta-cell"><div class="label">Sydney office</div><div class="value">Operational 6+ years</div></div>
+    <div class="meta-cell"><div class="label">APAC customers</div><div class="value">100+</div></div>
+    <div class="meta-cell"><div class="label">APAC headcount growth</div><div class="value">80% in 2 years</div></div>
+    <div class="meta-cell"><div class="label">Series A</div><div class="value">$56M from Summit Partners (2020)</div></div>
+  </div>
+
+  <div class="card-body">
+
+    <div class="section-block">
+      <div class="section-title">Company overview</div>
+      <p>LearnUpon was founded in June 2012 by Brendan Noud (CEO) and Des Anderson (CTO) in Dublin. It builds learning management software that companies use to train employees, customers and partners at scale. By 2026 it served more than 1,500 global customers across 40+ countries, with over 20 million active users and 150 million completed courses on the platform.</p>
+      <p>In October 2020, LearnUpon raised a $56 million Series A from Summit Partners — one of Ireland's largest edtech funding rounds — which accelerated product investment and international hiring. Australia and the broader APAC region were priorities in that growth plan.</p>
+    </div>
+
+    <div class="section-block">
+      <div class="section-title">ANZ and APAC market entry journey</div>
+      <p>LearnUpon's Sydney office had been operational for more than six years by early 2026. Rather than a dramatic launch, its ANZ presence was built incrementally — winning enterprise customers, building a local support function and growing the team as APAC revenue justified investment. In June 2024, it appointed Fiona Sweeney as APAC Director, signalling stronger regional leadership commitment.</p>
+      <p>In March 2026, LearnUpon announced it was accelerating APAC expansion through a larger Sydney headquarters at JustCo, deeper regional investment and the integration of Courseau — an AI-native course creation platform it had recently acquired. The announcement confirmed 100+ customers in the APAC region and said local headcount had grown 80% over two years.</p>
+    </div>
+
+    <div class="section-block">
+      <div class="section-title">APAC customer base</div>
+      <div class="tbl-wrap">
+        <table>
+          <thead><tr><th>Customer</th><th>Sector</th><th>Use case</th></tr></thead>
+          <tbody>
+            <tr><td>Healthcare Australia</td><td>Healthcare / Staffing</td><td>Workforce learning and compliance training</td></tr>
+            <tr><td>WorkPac</td><td>Labour hire</td><td>Onboarding and skills training at scale</td></tr>
+            <tr><td>Jetpilot</td><td>Consumer goods</td><td>Product knowledge and dealer training</td></tr>
+            <tr><td>Montu</td><td>Pharmaceutical</td><td>Regulatory and clinical learning</td></tr>
+            <tr><td>Morningstar</td><td>Financial services</td><td>Professional development</td></tr>
+            <tr><td>ACSO</td><td>Corrections/Justice</td><td>Staff training and compliance</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="callout">
+      "LearnUpon's APAC story is a counterpoint to acquisition-led entries. Sometimes the right move is not to buy — it's to serve the customers who find you, then invest in local density once the concentration justifies it."
+      <cite>— MES editorial lesson, LearnUpon case</cite>
+    </div>
+
+    <div class="section-block">
+      <div class="section-title">What founders can copy (MES Playbook)</div>
+      <div class="tbl-wrap">
+        <table>
+          <thead><tr><th>Play</th><th>How LearnUpon used it</th><th>Founder takeaway</th></tr></thead>
+          <tbody>
+            <tr><td>Let customer pull justify local investment</td><td>Grew APAC organically for six-plus years before making a bigger local commitment.</td><td>Don't invest in regional office and leadership before the customer demand exists. Let inbound traction tell you when the market is ready for more investment.</td></tr>
+            <tr><td>Add AI to accelerate regional relevance</td><td>Used the Courseau acquisition to offer AI course creation as a local differentiator.</td><td>An AI acquisition can refresh the expansion story in a region that already knows your product.</td></tr>
+            <tr><td>Name the local headcount growth</td><td>Cited 80% headcount growth in two years as a proof point in expansion announcement.</td><td>Percentage headcount growth is a powerful signal — it shows the region is a real business unit, not a satellite sales office.</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="section-block">
+      <div class="section-title">MES Tags</div>
+      <div class="tag-row">
+        <span class="tag">Edtech</span>
+        <span class="tag">LMS / Learning</span>
+        <span class="tag">SaaS</span>
+        <span class="tag">Australia</span>
+        <span class="tag">Sydney</span>
+        <span class="tag">Enterprise B2B</span>
+        <span class="tag">Ireland → APAC</span>
+        <span class="tag">Organic scaling</span>
+        <span class="tag">AI-enhanced product</span>
+      </div>
+    </div>
+
+    <div class="sources-block">
+      <h4>Citation sources (URL list)</h4>
+      <div class="src-list">
+        <div class="src-item"><div class="src-num">1</div><div><div class="src-label">LearnUpon — APAC expansion announcement (newsroom)</div><a href="https://www.learnupon.com/newsroom/learnupon-accelerates-apac-expansion/" target="_blank" rel="noopener noreferrer">https://www.learnupon.com/newsroom/learnupon-accelerates-apac-expansion/</a></div></div>
+        <div class="src-item"><div class="src-num">2</div><div><div class="src-label">IT Brief Australia — APAC growth and Courseau</div><a href="https://itbrief.com.au/story/learnupon-boosts-apac-growth-with-ai-course-platform" target="_blank" rel="noopener noreferrer">https://itbrief.com.au/story/learnupon-boosts-apac-growth-with-ai-course-platform</a></div></div>
+        <div class="src-item"><div class="src-num">3</div><div><div class="src-label">Medianet — Sydney HQ and Courseau acquisition</div><a href="https://newshub.medianet.com.au/2026/03/learnupon-accelerates-apac-expansion-with-new-sydney-headquarters-and-ai-native-courseau/144128/" target="_blank" rel="noopener noreferrer">https://newshub.medianet.com.au/2026/03/learnupon-accelerates-apac-expansion-with-new-sydney-headquarters-and-ai-native-courseau/144128/</a></div></div>
+        <div class="src-item"><div class="src-num">4</div><div><div class="src-label">Mirage News — APAC Sydney HQ update</div><a href="https://www.miragenews.com/learnupon-expands-apac-with-sydney-hq-ai-1637940/" target="_blank" rel="noopener noreferrer">https://www.miragenews.com/learnupon-expands-apac-with-sydney-hq-ai-1637940/</a></div></div>
+        <div class="src-item"><div class="src-num">5</div><div><div class="src-label">BusinessWire — 2025 year-end performance and global recognition</div><a href="https://www.businesswire.com/news/home/20260129847362/en/LearnUpon-Ends-2025-With-Breakthrough-Growth-Product-Innovation-and-Global-Recognition" target="_blank" rel="noopener noreferrer">https://www.businesswire.com/news/home/20260129847362/en/LearnUpon-Ends-2025-With-Breakthrough-Growth-Product-Innovation-and-Global-Recognition</a></div></div>
+      </div>
+    </div>
+
+    <div class="section-block">
+      <div class="section-title">Supabase Schema Preview</div>
+      <div class="schema-box">
+{<br>
+&nbsp;&nbsp;<span class="key">"slug"</span>: <span class="str">"learnupon-apac"</span>,<br>
+&nbsp;&nbsp;<span class="key">"title"</span>: <span class="str">"LearnUpon: Sydney-led APAC scaling in LMS and AI course creation"</span>,<br>
+&nbsp;&nbsp;<span class="key">"origin_country"</span>: <span class="str">"Ireland"</span>,<br>
+&nbsp;&nbsp;<span class="key">"target_market"</span>: <span class="str">"Australia, APAC"</span>,<br>
+&nbsp;&nbsp;<span class="key">"sector"</span>: <span class="str">"Edtech / LMS / SaaS"</span>,<br>
+&nbsp;&nbsp;<span class="key">"entry_mode"</span>: <span class="str">"Organic scaling"</span>,<br>
+&nbsp;&nbsp;<span class="key">"entry_year"</span>: <span class="str">"2018"</span>,<br>
+&nbsp;&nbsp;<span class="key">"founders"</span>: <span class="arr">["Brendan Noud","Des Anderson"]</span>,<br>
+&nbsp;&nbsp;<span class="key">"tags"</span>: <span class="arr">["edtech","LMS","SaaS","australia","enterprise-B2B","organic","AI"]</span>,<br>
+&nbsp;&nbsp;<span class="key">"tier"</span>: <span class="str">"tier1-irish"</span>,<br>
+&nbsp;&nbsp;<span class="key">"status"</span>: <span class="str">"published"</span>,<br>
+&nbsp;&nbsp;<span class="key">"sources_count"</span>: 5<br>
+}
+      </div>
+    </div>
+
+  </div>
+</div>
+</section>
+
+<!-- ════════════════════════════════════════════
+     CASE STUDY 6 — KYCKR
+════════════════════════════════════════════ -->
+<section class="case-study" id="cs-kyckr">
+<div class="card">
+  <div class="card-header">
+    <div class="card-header-top">
+      <span class="case-num">Case Study 06 · Fintech / Regtech</span>
+      <span class="slug-code">slug: kyckr-asx</span>
+    </div>
+    <h2>Kyckr: using an ASX listing as the market-entry mechanism for an Irish regtech</h2>
+    <p class="tagline">How a Waterford-founded company registry intelligence startup used the Australian Securities Exchange not just as a capital-raising tool but as a market-entry strategy — gaining Australian institutional credibility, local investor visibility, and a listed-company governance structure that resonated with its compliance-focused customers.</p>
+  </div>
+
+  <div class="meta-strip">
+    <div class="meta-cell"><div class="label">Founded</div><div class="value">March 2007, Waterford</div></div>
+    <div class="meta-cell"><div class="label">ASX listing</div><div class="value">September 2016</div></div>
+    <div class="meta-cell"><div class="label">IPO raise</div><div class="value">A$5M (A$26M fully diluted value)</div></div>
+    <div class="meta-cell"><div class="label">Registries covered</div><div class="value">300+ globally</div></div>
+    <div class="meta-cell"><div class="label">Companies indexed</div><div class="value">120M+ businesses</div></div>
+    <div class="meta-cell"><div class="label">Exit</div><div class="value">Acquired by Richard White, Nov 2022</div></div>
+  </div>
+
+  <div class="card-body">
+
+    <div class="section-block">
+      <div class="section-title">Company overview</div>
+      <p>Kyckr was founded in Waterford in March 2007 by Ben Cronin, Rob Leslie, John Murray and Richard Wood. The company built a real-time registry intelligence platform that gave compliance teams at banks, financial institutions and corporates direct access to official company registry data across 300+ jurisdictions — removing the need to manually check registries or rely on outdated static databases.</p>
+      <p>Its core product addressed a genuine compliance burden: banks performing KYC, AML and onboarding checks needed accurate, current company ownership and incorporation data at speed. Kyckr automated this by connecting directly to primary regulatory sources.</p>
+    </div>
+
+    <div class="section-block">
+      <div class="section-title">The ASX as a market-entry strategy</div>
+      <p>In September 2016, Kyckr listed on the Australian Securities Exchange under the ticker KYK, raising A$5 million with a fully diluted market capitalisation of approximately A$26 million. Enterprise Ireland had backed the company with a €250,000 investment ahead of the listing.</p>
+      <p>This was not a conventional market-entry play. Kyckr was not simply raising capital on a convenient exchange. It was choosing to make Australia its listed domicile — which gave it Australian institutional shareholder support, regular ASX reporting obligations, and a profile in the Australian financial services sector precisely where its target customers operated. For a compliance-focused product, being a listed entity with transparent public reporting was itself a trust signal.</p>
+    </div>
+
+    <div class="section-block">
+      <div class="section-title">Growth and exit</div>
+      <p>After listing, Kyckr grew its product to cover more than 120 million businesses from 300-plus primary regulatory sources across more than 100 countries. In FY2017 it reported $1.54 million in revenue, up 34%. By FY2019 revenue had reached $2.14 million, representing growth of more than 25%. Clients included Citi Commercial Bank and Commerzbank.</p>
+      <p>In November 2022, Richard White — the founder of WiseTech Global, one of Australia's most successful technology companies — completed the acquisition of the remaining 77.24% stake in Kyckr he did not already own and delisted the company. The acquisition validated Kyckr's technology and validated the ANZ market-entry approach by attracting strategic attention from one of Australia's most respected technology founders.</p>
+    </div>
+
+    <div class="callout">
+      "A public listing is not just a capital event. For a compliance-first product, it can be a trust signal, a market-entry mechanism and a talent-attraction tool — all at the same time."
+      <cite>— MES editorial lesson, Kyckr case</cite>
+    </div>
+
+    <div class="section-block">
+      <div class="section-title">What founders can copy (MES Playbook)</div>
+      <div class="tbl-wrap">
+        <table>
+          <thead><tr><th>Play</th><th>How Kyckr used it</th><th>Founder takeaway</th></tr></thead>
+          <tbody>
+            <tr><td>Use capital markets as an entry mechanism</td><td>Listed on ASX to gain Australian institutional credibility alongside capital.</td><td>In regulated B2B sectors, a public listing can be more effective than a sales office. It makes trust transparent and permanent.</td></tr>
+            <tr><td>Match the entry mechanism to the product's trust requirements</td><td>A compliance product for banks needed to demonstrate governance. A listed company structure did exactly that.</td><td>Think about what signal your customers need most and choose an entry mechanism that delivers it.</td></tr>
+            <tr><td>Build toward strategic acquirers</td><td>Kyckr's data infrastructure attracted WiseTech founder Richard White as a personal acquirer.</td><td>If your product is genuinely valuable infrastructure, ANZ exits to global tech leaders are achievable.</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="section-block">
+      <div class="section-title">MES Tags</div>
+      <div class="tag-row">
+        <span class="tag">Fintech</span>
+        <span class="tag">Regtech</span>
+        <span class="tag">KYC / AML</span>
+        <span class="tag">ASX listing</span>
+        <span class="tag">Capital markets entry</span>
+        <span class="tag">Australia</span>
+        <span class="tag">Ireland → ANZ</span>
+        <span class="tag">B2B Enterprise</span>
+        <span class="tag">Exit to acquisition</span>
+        <span class="tag">Compliance</span>
+      </div>
+    </div>
+
+    <div class="sources-block">
+      <h4>Citation sources (URL list)</h4>
+      <div class="src-list">
+        <div class="src-item"><div class="src-num">1</div><div><div class="src-label">Fora.ie — Kyckr ASX IPO announcement (Sept 2016)</div><a href="https://fora.ie/kyckr-waterford-ipo-2968390-Sep2016/" target="_blank" rel="noopener noreferrer">https://fora.ie/kyckr-waterford-ipo-2968390-Sep2016/</a></div></div>
+        <div class="src-item"><div class="src-num">2</div><div><div class="src-label">MarketScreener — Richard White acquires remaining Kyckr stake (Nov 2022)</div><a href="https://in.marketscreener.com/quote/stock/KYCKR-LIMITED-27546659/news/Richard-White-completed-the-acquisition-of-the-remaining-77.24-stake-in-Kyckr-Limited-42171348/" target="_blank" rel="noopener noreferrer">https://in.marketscreener.com/quote/stock/KYCKR-LIMITED-27546659/news/Richard-White-completed-the-acquisition-of-the-remaining-77.24-stake-in-Kyckr-Limited.</a></div></div>
+        <div class="src-item"><div class="src-num">3</div><div><div class="src-label">Addisons — Kyckr ASX KYK acquisition by RealWise (legal announcement)</div><a href="https://addisons.com/announcement/addisons-advises-kyckr-asx-kyk-on-its-acquisition-by-realwise/" target="_blank" rel="noopener noreferrer">https://addisons.com/announcement/addisons-advises-kyckr-asx-kyk-on-its-acquisition-by-realwise/</a></div></div>
+        <div class="src-item"><div class="src-num">4</div><div><div class="src-label">Wikipedia — Kyckr company article</div><a href="https://en.wikipedia.org/wiki/Kyckr" target="_blank" rel="noopener noreferrer">https://en.wikipedia.org/wiki/Kyckr</a></div></div>
+        <div class="src-item"><div class="src-num">5</div><div><div class="src-label">Finovate — Kyckr archive (product and financial service context)</div><a href="https://finovate.com/category/kyckr/" target="_blank" rel="noopener noreferrer">https://finovate.com/category/kyckr/</a></div></div>
+      </div>
+    </div>
+
+    <div class="section-block">
+      <div class="section-title">Supabase Schema Preview</div>
+      <div class="schema-box">
+{<br>
+&nbsp;&nbsp;<span class="key">"slug"</span>: <span class="str">"kyckr-asx"</span>,<br>
+&nbsp;&nbsp;<span class="key">"title"</span>: <span class="str">"Kyckr: ASX listing as market-entry mechanism for Irish regtech"</span>,<br>
+&nbsp;&nbsp;<span class="key">"origin_country"</span>: <span class="str">"Ireland"</span>,<br>
+&nbsp;&nbsp;<span class="key">"target_market"</span>: <span class="str">"Australia"</span>,<br>
+&nbsp;&nbsp;<span class="key">"sector"</span>: <span class="str">"Fintech / Regtech / Compliance"</span>,<br>
+&nbsp;&nbsp;<span class="key">"entry_mode"</span>: <span class="str">"ASX IPO / capital markets listing"</span>,<br>
+&nbsp;&nbsp;<span class="key">"entry_year"</span>: <span class="str">"2016"</span>,<br>
+&nbsp;&nbsp;<span class="key">"company_founded"</span>: <span class="str">"2007"</span>,<br>
+&nbsp;&nbsp;<span class="key">"exit"</span>: <span class="str">"Acquired by Richard White / RealWise, Nov 2022"</span>,<br>
+&nbsp;&nbsp;<span class="key">"tags"</span>: <span class="arr">["fintech","regtech","KYC","AML","ASX","capital-markets","acquisition-exit","B2B"]</span>,<br>
+&nbsp;&nbsp;<span class="key">"tier"</span>: <span class="str">"tier1-irish"</span>,<br>
+&nbsp;&nbsp;<span class="key">"status"</span>: <span class="str">"published"</span>,<br>
+&nbsp;&nbsp;<span class="key">"sources_count"</span>: 5<br>
+}
+      </div>
+    </div>
+
+  </div>
+</div>
+</section>
+
+<footer>
+  <p>Market Entry Secrets (MES) · Irish Tier 1 Case Studies · Master file generated May 2026</p>
+  <p style="margin-top:8px;">All source URLs verified and embedded inline. Ready for CC-assisted Supabase ingestion.</p>
+</footer>
+
+<script>
+  // Dark mode toggle (optional)
+  document.querySelectorAll('[data-theme-toggle]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const html = document.documentElement;
+      html.setAttribute('data-theme',
+        html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark');
+    });
+  });
+</script>
+</body>
+</html>

--- a/reports/irish-tier1-import-summary-2026-05-08.md
+++ b/reports/irish-tier1-import-summary-2026-05-08.md
@@ -1,0 +1,96 @@
+# Irish Tier 1 Case Studies — Import Summary
+
+**Date:** 2026-05-08
+**Branch:** `claude/import-irish-tier1-case-studies`
+**Supabase project:** `xhziwveaiuhzdoutpgrh` (MES Platform)
+**Source:** `data/case-studies/irish_tier1_anz_research.html` (Perplexity-produced HTML, 6 case studies, ~42 citation URLs)
+
+---
+
+## What was added
+
+Six **net-new** Irish ANZ case studies, all imported with `status='published'`.
+All slugs were normalised to the standard `<company>-anz-market-entry` pattern
+to match the existing 45 case studies in the directory.
+
+| Slug | Source slug | Sector | Category | Sections | Bodies | Founders | Sources |
+|---|---|---|---|---:|---:|---:|---:|
+| clanwilliam-anz-market-entry | clanwilliam-anz | Healthtech | Technology Market Entry | 4 | 9 | 1 | 6 |
+| spectrum-life-anz-market-entry | spectrumlife-australia | Insurtech | Fintech Success | 4 | 11 | 2 | 14 |
+| t-pro-anz-market-entry | tpro-apac | Healthcare AI | Technology Market Entry | 4 | 9 | 0 | 5 |
+| fexco-anz-market-entry | fexco-pacific-australia | Fintech | Fintech Success | 4 | 9 | 1 | 3 |
+| learnupon-anz-market-entry | learnupon-apac | Edtech | Technology Market Entry | 4 | 8 | 2 | 5 |
+| kyckr-anz-market-entry | kyckr-asx | RegTech | Fintech Success | 4 | 9 | 4 | 5 |
+
+DB delta: +6 `content_items`, +6 `content_company_profiles`, +10 `content_founders`,
++24 `content_sections`, +55 `content_bodies`, +38 `case_study_sources`.
+
+---
+
+## Pipeline (reused / extended from the UK enrichment)
+
+1. **Persist source** — Saved the signed-CloudFront HTML verbatim to `data/case-studies/irish_tier1_anz_research.html` (so the URL expiry doesn't break reproducibility).
+2. **`scripts/parse_irish_tier1.py`** — BeautifulSoup-based parser. For each `<section class="case-study">`:
+   - Reads the slug-code, h2, tagline, meta-strip, all `section-block`s.
+   - Renders entry-journey / outcomes / playbook tables → `<ul>` with `<strong>{key}</strong> — {value} <em>({detail})</em>` per row.
+   - Strips inline `<strong>` from cell content before wrapping (no nested tags).
+   - Pulls the editorial `callout` quote and renders as `<p><em>...</em></p>`. Named attributions (e.g. CEO quote) are kept; generic "MES editorial lesson" attributions are dropped.
+   - Resolves citation URLs to `case_study_sources` rows with domain-based source_type detection.
+   - Synthesizes a Key Metrics section from the meta-strip when the source lacks an explicit "Key outcomes" table (T-Pro, Fexco) — keeps every case at a uniform 4-section shape.
+3. **`scripts/generate_irish_tier1_sql.py`** — emits one idempotent DO block per case:
+   - `INSERT … ON CONFLICT (slug) DO UPDATE` for `content_items`
+   - `IF NOT EXISTS` skip-guards for `content_company_profiles` and `content_founders`
+   - lookup-or-INSERT pattern for `content_sections`
+   - `IF EXISTS / UPDATE / ELSE INSERT` pattern for `content_bodies`
+   - `INSERT … ON CONFLICT (case_study_id, url) DO NOTHING` for sources
+4. **Executed** via Supabase MCP, one DO block at a time.
+5. **Validated** with the 5-phase test suite from the UK enrichment.
+
+---
+
+## Validation results
+
+| Check | Result |
+|---|---|
+| All 6 cases `status='published'` and `content_type='case_study'` | ✅ 6/6 |
+| Section sort_order contiguous (1..N) within each case | ✅ no gaps |
+| Body sort_order contiguous within each section | ✅ no gaps |
+| No duplicate (section_id, sort_order) pairs | ✅ |
+| HTML tag balance (`<p>`, `<ul>`, `<li>`, `<strong>`, `<em>`) | ✅ all balanced |
+| Frontend hook compatibility (`useCaseStudy` filters + section shape) | ✅ 6/6 |
+| `category_id` resolves to a real row | ✅ |
+| `source_type` within the renderable enum | ✅ |
+| Idempotency: re-ran Clanwilliam, all counts unchanged | ✅ |
+| Pre-existing 45 case studies untouched (total now 51) | ✅ |
+
+---
+
+## Notable parsing decisions
+
+- **Slug normalisation.** Source uses ad-hoc slugs (`tpro-apac`, `kyckr-asx`, etc.). For directory consistency I normalised to `<company>-anz-market-entry`. The original is preserved in the parsed JSON (`legacy_slug`) for traceability.
+- **T-Pro founders.** The source narrates the company without naming founders, so `founder_count = NULL` and no `content_founders` rows. Manual backfill needed if desired.
+- **Spectrum.Life entry date.** Stored as `2026-01-01` (the company announced its triple acquisition on 17 March 2026 — recent-future-dated relative to the source). Worth re-checking `last_verified_at` once the deal closes formally.
+- **Fexco entry date.** Set to `2009-01-01` (NZ entry via Federal Pacific acquisition), reflecting Fexco's first ANZ presence rather than the September 2024 Australian launch.
+
+---
+
+## Files added in this task
+
+- `data/case-studies/irish_tier1_anz_research.html` — verbatim source (75KB, 6 case studies)
+- `scripts/parse_irish_tier1.py` — BeautifulSoup-based HTML → JSON parser
+- `scripts/parsed_irish_tier1.json` — parsed records
+- `scripts/generate_irish_tier1_sql.py` — idempotent SQL generator
+- `scripts/irish_tier1_import.sql` — bundled SQL
+- `scripts/irish_tier1_import_blocks/{NN}-{slug}.sql` — one DO block per case
+- `reports/irish-tier1-import-summary-2026-05-08.md` — this file
+
+---
+
+## Aggregate ANZ case-study count
+
+After this import: **31 ANZ market-entry case studies** total.
+- 5 original Irish (May 2026 batch)
+- 20 enriched UK (May 2026)
+- **6 new Irish Tier 1 (this PR)**
+
+(Plus 20 unrelated `*-australia-market-entry` cases from other workflows, total `case_study` rows now 51.)

--- a/scripts/generate_irish_tier1_sql.py
+++ b/scripts/generate_irish_tier1_sql.py
@@ -1,0 +1,213 @@
+"""Generate idempotent PL/pgSQL DO blocks per Irish Tier 1 case study.
+
+Net-new slugs (none of these 6 exist in the DB), so we use:
+  - INSERT … ON CONFLICT (slug) DO UPDATE for content_items
+  - skip-if-exists for content_company_profiles, content_founders
+  - lookup-or-INSERT for content_sections
+  - UPDATE-or-INSERT for content_bodies (no unique constraint exists,
+    so we use IF EXISTS / ELSE INSERT — same pattern as the UK enrichment)
+  - INSERT ON CONFLICT (case_study_id, url) DO NOTHING for sources
+
+Re-running any block is a no-op.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PARSED_PATH = REPO_ROOT / "scripts" / "parsed_irish_tier1.json"
+OUT_BUNDLE = REPO_ROOT / "scripts" / "irish_tier1_import.sql"
+OUT_DIR = REPO_ROOT / "scripts" / "irish_tier1_import_blocks"
+
+CATEGORY_MAP = {
+    "Fintech Success": "0563b826-2123-4627-b912-14f63e9fbfb6",
+    "Technology Market Entry": "6a837ef6-c7b5-457c-8069-2b8da9c85716",
+}
+
+
+def sql_str(s: str | None) -> str:
+    if s is None or s == "":
+        return "NULL"
+    return "'" + s.replace("'", "''") + "'"
+
+
+def sql_text_array(items: list[str]) -> str:
+    if not items:
+        return "ARRAY[]::text[]"
+    return "ARRAY[" + ", ".join(sql_str(i) for i in items) + "]::text[]"
+
+
+def sql_jsonb(obj) -> str:
+    return sql_str(json.dumps(obj, ensure_ascii=False)) + "::jsonb"
+
+
+SECTION_VAR_MAP = {
+    "entry-strategy": "v_sec_entry",
+    "success-factors": "v_sec_success",
+    "key-metrics": "v_sec_metrics",
+    "lessons-learned": "v_sec_lessons",
+}
+
+
+def block_for_case(case: dict) -> str:
+    slug = case["slug"]
+    title = case["title"]
+    subtitle = case.get("subtitle")
+    category_id = CATEGORY_MAP[case["category"]]
+    tldr = case.get("tldr") or []
+    quick_facts = case.get("quick_facts") or []
+    read_time = case.get("read_time") or 2
+    sections = case.get("sections") or []
+    founders = case.get("founders") or []
+    sources = case.get("sources") or []
+    company = case["company_name"]
+    industry = case.get("industry")
+    company_founded = case.get("company_founded")
+    entry_year = case.get("entry_year")
+
+    lines: list[str] = []
+    lines.append("DO $do_block$")
+    lines.append("DECLARE")
+    lines.append("  v_id uuid;")
+    for sec in sections:
+        var = SECTION_VAR_MAP.get(sec["slug"])
+        if var:
+            lines.append(f"  {var} uuid;")
+    lines.append("BEGIN")
+
+    # ---------------- content_items UPSERT ----------------
+    lines.append("  INSERT INTO content_items (")
+    lines.append("    slug, title, subtitle, category_id, content_type, status, featured,")
+    lines.append("    read_time, tldr, quick_facts, researched_by, style_version")
+    lines.append("  ) VALUES (")
+    lines.append(f"    {sql_str(slug)}, {sql_str(title)}, {sql_str(subtitle)},")
+    lines.append(f"    {sql_str(category_id)}::uuid, 'case_study', 'published', false,")
+    lines.append(
+        f"    {read_time}, {sql_text_array(tldr)}, {sql_jsonb(quick_facts)}, "
+        "'Stephen Browne', 2"
+    )
+    lines.append("  )")
+    lines.append("  ON CONFLICT (slug) DO UPDATE SET")
+    lines.append("    title = EXCLUDED.title,")
+    lines.append("    subtitle = EXCLUDED.subtitle,")
+    lines.append("    category_id = EXCLUDED.category_id,")
+    lines.append("    status = EXCLUDED.status,")
+    lines.append("    read_time = EXCLUDED.read_time,")
+    lines.append("    tldr = EXCLUDED.tldr,")
+    lines.append("    quick_facts = EXCLUDED.quick_facts,")
+    lines.append("    researched_by = EXCLUDED.researched_by,")
+    lines.append("    style_version = EXCLUDED.style_version")
+    lines.append("  RETURNING id INTO v_id;")
+    lines.append("")
+
+    # ---------------- content_company_profiles ----------------
+    lines.append("  IF NOT EXISTS (SELECT 1 FROM content_company_profiles WHERE content_id = v_id) THEN")
+    lines.append("    INSERT INTO content_company_profiles (")
+    lines.append("      content_id, company_name, origin_country, target_market,")
+    lines.append("      entry_date, industry, founder_count, employee_count, is_profitable")
+    lines.append("    ) VALUES (")
+    fc = len(founders) if founders else "NULL"
+    lines.append(
+        f"      v_id, {sql_str(company)}, 'Ireland', 'Australia & New Zealand',"
+    )
+    entry_date_sql = sql_str(f"{entry_year}-01-01") if entry_year else "NULL"
+    lines.append(
+        f"      {entry_date_sql}, {sql_str(industry)}, {fc}, NULL, NULL"
+    )
+    lines.append("    );")
+    lines.append("  END IF;")
+    lines.append("")
+
+    # ---------------- content_founders ----------------
+    if founders:
+        lines.append("  IF NOT EXISTS (SELECT 1 FROM content_founders WHERE content_id = v_id) THEN")
+        for f in founders:
+            primary = "true" if f.get("is_primary") else "false"
+            lines.append("    INSERT INTO content_founders (content_id, name, title, is_primary)")
+            lines.append(
+                f"    VALUES (v_id, {sql_str(f['name'])}, "
+                f"{sql_str(f.get('title') or 'Founder')}, {primary});"
+            )
+        lines.append("  END IF;")
+        lines.append("")
+
+    # ---------------- sections + bodies ----------------
+    for i, sec in enumerate(sections, start=1):
+        slug_sec = sec["slug"]
+        var = SECTION_VAR_MAP.get(slug_sec)
+        if not var:
+            continue
+        lines.append(f"  -- Section: {slug_sec}")
+        lines.append(f"  SELECT id INTO {var} FROM content_sections")
+        lines.append(f"   WHERE content_id = v_id AND slug = {sql_str(slug_sec)};")
+        lines.append(f"  IF {var} IS NULL THEN")
+        lines.append(
+            "    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)"
+        )
+        lines.append(
+            f"    VALUES (v_id, {sql_str(sec['title'])}, {sql_str(slug_sec)}, {i}, true)"
+        )
+        lines.append(f"    RETURNING id INTO {var};")
+        lines.append("  ELSE")
+        lines.append("    UPDATE content_sections")
+        lines.append(f"      SET title = {sql_str(sec['title'])}, sort_order = {i}, is_active = true")
+        lines.append(f"      WHERE id = {var};")
+        lines.append("  END IF;")
+        for j, body in enumerate(sec["bodies"], start=1):
+            lines.append(
+                f"  IF EXISTS (SELECT 1 FROM content_bodies "
+                f"WHERE section_id = {var} AND sort_order = {j}) THEN"
+            )
+            lines.append(
+                f"    UPDATE content_bodies SET body_text = {sql_str(body)}, updated_at = now()"
+            )
+            lines.append(f"      WHERE section_id = {var} AND sort_order = {j};")
+            lines.append("  ELSE")
+            lines.append(
+                "    INSERT INTO content_bodies "
+                "(content_id, section_id, body_text, sort_order, content_type)"
+            )
+            lines.append(
+                f"    VALUES (v_id, {var}, {sql_str(body)}, {j}, 'case_study');"
+            )
+            lines.append("  END IF;")
+        lines.append("")
+
+    # ---------------- sources ----------------
+    for s in sources:
+        cn = s.get("citation_number")
+        cn_sql = str(cn) if cn else "NULL"
+        stype = s.get("source_type") or "other"
+        lines.append(
+            "  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)"
+        )
+        lines.append(
+            f"  VALUES (v_id, {sql_str(s['label'])}, {sql_str(s['url'])}, {cn_sql}, {sql_str(stype)})"
+        )
+        lines.append("  ON CONFLICT (case_study_id, url) DO NOTHING;")
+
+    lines.append("END")
+    lines.append("$do_block$;")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    cases = json.loads(PARSED_PATH.read_text(encoding="utf-8"))
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    bundle_parts: list[str] = []
+    for i, case in enumerate(cases, start=1):
+        block = block_for_case(case)
+        per_file = OUT_DIR / f"{i:02d}-{case['slug']}.sql"
+        per_file.write_text(block, encoding="utf-8")
+        bundle_parts.append(f"-- Case {i}/{len(cases)}: {case['company_name']} ({case['slug']})")
+        bundle_parts.append(block)
+    OUT_BUNDLE.write_text("\n".join(bundle_parts), encoding="utf-8")
+    print(f"Wrote {len(cases)} import blocks to {OUT_DIR}")
+    print(f"Bundle: {OUT_BUNDLE}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/irish_tier1_import.sql
+++ b/scripts/irish_tier1_import.sql
@@ -1,0 +1,1097 @@
+-- Case 1/6: Clanwilliam (clanwilliam-anz-market-entry)
+DO $do_block$
+DECLARE
+  v_id uuid;
+  v_sec_entry uuid;
+  v_sec_success uuid;
+  v_sec_metrics uuid;
+  v_sec_lessons uuid;
+BEGIN
+  INSERT INTO content_items (
+    slug, title, subtitle, category_id, content_type, status, featured,
+    read_time, tldr, quick_facts, researched_by, style_version
+  ) VALUES (
+    'clanwilliam-anz-market-entry', 'How Clanwilliam Entered the ANZ Market', 'How a Dublin-founded healthtech group turned a series of ANZ acquisitions into a dominant clinical communications and connected-care platform spanning Australia and New Zealand.',
+    '6a837ef6-c7b5-457c-8069-2b8da9c85716'::uuid, 'case_study', 'published', false,
+    3, ARRAY['How a Dublin-founded healthtech group turned a series of ANZ acquisitions into a dominant clinical communications and connected-care platform spanning Australia and New Zealand.', 'Clanwilliam is an Irish healthcare technology group founded in 1996 by Howard Beggs.']::text[], '[{"icon": "MapPin", "label": "HQ", "value": "Ireland"}, {"icon": "Briefcase", "label": "Sector", "value": "Healthtech"}, {"icon": "Globe", "label": "Target Market", "value": "Australia & New Zealand"}]'::jsonb, 'Stephen Browne', 2
+  )
+  ON CONFLICT (slug) DO UPDATE SET
+    title = EXCLUDED.title,
+    subtitle = EXCLUDED.subtitle,
+    category_id = EXCLUDED.category_id,
+    status = EXCLUDED.status,
+    read_time = EXCLUDED.read_time,
+    tldr = EXCLUDED.tldr,
+    quick_facts = EXCLUDED.quick_facts,
+    researched_by = EXCLUDED.researched_by,
+    style_version = EXCLUDED.style_version
+  RETURNING id INTO v_id;
+
+  IF NOT EXISTS (SELECT 1 FROM content_company_profiles WHERE content_id = v_id) THEN
+    INSERT INTO content_company_profiles (
+      content_id, company_name, origin_country, target_market,
+      entry_date, industry, founder_count, employee_count, is_profitable
+    ) VALUES (
+      v_id, 'Clanwilliam', 'Ireland', 'Australia & New Zealand',
+      '2017-01-01', 'Healthtech', 1, NULL, NULL
+    );
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM content_founders WHERE content_id = v_id) THEN
+    INSERT INTO content_founders (content_id, name, title, is_primary)
+    VALUES (v_id, 'Howard Beggs', 'Founder', true);
+  END IF;
+
+  -- Section: entry-strategy
+  SELECT id INTO v_sec_entry FROM content_sections
+   WHERE content_id = v_id AND slug = 'entry-strategy';
+  IF v_sec_entry IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Entry Strategy', 'entry-strategy', 1, true)
+    RETURNING id INTO v_sec_entry;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Entry Strategy', sort_order = 1, is_active = true
+      WHERE id = v_sec_entry;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p>Clanwilliam is an Irish healthcare technology group founded in 1996 by Howard Beggs. Its ANZ story is one of the clearest examples in the MES library of a company using acquisition to buy embedded market trust rather than attempting to build it from scratch against entrenched local competitors.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>Clanwilliam is an Irish healthcare technology group founded in 1996 by Howard Beggs. Its ANZ story is one of the clearest examples in the MES library of a company using acquisition to buy embedded market trust rather than attempting to build it from scratch against entrenched local competitors.</p>', 1, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 2) THEN
+    UPDATE content_bodies SET body_text = '<p>Rather than launch a sales operation into an unfamiliar healthcare system, Clanwilliam acquired businesses that were already woven into clinical workflows across Australian and New Zealand healthcare. That strategy gave it immediate network effects, customer relationships, and regulatory familiarity that would have taken years to replicate organically.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 2;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>Rather than launch a sales operation into an unfamiliar healthcare system, Clanwilliam acquired businesses that were already woven into clinical workflows across Australian and New Zealand healthcare. That strategy gave it immediate network effects, customer relationships, and regulatory familiarity that would have taken years to replicate organically.</p>', 2, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 3) THEN
+    UPDATE content_bodies SET body_text = '<p>Australian and New Zealand healthcare offered a compelling structural opportunity: both markets were digitising clinical communications but remained fragmented, with legacy secure messaging providers sitting alongside newer referral and data-exchange tools. Clanwilliam identified that connecting these silos was a solvable problem — but only if you owned or operated key pieces of the exchange infrastructure.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 3;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>Australian and New Zealand healthcare offered a compelling structural opportunity: both markets were digitising clinical communications but remained fragmented, with legacy secure messaging providers sitting alongside newer referral and data-exchange tools. Clanwilliam identified that connecting these silos was a solvable problem — but only if you owned or operated key pieces of the exchange infrastructure.</p>', 3, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 4) THEN
+    UPDATE content_bodies SET body_text = '<p>The English-language operating environment, a shared regulatory philosophy with Ireland, and strong government investment in digital health infrastructure made ANZ particularly accessible for an Irish company with deep healthcare workflow expertise.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 4;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>The English-language operating environment, a shared regulatory philosophy with Ireland, and strong government investment in digital health infrastructure made ANZ particularly accessible for an Irish company with deep healthcare workflow expertise.</p>', 4, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 5) THEN
+    UPDATE content_bodies SET body_text = '<ul><li><strong>2017</strong> — Acquired HealthLink (NZ-founded, ANZ coverage) <em>(Gained an established health messaging network across ANZ, including 15,000+ connected medical organisations.)</em></li><li><strong>2017–18</strong> — Acquired Konnect NET <em>(Added pharmacy connectivity and additional healthcare workflow capability in Australia.)</em></li><li><strong>Dec 2020</strong> — Merged HealthLink and Konnect NET <em>(Reduced regional operational fragmentation and created a cleaner ANZ platform structure ahead of further growth.)</em></li><li><strong>Mar 2024</strong> — Launched formal ANZ Division <em>(Formalised regional leadership (David Young as MD Australia, Mike Weiss as MD NZ) with four products: HealthLink, Konnect NET, Toniq, MBS.)</em></li><li><strong>Jan 2024</strong> — HealthLink acquired Telstra Health''s Argus, Connecting Care and eReferrals assets <em>(Consolidated a major competitor/complementary player; deepened secure messaging and e-referral market share across Australian healthcare.)</em></li></ul>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 5;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<ul><li><strong>2017</strong> — Acquired HealthLink (NZ-founded, ANZ coverage) <em>(Gained an established health messaging network across ANZ, including 15,000+ connected medical organisations.)</em></li><li><strong>2017–18</strong> — Acquired Konnect NET <em>(Added pharmacy connectivity and additional healthcare workflow capability in Australia.)</em></li><li><strong>Dec 2020</strong> — Merged HealthLink and Konnect NET <em>(Reduced regional operational fragmentation and created a cleaner ANZ platform structure ahead of further growth.)</em></li><li><strong>Mar 2024</strong> — Launched formal ANZ Division <em>(Formalised regional leadership (David Young as MD Australia, Mike Weiss as MD NZ) with four products: HealthLink, Konnect NET, Toniq, MBS.)</em></li><li><strong>Jan 2024</strong> — HealthLink acquired Telstra Health''s Argus, Connecting Care and eReferrals assets <em>(Consolidated a major competitor/complementary player; deepened secure messaging and e-referral market share across Australian healthcare.)</em></li></ul>', 5, 'case_study');
+  END IF;
+
+  -- Section: success-factors
+  SELECT id INTO v_sec_success FROM content_sections
+   WHERE content_id = v_id AND slug = 'success-factors';
+  IF v_sec_success IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Success Factors', 'success-factors', 2, true)
+    RETURNING id INTO v_sec_success;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Success Factors', sort_order = 2, is_active = true
+      WHERE id = v_sec_success;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_success AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p><em>In regulated health markets, the fastest route to credibility is to buy trust that is already embedded in the workflow — then consolidate around interoperability.</em></p>', updated_at = now()
+      WHERE section_id = v_sec_success AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_success, '<p><em>In regulated health markets, the fastest route to credibility is to buy trust that is already embedded in the workflow — then consolidate around interoperability.</em></p>', 1, 'case_study');
+  END IF;
+
+  -- Section: key-metrics
+  SELECT id INTO v_sec_metrics FROM content_sections
+   WHERE content_id = v_id AND slug = 'key-metrics';
+  IF v_sec_metrics IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Key Metrics & Performance', 'key-metrics', 3, true)
+    RETURNING id INTO v_sec_metrics;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Key Metrics & Performance', sort_order = 3, is_active = true
+      WHERE id = v_sec_metrics;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_metrics AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<ul><li><strong>Medical organisations connected</strong> — 15,000+ across Australasia <em>(HealthLink network data (healthlink.com.au))</em></li><li><strong>Clinical messages per year</strong> — 100 million+ <em>(HealthLink network data)</em></li><li><strong>ANZ Division product count</strong> — 4 (HealthLink, Konnect NET, Toniq, MBS) <em>(ANZ Division launch announcement, March 2024)</em></li><li><strong>Telstra Health assets acquired</strong> — Argus, Connecting Care, eReferrals <em>(MinterEllison deal announcement, Jan 2024)</em></li></ul>', updated_at = now()
+      WHERE section_id = v_sec_metrics AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_metrics, '<ul><li><strong>Medical organisations connected</strong> — 15,000+ across Australasia <em>(HealthLink network data (healthlink.com.au))</em></li><li><strong>Clinical messages per year</strong> — 100 million+ <em>(HealthLink network data)</em></li><li><strong>ANZ Division product count</strong> — 4 (HealthLink, Konnect NET, Toniq, MBS) <em>(ANZ Division launch announcement, March 2024)</em></li><li><strong>Telstra Health assets acquired</strong> — Argus, Connecting Care, eReferrals <em>(MinterEllison deal announcement, Jan 2024)</em></li></ul>', 1, 'case_study');
+  END IF;
+
+  -- Section: lessons-learned
+  SELECT id INTO v_sec_lessons FROM content_sections
+   WHERE content_id = v_id AND slug = 'lessons-learned';
+  IF v_sec_lessons IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Lessons Learned', 'lessons-learned', 4, true)
+    RETURNING id INTO v_sec_lessons;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Lessons Learned', sort_order = 4, is_active = true
+      WHERE id = v_sec_lessons;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_lessons AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p>For Irish operators considering ANZ entry, Clanwilliam''s playbook offers a clear template. The lessons below distil Clanwilliam''s entry decisions, partner choices, and milestones in Australia &amp; New Zealand.</p>', updated_at = now()
+      WHERE section_id = v_sec_lessons AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_lessons, '<p>For Irish operators considering ANZ entry, Clanwilliam''s playbook offers a clear template. The lessons below distil Clanwilliam''s entry decisions, partner choices, and milestones in Australia &amp; New Zealand.</p>', 1, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_lessons AND sort_order = 2) THEN
+    UPDATE content_bodies SET body_text = '<ul><li><strong>Buy installed trust</strong> — Acquired HealthLink''s embedded clinical messaging network rather than building one. <em>(In complex systems, distribution is often acquired, not invented. Look for businesses with workflow lock-in.)</em></li><li><strong>Integrate before scaling</strong> — Merged HealthLink and Konnect NET before launching a formal ANZ division. <em>(Operational coherence should precede expansion messaging. Don''t promote fragmented assets.)</em></li><li><strong>Consolidate adjacencies</strong> — Acquired Telstra Health''s overlapping secure messaging and e-referrals footprint. <em>(Once inside a workflow category, strengthen the moat by absorbing complementary infrastructure before a competitor does.)</em></li><li><strong>Formalise with leadership</strong> — Appointed dedicated MD for Australia and MD for NZ as part of division launch. <em>(A named regional leader signals permanence to customers, partners and regulators more than any press release.)</em></li></ul>', updated_at = now()
+      WHERE section_id = v_sec_lessons AND sort_order = 2;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_lessons, '<ul><li><strong>Buy installed trust</strong> — Acquired HealthLink''s embedded clinical messaging network rather than building one. <em>(In complex systems, distribution is often acquired, not invented. Look for businesses with workflow lock-in.)</em></li><li><strong>Integrate before scaling</strong> — Merged HealthLink and Konnect NET before launching a formal ANZ division. <em>(Operational coherence should precede expansion messaging. Don''t promote fragmented assets.)</em></li><li><strong>Consolidate adjacencies</strong> — Acquired Telstra Health''s overlapping secure messaging and e-referrals footprint. <em>(Once inside a workflow category, strengthen the moat by absorbing complementary infrastructure before a competitor does.)</em></li><li><strong>Formalise with leadership</strong> — Appointed dedicated MD for Australia and MD for NZ as part of division launch. <em>(A named regional leader signals permanence to customers, partners and regulators more than any press release.)</em></li></ul>', 2, 'case_study');
+  END IF;
+
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'ANZ Division launch announcement', 'https://insurtechnz.org.nz/2024/03/12/clanwilliam-launches-anz-division-in-a-commitment-to-the-future-of-healthcare-across-australia-and-new-zealand/', 1, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'MinterEllison on Telstra Health acquisition', 'https://www.minterellison.com/articles/minterellison-advises-clanwilliam-on-telstra-health-acquisition', 2, 'company_blog')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Telstra Health sale announcement', 'https://www.telstrahealth.com/healthlink-acquires-telstra-health-argus-connecting-care-and-ereferrals-business/', 3, 'company_blog')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'HealthLink acquisition background (Waterman)', 'https://www.waterman.co.nz/news/healthlink-acquired-by-global-healthcare-technology-specialist/', 4, 'company_blog')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Pulse IT on Telstra Health Argus deal', 'https://www.pulseit.news/australian-digital-health/healthlink-swoops-on-telstra-healths-secure-messaging-and-ereferrals-business/', 5, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'HealthLink network scale (corporate site)', 'https://www.healthlink.com.au/clanwilliams-healthlink-acquires-telstra-healths-argus-connecting-care-and-ereferrals-business/', 6, 'company_blog')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+END
+$do_block$;
+
+-- Case 2/6: Spectrum.Life (spectrum-life-anz-market-entry)
+DO $do_block$
+DECLARE
+  v_id uuid;
+  v_sec_entry uuid;
+  v_sec_success uuid;
+  v_sec_metrics uuid;
+  v_sec_lessons uuid;
+BEGIN
+  INSERT INTO content_items (
+    slug, title, subtitle, category_id, content_type, status, featured,
+    read_time, tldr, quick_facts, researched_by, style_version
+  ) VALUES (
+    'spectrum-life-anz-market-entry', 'How Spectrum.Life Entered the ANZ Market', 'How a Dublin-founded digital wellbeing platform skipped the greenfield build and entered Australia simultaneously across three complementary verticals — workplace mental health, EAP, and specialist virtual care — by acquiring three local businesses on the same day.',
+    '0563b826-2123-4627-b912-14f63e9fbfb6'::uuid, 'case_study', 'published', false,
+    4, ARRAY['How a Dublin-founded digital wellbeing platform skipped the greenfield build and entered Australia simultaneously across three complementary verticals — workplace mental health, EAP, and specialist virtual care — by acquiring three local businesses on the same day.', 'Spectrum.Life was founded in Dublin in 2018 by Stuart McGoldrick and Stephen Costello.']::text[], '[{"icon": "MapPin", "label": "HQ", "value": "Ireland"}, {"icon": "Briefcase", "label": "Sector", "value": "Insurtech"}, {"icon": "Globe", "label": "Target Market", "value": "Australia & New Zealand"}]'::jsonb, 'Stephen Browne', 2
+  )
+  ON CONFLICT (slug) DO UPDATE SET
+    title = EXCLUDED.title,
+    subtitle = EXCLUDED.subtitle,
+    category_id = EXCLUDED.category_id,
+    status = EXCLUDED.status,
+    read_time = EXCLUDED.read_time,
+    tldr = EXCLUDED.tldr,
+    quick_facts = EXCLUDED.quick_facts,
+    researched_by = EXCLUDED.researched_by,
+    style_version = EXCLUDED.style_version
+  RETURNING id INTO v_id;
+
+  IF NOT EXISTS (SELECT 1 FROM content_company_profiles WHERE content_id = v_id) THEN
+    INSERT INTO content_company_profiles (
+      content_id, company_name, origin_country, target_market,
+      entry_date, industry, founder_count, employee_count, is_profitable
+    ) VALUES (
+      v_id, 'Spectrum.Life', 'Ireland', 'Australia & New Zealand',
+      '2026-01-01', 'Insurtech', 2, NULL, NULL
+    );
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM content_founders WHERE content_id = v_id) THEN
+    INSERT INTO content_founders (content_id, name, title, is_primary)
+    VALUES (v_id, 'Stuart McGoldrick', 'Co-founder', true);
+    INSERT INTO content_founders (content_id, name, title, is_primary)
+    VALUES (v_id, 'Stephen Costello', 'Co-founder', false);
+  END IF;
+
+  -- Section: entry-strategy
+  SELECT id INTO v_sec_entry FROM content_sections
+   WHERE content_id = v_id AND slug = 'entry-strategy';
+  IF v_sec_entry IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Entry Strategy', 'entry-strategy', 1, true)
+    RETURNING id INTO v_sec_entry;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Entry Strategy', sort_order = 1, is_active = true
+      WHERE id = v_sec_entry;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p>Spectrum.Life was founded in Dublin in 2018 by Stuart McGoldrick and Stephen Costello. It operates a digital-first mental health and wellbeing platform serving employers, insurers and universities. The platform covers proactive wellbeing tools, digital therapy, EAP, and clinical triage through a single access point — making it well positioned to replace the fragmented point-solutions most employers and insurers were managing.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>Spectrum.Life was founded in Dublin in 2018 by Stuart McGoldrick and Stephen Costello. It operates a digital-first mental health and wellbeing platform serving employers, insurers and universities. The platform covers proactive wellbeing tools, digital therapy, EAP, and clinical triage through a single access point — making it well positioned to replace the fragmented point-solutions most employers and insurers were managing.</p>', 1, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 2) THEN
+    UPDATE content_bodies SET body_text = '<p>By 2024, the company served more than 4,000 corporate clients and 7.5 million insurance members. It raised a €17 million Series B round in May 2024 from Act Venture Capital and existing investors to fund international expansion — naming Australia as a target. In October 2024, it crossed 300 staff globally, and publicly targeted 500 by end of 2025 and revenue of €100 million by 2028.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 2;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>By 2024, the company served more than 4,000 corporate clients and 7.5 million insurance members. It raised a €17 million Series B round in May 2024 from Act Venture Capital and existing investors to fund international expansion — naming Australia as a target. In October 2024, it crossed 300 staff globally, and publicly targeted 500 by end of 2025 and revenue of €100 million by 2028.</p>', 2, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 3) THEN
+    UPDATE content_bodies SET body_text = '<p>Australia presented a near-perfect storm of demand drivers. Mental health-related workers'' compensation claims had risen 37 percent since 2017–18. Life insurance TPD claims for mental health among people in their 30s had risen by 732 percent over a decade. Employers were under pressure from new psychosocial safety obligations introduced in Australian WHS laws. And the EAP provider market remained fragmented, largely phone-based, and resistant to digital change.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 3;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>Australia presented a near-perfect storm of demand drivers. Mental health-related workers'' compensation claims had risen 37 percent since 2017–18. Life insurance TPD claims for mental health among people in their 30s had risen by 732 percent over a decade. Employers were under pressure from new psychosocial safety obligations introduced in Australian WHS laws. And the EAP provider market remained fragmented, largely phone-based, and resistant to digital change.</p>', 3, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 4) THEN
+    UPDATE content_bodies SET body_text = '<p>Spectrum.Life had already demonstrated in Ireland and the UK that a digitally-led, outcomes-focused model could win enterprise clients quickly. Australia replicated those macro conditions — regulatory tailwind, insurer pressure, employer demand — and offered a large enough addressable market to justify major investment.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 4;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>Spectrum.Life had already demonstrated in Ireland and the UK that a digitally-led, outcomes-focused model could win enterprise clients quickly. Australia replicated those macro conditions — regulatory tailwind, insurer pressure, employer demand — and offered a large enough addressable market to justify major investment.</p>', 4, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 5) THEN
+    UPDATE content_bodies SET body_text = '<p>On 17 March 2026, Spectrum.Life announced the simultaneous acquisition of three Australian businesses: MindFit at Work (Melbourne), We Lysn (Sydney) and Valion Health (Sydney). The company was explicit that it chose not to enter organically — it wanted immediate clinical depth, local regulatory familiarity and customer relationships that only established local operators could provide.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 5;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>On 17 March 2026, Spectrum.Life announced the simultaneous acquisition of three Australian businesses: MindFit at Work (Melbourne), We Lysn (Sydney) and Valion Health (Sydney). The company was explicit that it chose not to enter organically — it wanted immediate clinical depth, local regulatory familiarity and customer relationships that only established local operators could provide.</p>', 5, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 6) THEN
+    UPDATE content_bodies SET body_text = '<ul><li><strong>MindFit at Work</strong> — Melbourne <em>(Evidence-based workplace mental health and psychosocial risk programmes; APAC coverage including Singapore)</em></li><li><strong>We Lysn</strong> — Sydney <em>(Digital mental health, EAP, telehealth counselling (same/next-day access))</em></li><li><strong>Valion Health</strong> — Sydney <em>(ACHS-accredited specialist virtual care (cancer, metabolic, chronic conditions))</em></li></ul>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 6;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<ul><li><strong>MindFit at Work</strong> — Melbourne <em>(Evidence-based workplace mental health and psychosocial risk programmes; APAC coverage including Singapore)</em></li><li><strong>We Lysn</strong> — Sydney <em>(Digital mental health, EAP, telehealth counselling (same/next-day access))</em></li><li><strong>Valion Health</strong> — Sydney <em>(ACHS-accredited specialist virtual care (cancer, metabolic, chronic conditions))</em></li></ul>', 6, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 7) THEN
+    UPDATE content_bodies SET body_text = '<p>The three businesses were highly complementary. Together they gave Spectrum.Life an employer-facing prevention product, a frontline digital counselling service, and a specialist insurer pathway — covering the full spectrum from early intervention to complex case management.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 7;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>The three businesses were highly complementary. Together they gave Spectrum.Life an employer-facing prevention product, a frontline digital counselling service, and a specialist insurer pathway — covering the full spectrum from early intervention to complex case management.</p>', 7, 'case_study');
+  END IF;
+
+  -- Section: success-factors
+  SELECT id INTO v_sec_success FROM content_sections
+   WHERE content_id = v_id AND slug = 'success-factors';
+  IF v_sec_success IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Success Factors', 'success-factors', 2, true)
+    RETURNING id INTO v_sec_success;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Success Factors', sort_order = 2, is_active = true
+      WHERE id = v_sec_success;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_success AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p><em>&ldquo;We chose to make a long-term strategic commitment to Australia. One platform. One clinical pathway. 24/7 clinical access. Measurable outcomes.&rdquo; <span style="color: var(--muted);">— Stephen Costello, CEO, Spectrum.Life (March 2026)</span></em></p>', updated_at = now()
+      WHERE section_id = v_sec_success AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_success, '<p><em>&ldquo;We chose to make a long-term strategic commitment to Australia. One platform. One clinical pathway. 24/7 clinical access. Measurable outcomes.&rdquo; <span style="color: var(--muted);">— Stephen Costello, CEO, Spectrum.Life (March 2026)</span></em></p>', 1, 'case_study');
+  END IF;
+
+  -- Section: key-metrics
+  SELECT id INTO v_sec_metrics FROM content_sections
+   WHERE content_id = v_id AND slug = 'key-metrics';
+  IF v_sec_metrics IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Key Metrics & Performance', 'key-metrics', 3, true)
+    RETURNING id INTO v_sec_metrics;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Key Metrics & Performance', sort_order = 3, is_active = true
+      WHERE id = v_sec_metrics;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_metrics AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<ul><li><strong>Australian employees at launch</strong> — 35 <em>(Healthcare & Protection, March 2026)</em></li><li><strong>New AU roles planned (12 months)</strong> — 100+ <em>(CFO Tech / Spectrum.Life press release)</em></li><li><strong>Global members at entry</strong> — 15 million+ <em>(Spectrum.Life funding announcement 2024)</em></li><li><strong>Global corporate clients</strong> — 4,000+ corporate / 7.5M insurance members <em>(InsurTech Insights interview, Nov 2024)</em></li><li><strong>Deloitte Fast 50 Ireland 2024 rank</strong> — 41st <em>(WireNews, November 2024)</em></li><li><strong>Revenue target</strong> — €100M by 2028 <em>(Business & Finance Q&A, June 2025)</em></li></ul>', updated_at = now()
+      WHERE section_id = v_sec_metrics AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_metrics, '<ul><li><strong>Australian employees at launch</strong> — 35 <em>(Healthcare & Protection, March 2026)</em></li><li><strong>New AU roles planned (12 months)</strong> — 100+ <em>(CFO Tech / Spectrum.Life press release)</em></li><li><strong>Global members at entry</strong> — 15 million+ <em>(Spectrum.Life funding announcement 2024)</em></li><li><strong>Global corporate clients</strong> — 4,000+ corporate / 7.5M insurance members <em>(InsurTech Insights interview, Nov 2024)</em></li><li><strong>Deloitte Fast 50 Ireland 2024 rank</strong> — 41st <em>(WireNews, November 2024)</em></li><li><strong>Revenue target</strong> — €100M by 2028 <em>(Business & Finance Q&A, June 2025)</em></li></ul>', 1, 'case_study');
+  END IF;
+
+  -- Section: lessons-learned
+  SELECT id INTO v_sec_lessons FROM content_sections
+   WHERE content_id = v_id AND slug = 'lessons-learned';
+  IF v_sec_lessons IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Lessons Learned', 'lessons-learned', 4, true)
+    RETURNING id INTO v_sec_lessons;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Lessons Learned', sort_order = 4, is_active = true
+      WHERE id = v_sec_lessons;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_lessons AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p>For Irish operators considering ANZ entry, Spectrum.Life''s playbook offers a clear template. The lessons below distil Spectrum.Life''s entry decisions, partner choices, and milestones in Australia &amp; New Zealand.</p>', updated_at = now()
+      WHERE section_id = v_sec_lessons AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_lessons, '<p>For Irish operators considering ANZ entry, Spectrum.Life''s playbook offers a clear template. The lessons below distil Spectrum.Life''s entry decisions, partner choices, and milestones in Australia &amp; New Zealand.</p>', 1, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_lessons AND sort_order = 2) THEN
+    UPDATE content_bodies SET body_text = '<ul><li><strong>Use one expansion market to validate the next</strong> — Built UK scale and proof points before targeting Australia. UK became the case study that made the Australia investment case. <em>(Sequence markets deliberately. Your second market is easier to enter if your first market has already proved the model works internationally.)</em></li><li><strong>Bundle complementary acquisitions</strong> — Bought three firms covering different parts of the care pathway simultaneously — employer prevention, frontline access, specialist care. <em>(When a category is fragmented, acquire breadth rather than build each component. Speed and coverage compound faster than organic build.)</em></li><li><strong>Use market data to justify the entry</strong> — Cited the 37% rise in AU mental health claims to underpin the commercial rationale in media and to prospects. <em>(Lead with the market problem, not the company. Local data makes your entry story immediately relevant to customers, partners and press.)</em></li><li><strong>Announce jobs alongside acquisitions</strong> — Committed to 100+ new roles within 12 months at the time of the acquisition announcement. <em>(Hiring commitments signal permanence to customers, regulators and local government. They also generate media coverage beyond the deal itself.)</em></li><li><strong>Lead with outcomes language</strong> — Positioned the combined platform around measurable outcomes and 24/7 clinical access — not features. <em>(In health and insurance, procurement teams respond to outcome architecture and accountability language, not feature lists.)</em></li></ul>', updated_at = now()
+      WHERE section_id = v_sec_lessons AND sort_order = 2;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_lessons, '<ul><li><strong>Use one expansion market to validate the next</strong> — Built UK scale and proof points before targeting Australia. UK became the case study that made the Australia investment case. <em>(Sequence markets deliberately. Your second market is easier to enter if your first market has already proved the model works internationally.)</em></li><li><strong>Bundle complementary acquisitions</strong> — Bought three firms covering different parts of the care pathway simultaneously — employer prevention, frontline access, specialist care. <em>(When a category is fragmented, acquire breadth rather than build each component. Speed and coverage compound faster than organic build.)</em></li><li><strong>Use market data to justify the entry</strong> — Cited the 37% rise in AU mental health claims to underpin the commercial rationale in media and to prospects. <em>(Lead with the market problem, not the company. Local data makes your entry story immediately relevant to customers, partners and press.)</em></li><li><strong>Announce jobs alongside acquisitions</strong> — Committed to 100+ new roles within 12 months at the time of the acquisition announcement. <em>(Hiring commitments signal permanence to customers, regulators and local government. They also generate media coverage beyond the deal itself.)</em></li><li><strong>Lead with outcomes language</strong> — Positioned the combined platform around measurable outcomes and 24/7 clinical access — not features. <em>(In health and insurance, procurement teams respond to outcome architecture and accountability language, not feature lists.)</em></li></ul>', 2, 'case_study');
+  END IF;
+
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Healthcare & Protection — triple acquisition announcement', 'https://healthcareandprotection.com/spectrum-life-expands-into-australia-through-mindfit-we-lysn-and-valion-acquisitions/', 1, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Spectrum.Life official press release', 'https://www.spectrum.life/resources/press-releases/spectrum-life-expands-into-australia-with-long-term-strategic-commitment/', 2, 'company_blog')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'CFO Tech Australia — triple acquisition coverage', 'https://cfotech.com.au/story/spectrum-life-buys-three-aussie-digital-health-firms', 3, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Melbourne Insider — Australia expansion story', 'https://melbourne-insider.au/spectrum-life-australia-expansion/', 4, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Silicon Republic — Series B funding announcement', 'https://www.siliconrepublic.com/start-ups/spectrum-life-funding-digital-health-ireland-uk', 5, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Spectrum.Life €17M funding announcement (official)', 'https://www.spectrum.life/resources/spectrum-life-funding-announcement-may-2024/', 6, 'company_blog')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'EIN Presswire — €17M round details and international growth plans', 'https://www.einpresswire.com/article/714935154/spectrum-life-closes-17m-investment-round-to-accelerate-international-growth', 7, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'InsurTech Insights — CEO Stephen Costello interview', 'https://www.insurtechinsights.com/startup-story-spectrum-life-ceo-and-co-founder-stephen-costello-talks-technology-and-wellbeing/', 8, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'TechBuzz Ireland — 300 staff milestone', 'https://techbuzzireland.com/2024/10/09/spectrum-life-surpasses-300-employees-and-eyes-growth-to-500-by-end-of-2025/', 9, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'WireNews — Deloitte Fast 50 Ireland 2024 ranking', 'https://www.wirenn.com/post/spectrum-life-ranked-41st-in-the-deloitte-ireland-2024-technology-fast-50-awards', 10, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Business & Finance Q&A — Stephen Costello on mission and €100M target', 'https://businessandfinance.com/news/my-primary-focus-is-delivering-on-our-mission-to-save-and-change-as-many-lives-as-possible-qanda-with-stephen-costello/', 11, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'AIHS.org.au — 37% mental health claims rise in Australian workers'' compensation', 'https://aihs.org.au/Web/Web/Advocacy-Media/All-News/2024/03-March/Mental-health-conditions-jump-37-per-cent-in-workers-compensation-claims.aspx', 12, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Valion Health — about page (founded by Michael Marthick)', 'https://valionhealth.com.au/about-valion/', 13, 'company_blog')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'SBS News — We Lysn founding story', 'https://www.sbs.com.au/news/small-business-secrets/article/how-start-up-lysn-is-removing-the-stigma-surrounding-seeking-mental-health-support/0x1cd1dtu', 14, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+END
+$do_block$;
+
+-- Case 3/6: T-Pro (t-pro-anz-market-entry)
+DO $do_block$
+DECLARE
+  v_id uuid;
+  v_sec_entry uuid;
+  v_sec_success uuid;
+  v_sec_metrics uuid;
+  v_sec_lessons uuid;
+BEGIN
+  INSERT INTO content_items (
+    slug, title, subtitle, category_id, content_type, status, featured,
+    read_time, tldr, quick_facts, researched_by, style_version
+  ) VALUES (
+    't-pro-anz-market-entry', 'How T-Pro Entered the ANZ Market', 'How a Dublin-founded healthcare speech and documentation company expanded across Australia and New Zealand through three targeted acquisitions — buying local customer relationships and clinical workflow knowledge faster than any organic sales team could build them.',
+    '6a837ef6-c7b5-457c-8069-2b8da9c85716'::uuid, 'case_study', 'published', false,
+    2, ARRAY['How a Dublin-founded healthcare speech and documentation company expanded across Australia and New Zealand through three targeted acquisitions — buying local customer relationships and clinical workflow knowledge faster than any organic sales team could build them.', 'T-Pro is an Irish healthcare technology company specialising in speech recognition, clinical documentation and AI-enabled workflow tools for healthcare providers.']::text[], '[{"icon": "MapPin", "label": "HQ", "value": "Ireland"}, {"icon": "Briefcase", "label": "Sector", "value": "Healthcare AI"}, {"icon": "Globe", "label": "Target Market", "value": "Australia & New Zealand"}]'::jsonb, 'Stephen Browne', 2
+  )
+  ON CONFLICT (slug) DO UPDATE SET
+    title = EXCLUDED.title,
+    subtitle = EXCLUDED.subtitle,
+    category_id = EXCLUDED.category_id,
+    status = EXCLUDED.status,
+    read_time = EXCLUDED.read_time,
+    tldr = EXCLUDED.tldr,
+    quick_facts = EXCLUDED.quick_facts,
+    researched_by = EXCLUDED.researched_by,
+    style_version = EXCLUDED.style_version
+  RETURNING id INTO v_id;
+
+  IF NOT EXISTS (SELECT 1 FROM content_company_profiles WHERE content_id = v_id) THEN
+    INSERT INTO content_company_profiles (
+      content_id, company_name, origin_country, target_market,
+      entry_date, industry, founder_count, employee_count, is_profitable
+    ) VALUES (
+      v_id, 'T-Pro', 'Ireland', 'Australia & New Zealand',
+      NULL, 'Healthcare AI', NULL, NULL, NULL
+    );
+  END IF;
+
+  -- Section: entry-strategy
+  SELECT id INTO v_sec_entry FROM content_sections
+   WHERE content_id = v_id AND slug = 'entry-strategy';
+  IF v_sec_entry IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Entry Strategy', 'entry-strategy', 1, true)
+    RETURNING id INTO v_sec_entry;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Entry Strategy', sort_order = 1, is_active = true
+      WHERE id = v_sec_entry;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p>T-Pro is an Irish healthcare technology company specialising in speech recognition, clinical documentation and AI-enabled workflow tools for healthcare providers. Its technology reduces the administrative burden on clinicians by automating documentation tasks from dictation to structured clinical notes.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>T-Pro is an Irish healthcare technology company specialising in speech recognition, clinical documentation and AI-enabled workflow tools for healthcare providers. Its technology reduces the administrative burden on clinicians by automating documentation tasks from dictation to structured clinical notes.</p>', 1, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 2) THEN
+    UPDATE content_bodies SET body_text = '<p>T-Pro''s ANZ expansion strategy was acquisition-led from the outset. Rather than entering with its own sales team or a channel partner, it identified established local documentation and transcription businesses that already had deep relationships with hospitals, clinics and healthcare networks — then acquired them and layered its AI documentation platform over the existing operations.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 2;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>T-Pro''s ANZ expansion strategy was acquisition-led from the outset. Rather than entering with its own sales team or a channel partner, it identified established local documentation and transcription businesses that already had deep relationships with hospitals, clinics and healthcare networks — then acquired them and layered its AI documentation platform over the existing operations.</p>', 2, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 3) THEN
+    UPDATE content_bodies SET body_text = '<ul><li><strong>2022</strong> — SyberScribe <em>(Melbourne, Australia)</em></li><li><strong>2022</strong> — Livingbridge investment <em>(UK PE backing)</em></li><li><strong>2023</strong> — NTS Transcriptions <em>(Australia)</em></li><li><strong>2025</strong> — Sound Business Systems (SBS) <em>(New Zealand + Australia)</em></li></ul>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 3;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<ul><li><strong>2022</strong> — SyberScribe <em>(Melbourne, Australia)</em></li><li><strong>2022</strong> — Livingbridge investment <em>(UK PE backing)</em></li><li><strong>2023</strong> — NTS Transcriptions <em>(Australia)</em></li><li><strong>2025</strong> — Sound Business Systems (SBS) <em>(New Zealand + Australia)</em></li></ul>', 3, 'case_study');
+  END IF;
+
+  -- Section: success-factors
+  SELECT id INTO v_sec_success FROM content_sections
+   WHERE content_id = v_id AND slug = 'success-factors';
+  IF v_sec_success IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Success Factors', 'success-factors', 2, true)
+    RETURNING id INTO v_sec_success;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Success Factors', sort_order = 2, is_active = true
+      WHERE id = v_sec_success;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_success AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p>Healthcare documentation sits at the intersection of clinician behaviour, data compliance and hospital IT infrastructure. Local relationships matter enormously because switching documentation tools requires clinical workflow change management — something hospitals only do when they trust the vendor deeply. T-Pro''s acquisition strategy meant it inherited trusted local operators rather than asking customers to take a risk on a remote Irish startup.</p>', updated_at = now()
+      WHERE section_id = v_sec_success AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_success, '<p>Healthcare documentation sits at the intersection of clinician behaviour, data compliance and hospital IT infrastructure. Local relationships matter enormously because switching documentation tools requires clinical workflow change management — something hospitals only do when they trust the vendor deeply. T-Pro''s acquisition strategy meant it inherited trusted local operators rather than asking customers to take a risk on a remote Irish startup.</p>', 1, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_success AND sort_order = 2) THEN
+    UPDATE content_bodies SET body_text = '<p>By acquiring three ANZ businesses rather than one, T-Pro built a narrative of regional commitment and demonstrated to healthcare networks that it was building a long-term APAC presence rather than testing the market opportunistically.</p>', updated_at = now()
+      WHERE section_id = v_sec_success AND sort_order = 2;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_success, '<p>By acquiring three ANZ businesses rather than one, T-Pro built a narrative of regional commitment and demonstrated to healthcare networks that it was building a long-term APAC presence rather than testing the market opportunistically.</p>', 2, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_success AND sort_order = 3) THEN
+    UPDATE content_bodies SET body_text = '<p><em>T-Pro''s ANZ story shows that in specialist enterprise categories, acquisitions function simultaneously as distribution, localisation and trust-building — compressing years of relationship development into a single transaction.</em></p>', updated_at = now()
+      WHERE section_id = v_sec_success AND sort_order = 3;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_success, '<p><em>T-Pro''s ANZ story shows that in specialist enterprise categories, acquisitions function simultaneously as distribution, localisation and trust-building — compressing years of relationship development into a single transaction.</em></p>', 3, 'case_study');
+  END IF;
+
+  -- Section: key-metrics
+  SELECT id INTO v_sec_metrics FROM content_sections
+   WHERE content_id = v_id AND slug = 'key-metrics';
+  IF v_sec_metrics IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Key Metrics & Performance', 'key-metrics', 3, true)
+    RETURNING id INTO v_sec_metrics;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Key Metrics & Performance', sort_order = 3, is_active = true
+      WHERE id = v_sec_metrics;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_metrics AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<ul><li><strong>Founded</strong>: Ireland</li><li><strong>Entry mode</strong>: Serial acquisition</li><li><strong>Acquisition 1</strong>: SyberScribe, Melbourne (2022)</li><li><strong>Acquisition 2</strong>: NTS Transcriptions, AU (2023)</li><li><strong>Acquisition 3</strong>: Sound Business Systems, NZ/AU (2025)</li><li><strong>PE backing</strong>: Livingbridge (2022)</li></ul>', updated_at = now()
+      WHERE section_id = v_sec_metrics AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_metrics, '<ul><li><strong>Founded</strong>: Ireland</li><li><strong>Entry mode</strong>: Serial acquisition</li><li><strong>Acquisition 1</strong>: SyberScribe, Melbourne (2022)</li><li><strong>Acquisition 2</strong>: NTS Transcriptions, AU (2023)</li><li><strong>Acquisition 3</strong>: Sound Business Systems, NZ/AU (2025)</li><li><strong>PE backing</strong>: Livingbridge (2022)</li></ul>', 1, 'case_study');
+  END IF;
+
+  -- Section: lessons-learned
+  SELECT id INTO v_sec_lessons FROM content_sections
+   WHERE content_id = v_id AND slug = 'lessons-learned';
+  IF v_sec_lessons IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Lessons Learned', 'lessons-learned', 4, true)
+    RETURNING id INTO v_sec_lessons;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Lessons Learned', sort_order = 4, is_active = true
+      WHERE id = v_sec_lessons;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_lessons AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p>For Irish operators considering ANZ entry, T-Pro''s playbook offers a clear template. The lessons below distil T-Pro''s entry decisions, partner choices, and milestones in Australia &amp; New Zealand.</p>', updated_at = now()
+      WHERE section_id = v_sec_lessons AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_lessons, '<p>For Irish operators considering ANZ entry, T-Pro''s playbook offers a clear template. The lessons below distil T-Pro''s entry decisions, partner choices, and milestones in Australia &amp; New Zealand.</p>', 1, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_lessons AND sort_order = 2) THEN
+    UPDATE content_bodies SET body_text = '<ul><li><strong>Let acquisitions replace the sales team</strong> — Each acquired business brought its own hospital and clinic relationships. <em>(In enterprise healthcare, distribution IS the product. Buying an established operator often beats hiring a country manager and starting from zero.)</em></li><li><strong>Layer technology over trusted operations</strong> — T-Pro applied its AI documentation platform over acquired businesses rather than replacing them. <em>(Don''t replace what works locally. Add your IP on top of existing customer trust.)</em></li><li><strong>Build a serial acquisition narrative</strong> — Three acquisitions created a regional expansion story that one deal could not. <em>(Announcing a second and third acquisition compounds the credibility signal from the first. You stop looking like an experiment and start looking like a regional player.)</em></li></ul>', updated_at = now()
+      WHERE section_id = v_sec_lessons AND sort_order = 2;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_lessons, '<ul><li><strong>Let acquisitions replace the sales team</strong> — Each acquired business brought its own hospital and clinic relationships. <em>(In enterprise healthcare, distribution IS the product. Buying an established operator often beats hiring a country manager and starting from zero.)</em></li><li><strong>Layer technology over trusted operations</strong> — T-Pro applied its AI documentation platform over acquired businesses rather than replacing them. <em>(Don''t replace what works locally. Add your IP on top of existing customer trust.)</em></li><li><strong>Build a serial acquisition narrative</strong> — Three acquisitions created a regional expansion story that one deal could not. <em>(Announcing a second and third acquisition compounds the credibility signal from the first. You stop looking like an experiment and start looking like a regional player.)</em></li></ul>', 2, 'case_study');
+  END IF;
+
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Silicon Republic — T-Pro acquires SyberScribe (2022)', 'https://www.siliconrepublic.com/business/t-pro-syberscribe-acquisition-australia-speech-transcription-technology', 1, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'ThinkBusiness — T-Pro voice AI and NTS (2024 profile)', 'https://www.thinkbusiness.ie/articles/tpro-voice-ai-speech-technology/', 2, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'T-Pro blog — Sound Business Systems joins the group', 'https://blog.tpro.io/sbs-part-of-tpro', 3, 'company_blog')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Livingbridge — T-Pro acquires SBS (PE announcement)', 'https://www.livingbridge.com/livingroom/t-pro-acquires-sound-business-systems-expanding-global-healthcare-ai-reach', 4, 'company_blog')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Sound Business Systems — corporate site', 'https://soundbusiness.co.nz', 5, 'company_blog')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+END
+$do_block$;
+
+-- Case 4/6: Fexco (fexco-anz-market-entry)
+DO $do_block$
+DECLARE
+  v_id uuid;
+  v_sec_entry uuid;
+  v_sec_success uuid;
+  v_sec_metrics uuid;
+  v_sec_lessons uuid;
+BEGIN
+  INSERT INTO content_items (
+    slug, title, subtitle, category_id, content_type, status, featured,
+    read_time, tldr, quick_facts, researched_by, style_version
+  ) VALUES (
+    'fexco-anz-market-entry', 'How Fexco Entered the ANZ Market', 'How a Kerry-founded payments and FX group used New Zealand as its Pacific base for over a decade, built a 400-person regional operation, and then used that platform to launch into Australian retail with hard numbers behind the expansion story.',
+    '0563b826-2123-4627-b912-14f63e9fbfb6'::uuid, 'case_study', 'published', false,
+    3, ARRAY['How a Kerry-founded payments and FX group used New Zealand as its Pacific base for over a decade, built a 400-person regional operation, and then used that platform to launch into Australian retail with hard numbers behind the expansion story.', 'Fexco is one of Ireland''s largest private companies, founded in 1981 in Killorglin, County Kerry by Brian McCarthy.']::text[], '[{"icon": "MapPin", "label": "HQ", "value": "Ireland"}, {"icon": "Briefcase", "label": "Sector", "value": "Fintech"}, {"icon": "Globe", "label": "Target Market", "value": "Australia & New Zealand"}]'::jsonb, 'Stephen Browne', 2
+  )
+  ON CONFLICT (slug) DO UPDATE SET
+    title = EXCLUDED.title,
+    subtitle = EXCLUDED.subtitle,
+    category_id = EXCLUDED.category_id,
+    status = EXCLUDED.status,
+    read_time = EXCLUDED.read_time,
+    tldr = EXCLUDED.tldr,
+    quick_facts = EXCLUDED.quick_facts,
+    researched_by = EXCLUDED.researched_by,
+    style_version = EXCLUDED.style_version
+  RETURNING id INTO v_id;
+
+  IF NOT EXISTS (SELECT 1 FROM content_company_profiles WHERE content_id = v_id) THEN
+    INSERT INTO content_company_profiles (
+      content_id, company_name, origin_country, target_market,
+      entry_date, industry, founder_count, employee_count, is_profitable
+    ) VALUES (
+      v_id, 'Fexco', 'Ireland', 'Australia & New Zealand',
+      '2009-01-01', 'Fintech', 1, NULL, NULL
+    );
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM content_founders WHERE content_id = v_id) THEN
+    INSERT INTO content_founders (content_id, name, title, is_primary)
+    VALUES (v_id, 'Brian McCarthy', 'Founder', true);
+  END IF;
+
+  -- Section: entry-strategy
+  SELECT id INTO v_sec_entry FROM content_sections
+   WHERE content_id = v_id AND slug = 'entry-strategy';
+  IF v_sec_entry IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Entry Strategy', 'entry-strategy', 1, true)
+    RETURNING id INTO v_sec_entry;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Entry Strategy', sort_order = 1, is_active = true
+      WHERE id = v_sec_entry;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p>Fexco is one of Ireland''s largest private companies, founded in 1981 in Killorglin, County Kerry by Brian McCarthy. It operates across payments, foreign exchange, financial services and business outsourcing. In the Pacific, its brand is anchored around currency exchange and remittance services under the No1 Currency banner, operating as a major Western Union master agent across the region.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>Fexco is one of Ireland''s largest private companies, founded in 1981 in Killorglin, County Kerry by Brian McCarthy. It operates across payments, foreign exchange, financial services and business outsourcing. In the Pacific, its brand is anchored around currency exchange and remittance services under the No1 Currency banner, operating as a major Western Union master agent across the region.</p>', 1, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 2) THEN
+    UPDATE content_bodies SET body_text = '<p>Fexco''s ANZ story begins in New Zealand. In 2009 it acquired Federal Pacific in Auckland, which it later renamed Fexco Pacific. From that base it expanded across New Zealand and Pacific island markets — building a network of 24 stores in New Zealand, over 100 offices and outlets across the Pacific, and a team of more than 400 staff. With more than two million transactions per year, Fexco Pacific became a significant financial services operation in its own right.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 2;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>Fexco''s ANZ story begins in New Zealand. In 2009 it acquired Federal Pacific in Auckland, which it later renamed Fexco Pacific. From that base it expanded across New Zealand and Pacific island markets — building a network of 24 stores in New Zealand, over 100 offices and outlets across the Pacific, and a team of more than 400 staff. With more than two million transactions per year, Fexco Pacific became a significant financial services operation in its own right.</p>', 2, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 3) THEN
+    UPDATE content_bodies SET body_text = '<p>In September 2024, Fexco took the next logical step and opened two No1 Currency stores in Sydney — at Westfield Hurstville and Westfield Liverpool. The company explicitly framed this as the start of a broader Australian rollout, with plans for more than 20 outlets and 80-plus local jobs.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 3;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>In September 2024, Fexco took the next logical step and opened two No1 Currency stores in Sydney — at Westfield Hurstville and Westfield Liverpool. The company explicitly framed this as the start of a broader Australian rollout, with plans for more than 20 outlets and 80-plus local jobs.</p>', 3, 'case_study');
+  END IF;
+
+  -- Section: success-factors
+  SELECT id INTO v_sec_success FROM content_sections
+   WHERE content_id = v_id AND slug = 'success-factors';
+  IF v_sec_success IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Success Factors', 'success-factors', 2, true)
+    RETURNING id INTO v_sec_success;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Success Factors', sort_order = 2, is_active = true
+      WHERE id = v_sec_success;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_success AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p>Most market-entry advice assumes Australia is the primary target and New Zealand is an afterthought. Fexco inverts this entirely. It built 15 years of Pacific operating experience before entering Australian retail — and when it did, it arrived with proven unit economics, brand recognition among Pacific diaspora communities, and a credible expansion narrative backed by real numbers.</p>', updated_at = now()
+      WHERE section_id = v_sec_success AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_success, '<p>Most market-entry advice assumes Australia is the primary target and New Zealand is an afterthought. Fexco inverts this entirely. It built 15 years of Pacific operating experience before entering Australian retail — and when it did, it arrived with proven unit economics, brand recognition among Pacific diaspora communities, and a credible expansion narrative backed by real numbers.</p>', 1, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_success AND sort_order = 2) THEN
+    UPDATE content_bodies SET body_text = '<p>Fexco also had an indirect Australian connection through its co-ownership of PICA Group, one of Australia''s largest strata property services companies. This gave the Fexco leadership team long-running familiarity with the Australian operating and regulatory environment before the currency retail rollout.</p>', updated_at = now()
+      WHERE section_id = v_sec_success AND sort_order = 2;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_success, '<p>Fexco also had an indirect Australian connection through its co-ownership of PICA Group, one of Australia''s largest strata property services companies. This gave the Fexco leadership team long-running familiarity with the Australian operating and regulatory environment before the currency retail rollout.</p>', 2, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_success AND sort_order = 3) THEN
+    UPDATE content_bodies SET body_text = '<p><em>New Zealand doesn''t have to be a test market or a secondary afterthought. For the right business, it can be the foundation of a decade-long Pacific operation that makes Australia a more confident expansion, not a speculative one.</em></p>', updated_at = now()
+      WHERE section_id = v_sec_success AND sort_order = 3;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_success, '<p><em>New Zealand doesn''t have to be a test market or a secondary afterthought. For the right business, it can be the foundation of a decade-long Pacific operation that makes Australia a more confident expansion, not a speculative one.</em></p>', 3, 'case_study');
+  END IF;
+
+  -- Section: key-metrics
+  SELECT id INTO v_sec_metrics FROM content_sections
+   WHERE content_id = v_id AND slug = 'key-metrics';
+  IF v_sec_metrics IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Key Metrics & Performance', 'key-metrics', 3, true)
+    RETURNING id INTO v_sec_metrics;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Key Metrics & Performance', sort_order = 3, is_active = true
+      WHERE id = v_sec_metrics;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_metrics AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<ul><li><strong>Founded</strong>: 1981, Killorglin, Kerry</li><li><strong>NZ entry</strong>: 2009 (Federal Pacific acquisition)</li><li><strong>Pacific staff</strong>: 400+</li><li><strong>NZ stores</strong>: 24</li><li><strong>AU entry</strong>: Sept 2024 (2 Sydney stores)</li><li><strong>AU plan</strong>: 20+ outlets, 80+ jobs</li></ul>', updated_at = now()
+      WHERE section_id = v_sec_metrics AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_metrics, '<ul><li><strong>Founded</strong>: 1981, Killorglin, Kerry</li><li><strong>NZ entry</strong>: 2009 (Federal Pacific acquisition)</li><li><strong>Pacific staff</strong>: 400+</li><li><strong>NZ stores</strong>: 24</li><li><strong>AU entry</strong>: Sept 2024 (2 Sydney stores)</li><li><strong>AU plan</strong>: 20+ outlets, 80+ jobs</li></ul>', 1, 'case_study');
+  END IF;
+
+  -- Section: lessons-learned
+  SELECT id INTO v_sec_lessons FROM content_sections
+   WHERE content_id = v_id AND slug = 'lessons-learned';
+  IF v_sec_lessons IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Lessons Learned', 'lessons-learned', 4, true)
+    RETURNING id INTO v_sec_lessons;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Lessons Learned', sort_order = 4, is_active = true
+      WHERE id = v_sec_lessons;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_lessons AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p>For Irish operators considering ANZ entry, Fexco''s playbook offers a clear template. The lessons below distil Fexco''s entry decisions, partner choices, and milestones in Australia &amp; New Zealand.</p>', updated_at = now()
+      WHERE section_id = v_sec_lessons AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_lessons, '<p>For Irish operators considering ANZ entry, Fexco''s playbook offers a clear template. The lessons below distil Fexco''s entry decisions, partner choices, and milestones in Australia &amp; New Zealand.</p>', 1, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_lessons AND sort_order = 2) THEN
+    UPDATE content_bodies SET body_text = '<ul><li><strong>NZ as a genuine operating base</strong> — Built 400+ staff, 24 stores and 2M+ annual transactions before moving into Australia. <em>(NZ is a real market, not a stepping stone. The operating depth you build there is real credibility when you want to expand.)</em></li><li><strong>Pacific network as a moat</strong> — Became the largest Western Union master agent in the Pacific — hard to replicate quickly. <em>(In financial services and adjacent sectors, network infrastructure is a durable moat. Build the network before expanding the brand.)</em></li><li><strong>Lead the Australia announcement with jobs and footprint</strong> — Announced exact store locations, job creation numbers and a multi-year rollout plan. <em>(Specific commitments — named locations, headcount, timelines — earn media and government goodwill. Vague expansion plans do not.)</em></li></ul>', updated_at = now()
+      WHERE section_id = v_sec_lessons AND sort_order = 2;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_lessons, '<ul><li><strong>NZ as a genuine operating base</strong> — Built 400+ staff, 24 stores and 2M+ annual transactions before moving into Australia. <em>(NZ is a real market, not a stepping stone. The operating depth you build there is real credibility when you want to expand.)</em></li><li><strong>Pacific network as a moat</strong> — Became the largest Western Union master agent in the Pacific — hard to replicate quickly. <em>(In financial services and adjacent sectors, network infrastructure is a durable moat. Build the network before expanding the brand.)</em></li><li><strong>Lead the Australia announcement with jobs and footprint</strong> — Announced exact store locations, job creation numbers and a multi-year rollout plan. <em>(Specific commitments — named locations, headcount, timelines — earn media and government goodwill. Vague expansion plans do not.)</em></li></ul>', 2, 'case_study');
+  END IF;
+
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Fexco — Sydney store launch announcement (Oct 2024)', 'https://www.fexco.com/news-and-insights/fexco-expands-global-presence-with-launch-of-two-new-no1-currency-stores-in-sydney-australia/', 1, 'company_blog')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Fexco Pacific LinkedIn — network size and description', 'https://nz.linkedin.com/company/fexco-pacific-ltd', 2, 'linkedin')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Fexco corporate homepage', 'https://www.fexco.com', 3, 'company_blog')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+END
+$do_block$;
+
+-- Case 5/6: LearnUpon (learnupon-anz-market-entry)
+DO $do_block$
+DECLARE
+  v_id uuid;
+  v_sec_entry uuid;
+  v_sec_success uuid;
+  v_sec_metrics uuid;
+  v_sec_lessons uuid;
+BEGIN
+  INSERT INTO content_items (
+    slug, title, subtitle, category_id, content_type, status, featured,
+    read_time, tldr, quick_facts, researched_by, style_version
+  ) VALUES (
+    'learnupon-anz-market-entry', 'How LearnUpon Entered the ANZ Market', 'How a Dublin-founded learning management system company grew to 100+ APAC enterprise customers, 80% headcount growth in two years, and a bigger Sydney HQ — by proving demand first globally and then investing in regional density when the customer base justified it.',
+    '6a837ef6-c7b5-457c-8069-2b8da9c85716'::uuid, 'case_study', 'published', false,
+    2, ARRAY['How a Dublin-founded learning management system company grew to 100+ APAC enterprise customers, 80% headcount growth in two years, and a bigger Sydney HQ — by proving demand first globally and then investing in regional density when the customer base justified it.', 'LearnUpon was founded in June 2012 by Brendan Noud (CEO) and Des Anderson (CTO) in Dublin.']::text[], '[{"icon": "MapPin", "label": "HQ", "value": "Ireland"}, {"icon": "Briefcase", "label": "Sector", "value": "Edtech"}, {"icon": "Globe", "label": "Target Market", "value": "Australia & New Zealand"}]'::jsonb, 'Stephen Browne', 2
+  )
+  ON CONFLICT (slug) DO UPDATE SET
+    title = EXCLUDED.title,
+    subtitle = EXCLUDED.subtitle,
+    category_id = EXCLUDED.category_id,
+    status = EXCLUDED.status,
+    read_time = EXCLUDED.read_time,
+    tldr = EXCLUDED.tldr,
+    quick_facts = EXCLUDED.quick_facts,
+    researched_by = EXCLUDED.researched_by,
+    style_version = EXCLUDED.style_version
+  RETURNING id INTO v_id;
+
+  IF NOT EXISTS (SELECT 1 FROM content_company_profiles WHERE content_id = v_id) THEN
+    INSERT INTO content_company_profiles (
+      content_id, company_name, origin_country, target_market,
+      entry_date, industry, founder_count, employee_count, is_profitable
+    ) VALUES (
+      v_id, 'LearnUpon', 'Ireland', 'Australia & New Zealand',
+      NULL, 'Edtech', 2, NULL, NULL
+    );
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM content_founders WHERE content_id = v_id) THEN
+    INSERT INTO content_founders (content_id, name, title, is_primary)
+    VALUES (v_id, 'Brendan Noud', 'Co-founder & CEO', true);
+    INSERT INTO content_founders (content_id, name, title, is_primary)
+    VALUES (v_id, 'Des Anderson', 'Co-founder & CTO', false);
+  END IF;
+
+  -- Section: entry-strategy
+  SELECT id INTO v_sec_entry FROM content_sections
+   WHERE content_id = v_id AND slug = 'entry-strategy';
+  IF v_sec_entry IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Entry Strategy', 'entry-strategy', 1, true)
+    RETURNING id INTO v_sec_entry;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Entry Strategy', sort_order = 1, is_active = true
+      WHERE id = v_sec_entry;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p>LearnUpon was founded in June 2012 by Brendan Noud (CEO) and Des Anderson (CTO) in Dublin. It builds learning management software that companies use to train employees, customers and partners at scale. By 2026 it served more than 1,500 global customers across 40+ countries, with over 20 million active users and 150 million completed courses on the platform.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>LearnUpon was founded in June 2012 by Brendan Noud (CEO) and Des Anderson (CTO) in Dublin. It builds learning management software that companies use to train employees, customers and partners at scale. By 2026 it served more than 1,500 global customers across 40+ countries, with over 20 million active users and 150 million completed courses on the platform.</p>', 1, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 2) THEN
+    UPDATE content_bodies SET body_text = '<p>In October 2020, LearnUpon raised a $56 million Series A from Summit Partners — one of Ireland''s largest edtech funding rounds — which accelerated product investment and international hiring. Australia and the broader APAC region were priorities in that growth plan.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 2;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>In October 2020, LearnUpon raised a $56 million Series A from Summit Partners — one of Ireland''s largest edtech funding rounds — which accelerated product investment and international hiring. Australia and the broader APAC region were priorities in that growth plan.</p>', 2, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 3) THEN
+    UPDATE content_bodies SET body_text = '<p>LearnUpon''s Sydney office had been operational for more than six years by early 2026. Rather than a dramatic launch, its ANZ presence was built incrementally — winning enterprise customers, building a local support function and growing the team as APAC revenue justified investment. In June 2024, it appointed Fiona Sweeney as APAC Director, signalling stronger regional leadership commitment.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 3;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>LearnUpon''s Sydney office had been operational for more than six years by early 2026. Rather than a dramatic launch, its ANZ presence was built incrementally — winning enterprise customers, building a local support function and growing the team as APAC revenue justified investment. In June 2024, it appointed Fiona Sweeney as APAC Director, signalling stronger regional leadership commitment.</p>', 3, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 4) THEN
+    UPDATE content_bodies SET body_text = '<p>In March 2026, LearnUpon announced it was accelerating APAC expansion through a larger Sydney headquarters at JustCo, deeper regional investment and the integration of Courseau — an AI-native course creation platform it had recently acquired. The announcement confirmed 100+ customers in the APAC region and said local headcount had grown 80% over two years.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 4;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>In March 2026, LearnUpon announced it was accelerating APAC expansion through a larger Sydney headquarters at JustCo, deeper regional investment and the integration of Courseau — an AI-native course creation platform it had recently acquired. The announcement confirmed 100+ customers in the APAC region and said local headcount had grown 80% over two years.</p>', 4, 'case_study');
+  END IF;
+
+  -- Section: success-factors
+  SELECT id INTO v_sec_success FROM content_sections
+   WHERE content_id = v_id AND slug = 'success-factors';
+  IF v_sec_success IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Success Factors', 'success-factors', 2, true)
+    RETURNING id INTO v_sec_success;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Success Factors', sort_order = 2, is_active = true
+      WHERE id = v_sec_success;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_success AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p><em>LearnUpon''s APAC story is a counterpoint to acquisition-led entries. Sometimes the right move is not to buy — it''s to serve the customers who find you, then invest in local density once the concentration justifies it.</em></p>', updated_at = now()
+      WHERE section_id = v_sec_success AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_success, '<p><em>LearnUpon''s APAC story is a counterpoint to acquisition-led entries. Sometimes the right move is not to buy — it''s to serve the customers who find you, then invest in local density once the concentration justifies it.</em></p>', 1, 'case_study');
+  END IF;
+
+  -- Section: key-metrics
+  SELECT id INTO v_sec_metrics FROM content_sections
+   WHERE content_id = v_id AND slug = 'key-metrics';
+  IF v_sec_metrics IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Key Metrics & Performance', 'key-metrics', 3, true)
+    RETURNING id INTO v_sec_metrics;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Key Metrics & Performance', sort_order = 3, is_active = true
+      WHERE id = v_sec_metrics;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_metrics AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<ul><li><strong>Healthcare Australia</strong> — Healthcare / Staffing <em>(Workforce learning and compliance training)</em></li><li><strong>WorkPac</strong> — Labour hire <em>(Onboarding and skills training at scale)</em></li><li><strong>Jetpilot</strong> — Consumer goods <em>(Product knowledge and dealer training)</em></li><li><strong>Montu</strong> — Pharmaceutical <em>(Regulatory and clinical learning)</em></li><li><strong>Morningstar</strong> — Financial services <em>(Professional development)</em></li><li><strong>ACSO</strong> — Corrections/Justice <em>(Staff training and compliance)</em></li></ul>', updated_at = now()
+      WHERE section_id = v_sec_metrics AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_metrics, '<ul><li><strong>Healthcare Australia</strong> — Healthcare / Staffing <em>(Workforce learning and compliance training)</em></li><li><strong>WorkPac</strong> — Labour hire <em>(Onboarding and skills training at scale)</em></li><li><strong>Jetpilot</strong> — Consumer goods <em>(Product knowledge and dealer training)</em></li><li><strong>Montu</strong> — Pharmaceutical <em>(Regulatory and clinical learning)</em></li><li><strong>Morningstar</strong> — Financial services <em>(Professional development)</em></li><li><strong>ACSO</strong> — Corrections/Justice <em>(Staff training and compliance)</em></li></ul>', 1, 'case_study');
+  END IF;
+
+  -- Section: lessons-learned
+  SELECT id INTO v_sec_lessons FROM content_sections
+   WHERE content_id = v_id AND slug = 'lessons-learned';
+  IF v_sec_lessons IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Lessons Learned', 'lessons-learned', 4, true)
+    RETURNING id INTO v_sec_lessons;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Lessons Learned', sort_order = 4, is_active = true
+      WHERE id = v_sec_lessons;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_lessons AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p>For Irish operators considering ANZ entry, LearnUpon''s playbook offers a clear template. The lessons below distil LearnUpon''s entry decisions, partner choices, and milestones in Australia &amp; New Zealand.</p>', updated_at = now()
+      WHERE section_id = v_sec_lessons AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_lessons, '<p>For Irish operators considering ANZ entry, LearnUpon''s playbook offers a clear template. The lessons below distil LearnUpon''s entry decisions, partner choices, and milestones in Australia &amp; New Zealand.</p>', 1, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_lessons AND sort_order = 2) THEN
+    UPDATE content_bodies SET body_text = '<ul><li><strong>Let customer pull justify local investment</strong> — Grew APAC organically for six-plus years before making a bigger local commitment. <em>(Don''t invest in regional office and leadership before the customer demand exists. Let inbound traction tell you when the market is ready for more investment.)</em></li><li><strong>Add AI to accelerate regional relevance</strong> — Used the Courseau acquisition to offer AI course creation as a local differentiator. <em>(An AI acquisition can refresh the expansion story in a region that already knows your product.)</em></li><li><strong>Name the local headcount growth</strong> — Cited 80% headcount growth in two years as a proof point in expansion announcement. <em>(Percentage headcount growth is a powerful signal — it shows the region is a real business unit, not a satellite sales office.)</em></li></ul>', updated_at = now()
+      WHERE section_id = v_sec_lessons AND sort_order = 2;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_lessons, '<ul><li><strong>Let customer pull justify local investment</strong> — Grew APAC organically for six-plus years before making a bigger local commitment. <em>(Don''t invest in regional office and leadership before the customer demand exists. Let inbound traction tell you when the market is ready for more investment.)</em></li><li><strong>Add AI to accelerate regional relevance</strong> — Used the Courseau acquisition to offer AI course creation as a local differentiator. <em>(An AI acquisition can refresh the expansion story in a region that already knows your product.)</em></li><li><strong>Name the local headcount growth</strong> — Cited 80% headcount growth in two years as a proof point in expansion announcement. <em>(Percentage headcount growth is a powerful signal — it shows the region is a real business unit, not a satellite sales office.)</em></li></ul>', 2, 'case_study');
+  END IF;
+
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'LearnUpon — APAC expansion announcement (newsroom)', 'https://www.learnupon.com/newsroom/learnupon-accelerates-apac-expansion/', 1, 'company_blog')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'IT Brief Australia — APAC growth and Courseau', 'https://itbrief.com.au/story/learnupon-boosts-apac-growth-with-ai-course-platform', 2, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Medianet — Sydney HQ and Courseau acquisition', 'https://newshub.medianet.com.au/2026/03/learnupon-accelerates-apac-expansion-with-new-sydney-headquarters-and-ai-native-courseau/144128/', 3, 'press_release')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Mirage News — APAC Sydney HQ update', 'https://www.miragenews.com/learnupon-expands-apac-with-sydney-hq-ai-1637940/', 4, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'BusinessWire — 2025 year-end performance and global recognition', 'https://www.businesswire.com/news/home/20260129847362/en/LearnUpon-Ends-2025-With-Breakthrough-Growth-Product-Innovation-and-Global-Recognition', 5, 'press_release')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+END
+$do_block$;
+
+-- Case 6/6: Kyckr (kyckr-anz-market-entry)
+DO $do_block$
+DECLARE
+  v_id uuid;
+  v_sec_entry uuid;
+  v_sec_success uuid;
+  v_sec_metrics uuid;
+  v_sec_lessons uuid;
+BEGIN
+  INSERT INTO content_items (
+    slug, title, subtitle, category_id, content_type, status, featured,
+    read_time, tldr, quick_facts, researched_by, style_version
+  ) VALUES (
+    'kyckr-anz-market-entry', 'How Kyckr Entered the ANZ Market', 'How a Waterford-founded company registry intelligence startup used the Australian Securities Exchange not just as a capital-raising tool but as a market-entry strategy — gaining Australian institutional credibility, local investor visibility, and a listed-company governance structure that resonated with its compliance-focused customers.',
+    '0563b826-2123-4627-b912-14f63e9fbfb6'::uuid, 'case_study', 'published', false,
+    2, ARRAY['How a Waterford-founded company registry intelligence startup used the Australian Securities Exchange not just as a capital-raising tool but as a market-entry strategy — gaining Australian institutional credibility, local investor visibility, and a listed-company governance structure that resonated with its compliance-focused customers.', 'Kyckr was founded in Waterford in March 2007 by Ben Cronin, Rob Leslie, John Murray and Richard Wood.']::text[], '[{"icon": "MapPin", "label": "HQ", "value": "Ireland"}, {"icon": "Briefcase", "label": "Sector", "value": "RegTech"}, {"icon": "Globe", "label": "Target Market", "value": "Australia & New Zealand"}]'::jsonb, 'Stephen Browne', 2
+  )
+  ON CONFLICT (slug) DO UPDATE SET
+    title = EXCLUDED.title,
+    subtitle = EXCLUDED.subtitle,
+    category_id = EXCLUDED.category_id,
+    status = EXCLUDED.status,
+    read_time = EXCLUDED.read_time,
+    tldr = EXCLUDED.tldr,
+    quick_facts = EXCLUDED.quick_facts,
+    researched_by = EXCLUDED.researched_by,
+    style_version = EXCLUDED.style_version
+  RETURNING id INTO v_id;
+
+  IF NOT EXISTS (SELECT 1 FROM content_company_profiles WHERE content_id = v_id) THEN
+    INSERT INTO content_company_profiles (
+      content_id, company_name, origin_country, target_market,
+      entry_date, industry, founder_count, employee_count, is_profitable
+    ) VALUES (
+      v_id, 'Kyckr', 'Ireland', 'Australia & New Zealand',
+      '2016-01-01', 'RegTech', 4, NULL, NULL
+    );
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM content_founders WHERE content_id = v_id) THEN
+    INSERT INTO content_founders (content_id, name, title, is_primary)
+    VALUES (v_id, 'Ben Cronin', 'Co-founder', true);
+    INSERT INTO content_founders (content_id, name, title, is_primary)
+    VALUES (v_id, 'Rob Leslie', 'Co-founder', false);
+    INSERT INTO content_founders (content_id, name, title, is_primary)
+    VALUES (v_id, 'John Murray', 'Co-founder', false);
+    INSERT INTO content_founders (content_id, name, title, is_primary)
+    VALUES (v_id, 'Richard Wood', 'Co-founder', false);
+  END IF;
+
+  -- Section: entry-strategy
+  SELECT id INTO v_sec_entry FROM content_sections
+   WHERE content_id = v_id AND slug = 'entry-strategy';
+  IF v_sec_entry IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Entry Strategy', 'entry-strategy', 1, true)
+    RETURNING id INTO v_sec_entry;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Entry Strategy', sort_order = 1, is_active = true
+      WHERE id = v_sec_entry;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p>Kyckr was founded in Waterford in March 2007 by Ben Cronin, Rob Leslie, John Murray and Richard Wood. The company built a real-time registry intelligence platform that gave compliance teams at banks, financial institutions and corporates direct access to official company registry data across 300+ jurisdictions — removing the need to manually check registries or rely on outdated static databases.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>Kyckr was founded in Waterford in March 2007 by Ben Cronin, Rob Leslie, John Murray and Richard Wood. The company built a real-time registry intelligence platform that gave compliance teams at banks, financial institutions and corporates direct access to official company registry data across 300+ jurisdictions — removing the need to manually check registries or rely on outdated static databases.</p>', 1, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 2) THEN
+    UPDATE content_bodies SET body_text = '<p>Its core product addressed a genuine compliance burden: banks performing KYC, AML and onboarding checks needed accurate, current company ownership and incorporation data at speed. Kyckr automated this by connecting directly to primary regulatory sources.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 2;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>Its core product addressed a genuine compliance burden: banks performing KYC, AML and onboarding checks needed accurate, current company ownership and incorporation data at speed. Kyckr automated this by connecting directly to primary regulatory sources.</p>', 2, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 3) THEN
+    UPDATE content_bodies SET body_text = '<p>In September 2016, Kyckr listed on the Australian Securities Exchange under the ticker KYK, raising A$5 million with a fully diluted market capitalisation of approximately A$26 million. Enterprise Ireland had backed the company with a €250,000 investment ahead of the listing.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 3;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>In September 2016, Kyckr listed on the Australian Securities Exchange under the ticker KYK, raising A$5 million with a fully diluted market capitalisation of approximately A$26 million. Enterprise Ireland had backed the company with a €250,000 investment ahead of the listing.</p>', 3, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 4) THEN
+    UPDATE content_bodies SET body_text = '<p>This was not a conventional market-entry play. Kyckr was not simply raising capital on a convenient exchange. It was choosing to make Australia its listed domicile — which gave it Australian institutional shareholder support, regular ASX reporting obligations, and a profile in the Australian financial services sector precisely where its target customers operated. For a compliance-focused product, being a listed entity with transparent public reporting was itself a trust signal.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 4;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>This was not a conventional market-entry play. Kyckr was not simply raising capital on a convenient exchange. It was choosing to make Australia its listed domicile — which gave it Australian institutional shareholder support, regular ASX reporting obligations, and a profile in the Australian financial services sector precisely where its target customers operated. For a compliance-focused product, being a listed entity with transparent public reporting was itself a trust signal.</p>', 4, 'case_study');
+  END IF;
+
+  -- Section: success-factors
+  SELECT id INTO v_sec_success FROM content_sections
+   WHERE content_id = v_id AND slug = 'success-factors';
+  IF v_sec_success IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Success Factors', 'success-factors', 2, true)
+    RETURNING id INTO v_sec_success;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Success Factors', sort_order = 2, is_active = true
+      WHERE id = v_sec_success;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_success AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p><em>A public listing is not just a capital event. For a compliance-first product, it can be a trust signal, a market-entry mechanism and a talent-attraction tool — all at the same time.</em></p>', updated_at = now()
+      WHERE section_id = v_sec_success AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_success, '<p><em>A public listing is not just a capital event. For a compliance-first product, it can be a trust signal, a market-entry mechanism and a talent-attraction tool — all at the same time.</em></p>', 1, 'case_study');
+  END IF;
+
+  -- Section: key-metrics
+  SELECT id INTO v_sec_metrics FROM content_sections
+   WHERE content_id = v_id AND slug = 'key-metrics';
+  IF v_sec_metrics IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Key Metrics & Performance', 'key-metrics', 3, true)
+    RETURNING id INTO v_sec_metrics;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Key Metrics & Performance', sort_order = 3, is_active = true
+      WHERE id = v_sec_metrics;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_metrics AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p>After listing, Kyckr grew its product to cover more than 120 million businesses from 300-plus primary regulatory sources across more than 100 countries. In FY2017 it reported $1.54 million in revenue, up 34%. By FY2019 revenue had reached $2.14 million, representing growth of more than 25%. Clients included Citi Commercial Bank and Commerzbank.</p>', updated_at = now()
+      WHERE section_id = v_sec_metrics AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_metrics, '<p>After listing, Kyckr grew its product to cover more than 120 million businesses from 300-plus primary regulatory sources across more than 100 countries. In FY2017 it reported $1.54 million in revenue, up 34%. By FY2019 revenue had reached $2.14 million, representing growth of more than 25%. Clients included Citi Commercial Bank and Commerzbank.</p>', 1, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_metrics AND sort_order = 2) THEN
+    UPDATE content_bodies SET body_text = '<p>In November 2022, Richard White — the founder of WiseTech Global, one of Australia''s most successful technology companies — completed the acquisition of the remaining 77.24% stake in Kyckr he did not already own and delisted the company. The acquisition validated Kyckr''s technology and validated the ANZ market-entry approach by attracting strategic attention from one of Australia''s most respected technology founders.</p>', updated_at = now()
+      WHERE section_id = v_sec_metrics AND sort_order = 2;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_metrics, '<p>In November 2022, Richard White — the founder of WiseTech Global, one of Australia''s most successful technology companies — completed the acquisition of the remaining 77.24% stake in Kyckr he did not already own and delisted the company. The acquisition validated Kyckr''s technology and validated the ANZ market-entry approach by attracting strategic attention from one of Australia''s most respected technology founders.</p>', 2, 'case_study');
+  END IF;
+
+  -- Section: lessons-learned
+  SELECT id INTO v_sec_lessons FROM content_sections
+   WHERE content_id = v_id AND slug = 'lessons-learned';
+  IF v_sec_lessons IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Lessons Learned', 'lessons-learned', 4, true)
+    RETURNING id INTO v_sec_lessons;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Lessons Learned', sort_order = 4, is_active = true
+      WHERE id = v_sec_lessons;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_lessons AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p>For Irish operators considering ANZ entry, Kyckr''s playbook offers a clear template. The lessons below distil Kyckr''s entry decisions, partner choices, and milestones in Australia &amp; New Zealand.</p>', updated_at = now()
+      WHERE section_id = v_sec_lessons AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_lessons, '<p>For Irish operators considering ANZ entry, Kyckr''s playbook offers a clear template. The lessons below distil Kyckr''s entry decisions, partner choices, and milestones in Australia &amp; New Zealand.</p>', 1, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_lessons AND sort_order = 2) THEN
+    UPDATE content_bodies SET body_text = '<ul><li><strong>Use capital markets as an entry mechanism</strong> — Listed on ASX to gain Australian institutional credibility alongside capital. <em>(In regulated B2B sectors, a public listing can be more effective than a sales office. It makes trust transparent and permanent.)</em></li><li><strong>Match the entry mechanism to the product''s trust requirements</strong> — A compliance product for banks needed to demonstrate governance. A listed company structure did exactly that. <em>(Think about what signal your customers need most and choose an entry mechanism that delivers it.)</em></li><li><strong>Build toward strategic acquirers</strong> — Kyckr''s data infrastructure attracted WiseTech founder Richard White as a personal acquirer. <em>(If your product is genuinely valuable infrastructure, ANZ exits to global tech leaders are achievable.)</em></li></ul>', updated_at = now()
+      WHERE section_id = v_sec_lessons AND sort_order = 2;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_lessons, '<ul><li><strong>Use capital markets as an entry mechanism</strong> — Listed on ASX to gain Australian institutional credibility alongside capital. <em>(In regulated B2B sectors, a public listing can be more effective than a sales office. It makes trust transparent and permanent.)</em></li><li><strong>Match the entry mechanism to the product''s trust requirements</strong> — A compliance product for banks needed to demonstrate governance. A listed company structure did exactly that. <em>(Think about what signal your customers need most and choose an entry mechanism that delivers it.)</em></li><li><strong>Build toward strategic acquirers</strong> — Kyckr''s data infrastructure attracted WiseTech founder Richard White as a personal acquirer. <em>(If your product is genuinely valuable infrastructure, ANZ exits to global tech leaders are achievable.)</em></li></ul>', 2, 'case_study');
+  END IF;
+
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Fora.ie — Kyckr ASX IPO announcement (Sept 2016)', 'https://fora.ie/kyckr-waterford-ipo-2968390-Sep2016/', 1, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'MarketScreener — Richard White acquires remaining Kyckr stake (Nov 2022)', 'https://in.marketscreener.com/quote/stock/KYCKR-LIMITED-27546659/news/Richard-White-completed-the-acquisition-of-the-remaining-77.24-stake-in-Kyckr-Limited-42171348/', 2, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Addisons — Kyckr ASX KYK acquisition by RealWise (legal announcement)', 'https://addisons.com/announcement/addisons-advises-kyckr-asx-kyk-on-its-acquisition-by-realwise/', 3, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Wikipedia — Kyckr company article', 'https://en.wikipedia.org/wiki/Kyckr', 4, 'other')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Finovate — Kyckr archive (product and financial service context)', 'https://finovate.com/category/kyckr/', 5, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+END
+$do_block$;

--- a/scripts/irish_tier1_import_blocks/01-clanwilliam-anz-market-entry.sql
+++ b/scripts/irish_tier1_import_blocks/01-clanwilliam-anz-market-entry.sql
@@ -1,0 +1,178 @@
+DO $do_block$
+DECLARE
+  v_id uuid;
+  v_sec_entry uuid;
+  v_sec_success uuid;
+  v_sec_metrics uuid;
+  v_sec_lessons uuid;
+BEGIN
+  INSERT INTO content_items (
+    slug, title, subtitle, category_id, content_type, status, featured,
+    read_time, tldr, quick_facts, researched_by, style_version
+  ) VALUES (
+    'clanwilliam-anz-market-entry', 'How Clanwilliam Entered the ANZ Market', 'How a Dublin-founded healthtech group turned a series of ANZ acquisitions into a dominant clinical communications and connected-care platform spanning Australia and New Zealand.',
+    '6a837ef6-c7b5-457c-8069-2b8da9c85716'::uuid, 'case_study', 'published', false,
+    3, ARRAY['How a Dublin-founded healthtech group turned a series of ANZ acquisitions into a dominant clinical communications and connected-care platform spanning Australia and New Zealand.', 'Clanwilliam is an Irish healthcare technology group founded in 1996 by Howard Beggs.']::text[], '[{"icon": "MapPin", "label": "HQ", "value": "Ireland"}, {"icon": "Briefcase", "label": "Sector", "value": "Healthtech"}, {"icon": "Globe", "label": "Target Market", "value": "Australia & New Zealand"}]'::jsonb, 'Stephen Browne', 2
+  )
+  ON CONFLICT (slug) DO UPDATE SET
+    title = EXCLUDED.title,
+    subtitle = EXCLUDED.subtitle,
+    category_id = EXCLUDED.category_id,
+    status = EXCLUDED.status,
+    read_time = EXCLUDED.read_time,
+    tldr = EXCLUDED.tldr,
+    quick_facts = EXCLUDED.quick_facts,
+    researched_by = EXCLUDED.researched_by,
+    style_version = EXCLUDED.style_version
+  RETURNING id INTO v_id;
+
+  IF NOT EXISTS (SELECT 1 FROM content_company_profiles WHERE content_id = v_id) THEN
+    INSERT INTO content_company_profiles (
+      content_id, company_name, origin_country, target_market,
+      entry_date, industry, founder_count, employee_count, is_profitable
+    ) VALUES (
+      v_id, 'Clanwilliam', 'Ireland', 'Australia & New Zealand',
+      '2017-01-01', 'Healthtech', 1, NULL, NULL
+    );
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM content_founders WHERE content_id = v_id) THEN
+    INSERT INTO content_founders (content_id, name, title, is_primary)
+    VALUES (v_id, 'Howard Beggs', 'Founder', true);
+  END IF;
+
+  -- Section: entry-strategy
+  SELECT id INTO v_sec_entry FROM content_sections
+   WHERE content_id = v_id AND slug = 'entry-strategy';
+  IF v_sec_entry IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Entry Strategy', 'entry-strategy', 1, true)
+    RETURNING id INTO v_sec_entry;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Entry Strategy', sort_order = 1, is_active = true
+      WHERE id = v_sec_entry;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p>Clanwilliam is an Irish healthcare technology group founded in 1996 by Howard Beggs. Its ANZ story is one of the clearest examples in the MES library of a company using acquisition to buy embedded market trust rather than attempting to build it from scratch against entrenched local competitors.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>Clanwilliam is an Irish healthcare technology group founded in 1996 by Howard Beggs. Its ANZ story is one of the clearest examples in the MES library of a company using acquisition to buy embedded market trust rather than attempting to build it from scratch against entrenched local competitors.</p>', 1, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 2) THEN
+    UPDATE content_bodies SET body_text = '<p>Rather than launch a sales operation into an unfamiliar healthcare system, Clanwilliam acquired businesses that were already woven into clinical workflows across Australian and New Zealand healthcare. That strategy gave it immediate network effects, customer relationships, and regulatory familiarity that would have taken years to replicate organically.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 2;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>Rather than launch a sales operation into an unfamiliar healthcare system, Clanwilliam acquired businesses that were already woven into clinical workflows across Australian and New Zealand healthcare. That strategy gave it immediate network effects, customer relationships, and regulatory familiarity that would have taken years to replicate organically.</p>', 2, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 3) THEN
+    UPDATE content_bodies SET body_text = '<p>Australian and New Zealand healthcare offered a compelling structural opportunity: both markets were digitising clinical communications but remained fragmented, with legacy secure messaging providers sitting alongside newer referral and data-exchange tools. Clanwilliam identified that connecting these silos was a solvable problem — but only if you owned or operated key pieces of the exchange infrastructure.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 3;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>Australian and New Zealand healthcare offered a compelling structural opportunity: both markets were digitising clinical communications but remained fragmented, with legacy secure messaging providers sitting alongside newer referral and data-exchange tools. Clanwilliam identified that connecting these silos was a solvable problem — but only if you owned or operated key pieces of the exchange infrastructure.</p>', 3, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 4) THEN
+    UPDATE content_bodies SET body_text = '<p>The English-language operating environment, a shared regulatory philosophy with Ireland, and strong government investment in digital health infrastructure made ANZ particularly accessible for an Irish company with deep healthcare workflow expertise.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 4;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>The English-language operating environment, a shared regulatory philosophy with Ireland, and strong government investment in digital health infrastructure made ANZ particularly accessible for an Irish company with deep healthcare workflow expertise.</p>', 4, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 5) THEN
+    UPDATE content_bodies SET body_text = '<ul><li><strong>2017</strong> — Acquired HealthLink (NZ-founded, ANZ coverage) <em>(Gained an established health messaging network across ANZ, including 15,000+ connected medical organisations.)</em></li><li><strong>2017–18</strong> — Acquired Konnect NET <em>(Added pharmacy connectivity and additional healthcare workflow capability in Australia.)</em></li><li><strong>Dec 2020</strong> — Merged HealthLink and Konnect NET <em>(Reduced regional operational fragmentation and created a cleaner ANZ platform structure ahead of further growth.)</em></li><li><strong>Mar 2024</strong> — Launched formal ANZ Division <em>(Formalised regional leadership (David Young as MD Australia, Mike Weiss as MD NZ) with four products: HealthLink, Konnect NET, Toniq, MBS.)</em></li><li><strong>Jan 2024</strong> — HealthLink acquired Telstra Health''s Argus, Connecting Care and eReferrals assets <em>(Consolidated a major competitor/complementary player; deepened secure messaging and e-referral market share across Australian healthcare.)</em></li></ul>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 5;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<ul><li><strong>2017</strong> — Acquired HealthLink (NZ-founded, ANZ coverage) <em>(Gained an established health messaging network across ANZ, including 15,000+ connected medical organisations.)</em></li><li><strong>2017–18</strong> — Acquired Konnect NET <em>(Added pharmacy connectivity and additional healthcare workflow capability in Australia.)</em></li><li><strong>Dec 2020</strong> — Merged HealthLink and Konnect NET <em>(Reduced regional operational fragmentation and created a cleaner ANZ platform structure ahead of further growth.)</em></li><li><strong>Mar 2024</strong> — Launched formal ANZ Division <em>(Formalised regional leadership (David Young as MD Australia, Mike Weiss as MD NZ) with four products: HealthLink, Konnect NET, Toniq, MBS.)</em></li><li><strong>Jan 2024</strong> — HealthLink acquired Telstra Health''s Argus, Connecting Care and eReferrals assets <em>(Consolidated a major competitor/complementary player; deepened secure messaging and e-referral market share across Australian healthcare.)</em></li></ul>', 5, 'case_study');
+  END IF;
+
+  -- Section: success-factors
+  SELECT id INTO v_sec_success FROM content_sections
+   WHERE content_id = v_id AND slug = 'success-factors';
+  IF v_sec_success IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Success Factors', 'success-factors', 2, true)
+    RETURNING id INTO v_sec_success;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Success Factors', sort_order = 2, is_active = true
+      WHERE id = v_sec_success;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_success AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p><em>In regulated health markets, the fastest route to credibility is to buy trust that is already embedded in the workflow — then consolidate around interoperability.</em></p>', updated_at = now()
+      WHERE section_id = v_sec_success AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_success, '<p><em>In regulated health markets, the fastest route to credibility is to buy trust that is already embedded in the workflow — then consolidate around interoperability.</em></p>', 1, 'case_study');
+  END IF;
+
+  -- Section: key-metrics
+  SELECT id INTO v_sec_metrics FROM content_sections
+   WHERE content_id = v_id AND slug = 'key-metrics';
+  IF v_sec_metrics IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Key Metrics & Performance', 'key-metrics', 3, true)
+    RETURNING id INTO v_sec_metrics;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Key Metrics & Performance', sort_order = 3, is_active = true
+      WHERE id = v_sec_metrics;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_metrics AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<ul><li><strong>Medical organisations connected</strong> — 15,000+ across Australasia <em>(HealthLink network data (healthlink.com.au))</em></li><li><strong>Clinical messages per year</strong> — 100 million+ <em>(HealthLink network data)</em></li><li><strong>ANZ Division product count</strong> — 4 (HealthLink, Konnect NET, Toniq, MBS) <em>(ANZ Division launch announcement, March 2024)</em></li><li><strong>Telstra Health assets acquired</strong> — Argus, Connecting Care, eReferrals <em>(MinterEllison deal announcement, Jan 2024)</em></li></ul>', updated_at = now()
+      WHERE section_id = v_sec_metrics AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_metrics, '<ul><li><strong>Medical organisations connected</strong> — 15,000+ across Australasia <em>(HealthLink network data (healthlink.com.au))</em></li><li><strong>Clinical messages per year</strong> — 100 million+ <em>(HealthLink network data)</em></li><li><strong>ANZ Division product count</strong> — 4 (HealthLink, Konnect NET, Toniq, MBS) <em>(ANZ Division launch announcement, March 2024)</em></li><li><strong>Telstra Health assets acquired</strong> — Argus, Connecting Care, eReferrals <em>(MinterEllison deal announcement, Jan 2024)</em></li></ul>', 1, 'case_study');
+  END IF;
+
+  -- Section: lessons-learned
+  SELECT id INTO v_sec_lessons FROM content_sections
+   WHERE content_id = v_id AND slug = 'lessons-learned';
+  IF v_sec_lessons IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Lessons Learned', 'lessons-learned', 4, true)
+    RETURNING id INTO v_sec_lessons;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Lessons Learned', sort_order = 4, is_active = true
+      WHERE id = v_sec_lessons;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_lessons AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p>For Irish operators considering ANZ entry, Clanwilliam''s playbook offers a clear template. The lessons below distil Clanwilliam''s entry decisions, partner choices, and milestones in Australia &amp; New Zealand.</p>', updated_at = now()
+      WHERE section_id = v_sec_lessons AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_lessons, '<p>For Irish operators considering ANZ entry, Clanwilliam''s playbook offers a clear template. The lessons below distil Clanwilliam''s entry decisions, partner choices, and milestones in Australia &amp; New Zealand.</p>', 1, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_lessons AND sort_order = 2) THEN
+    UPDATE content_bodies SET body_text = '<ul><li><strong>Buy installed trust</strong> — Acquired HealthLink''s embedded clinical messaging network rather than building one. <em>(In complex systems, distribution is often acquired, not invented. Look for businesses with workflow lock-in.)</em></li><li><strong>Integrate before scaling</strong> — Merged HealthLink and Konnect NET before launching a formal ANZ division. <em>(Operational coherence should precede expansion messaging. Don''t promote fragmented assets.)</em></li><li><strong>Consolidate adjacencies</strong> — Acquired Telstra Health''s overlapping secure messaging and e-referrals footprint. <em>(Once inside a workflow category, strengthen the moat by absorbing complementary infrastructure before a competitor does.)</em></li><li><strong>Formalise with leadership</strong> — Appointed dedicated MD for Australia and MD for NZ as part of division launch. <em>(A named regional leader signals permanence to customers, partners and regulators more than any press release.)</em></li></ul>', updated_at = now()
+      WHERE section_id = v_sec_lessons AND sort_order = 2;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_lessons, '<ul><li><strong>Buy installed trust</strong> — Acquired HealthLink''s embedded clinical messaging network rather than building one. <em>(In complex systems, distribution is often acquired, not invented. Look for businesses with workflow lock-in.)</em></li><li><strong>Integrate before scaling</strong> — Merged HealthLink and Konnect NET before launching a formal ANZ division. <em>(Operational coherence should precede expansion messaging. Don''t promote fragmented assets.)</em></li><li><strong>Consolidate adjacencies</strong> — Acquired Telstra Health''s overlapping secure messaging and e-referrals footprint. <em>(Once inside a workflow category, strengthen the moat by absorbing complementary infrastructure before a competitor does.)</em></li><li><strong>Formalise with leadership</strong> — Appointed dedicated MD for Australia and MD for NZ as part of division launch. <em>(A named regional leader signals permanence to customers, partners and regulators more than any press release.)</em></li></ul>', 2, 'case_study');
+  END IF;
+
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'ANZ Division launch announcement', 'https://insurtechnz.org.nz/2024/03/12/clanwilliam-launches-anz-division-in-a-commitment-to-the-future-of-healthcare-across-australia-and-new-zealand/', 1, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'MinterEllison on Telstra Health acquisition', 'https://www.minterellison.com/articles/minterellison-advises-clanwilliam-on-telstra-health-acquisition', 2, 'company_blog')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Telstra Health sale announcement', 'https://www.telstrahealth.com/healthlink-acquires-telstra-health-argus-connecting-care-and-ereferrals-business/', 3, 'company_blog')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'HealthLink acquisition background (Waterman)', 'https://www.waterman.co.nz/news/healthlink-acquired-by-global-healthcare-technology-specialist/', 4, 'company_blog')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Pulse IT on Telstra Health Argus deal', 'https://www.pulseit.news/australian-digital-health/healthlink-swoops-on-telstra-healths-secure-messaging-and-ereferrals-business/', 5, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'HealthLink network scale (corporate site)', 'https://www.healthlink.com.au/clanwilliams-healthlink-acquires-telstra-healths-argus-connecting-care-and-ereferrals-business/', 6, 'company_blog')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+END
+$do_block$;

--- a/scripts/irish_tier1_import_blocks/02-spectrum-life-anz-market-entry.sql
+++ b/scripts/irish_tier1_import_blocks/02-spectrum-life-anz-market-entry.sql
@@ -1,0 +1,218 @@
+DO $do_block$
+DECLARE
+  v_id uuid;
+  v_sec_entry uuid;
+  v_sec_success uuid;
+  v_sec_metrics uuid;
+  v_sec_lessons uuid;
+BEGIN
+  INSERT INTO content_items (
+    slug, title, subtitle, category_id, content_type, status, featured,
+    read_time, tldr, quick_facts, researched_by, style_version
+  ) VALUES (
+    'spectrum-life-anz-market-entry', 'How Spectrum.Life Entered the ANZ Market', 'How a Dublin-founded digital wellbeing platform skipped the greenfield build and entered Australia simultaneously across three complementary verticals — workplace mental health, EAP, and specialist virtual care — by acquiring three local businesses on the same day.',
+    '0563b826-2123-4627-b912-14f63e9fbfb6'::uuid, 'case_study', 'published', false,
+    4, ARRAY['How a Dublin-founded digital wellbeing platform skipped the greenfield build and entered Australia simultaneously across three complementary verticals — workplace mental health, EAP, and specialist virtual care — by acquiring three local businesses on the same day.', 'Spectrum.Life was founded in Dublin in 2018 by Stuart McGoldrick and Stephen Costello.']::text[], '[{"icon": "MapPin", "label": "HQ", "value": "Ireland"}, {"icon": "Briefcase", "label": "Sector", "value": "Insurtech"}, {"icon": "Globe", "label": "Target Market", "value": "Australia & New Zealand"}]'::jsonb, 'Stephen Browne', 2
+  )
+  ON CONFLICT (slug) DO UPDATE SET
+    title = EXCLUDED.title,
+    subtitle = EXCLUDED.subtitle,
+    category_id = EXCLUDED.category_id,
+    status = EXCLUDED.status,
+    read_time = EXCLUDED.read_time,
+    tldr = EXCLUDED.tldr,
+    quick_facts = EXCLUDED.quick_facts,
+    researched_by = EXCLUDED.researched_by,
+    style_version = EXCLUDED.style_version
+  RETURNING id INTO v_id;
+
+  IF NOT EXISTS (SELECT 1 FROM content_company_profiles WHERE content_id = v_id) THEN
+    INSERT INTO content_company_profiles (
+      content_id, company_name, origin_country, target_market,
+      entry_date, industry, founder_count, employee_count, is_profitable
+    ) VALUES (
+      v_id, 'Spectrum.Life', 'Ireland', 'Australia & New Zealand',
+      '2026-01-01', 'Insurtech', 2, NULL, NULL
+    );
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM content_founders WHERE content_id = v_id) THEN
+    INSERT INTO content_founders (content_id, name, title, is_primary)
+    VALUES (v_id, 'Stuart McGoldrick', 'Co-founder', true);
+    INSERT INTO content_founders (content_id, name, title, is_primary)
+    VALUES (v_id, 'Stephen Costello', 'Co-founder', false);
+  END IF;
+
+  -- Section: entry-strategy
+  SELECT id INTO v_sec_entry FROM content_sections
+   WHERE content_id = v_id AND slug = 'entry-strategy';
+  IF v_sec_entry IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Entry Strategy', 'entry-strategy', 1, true)
+    RETURNING id INTO v_sec_entry;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Entry Strategy', sort_order = 1, is_active = true
+      WHERE id = v_sec_entry;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p>Spectrum.Life was founded in Dublin in 2018 by Stuart McGoldrick and Stephen Costello. It operates a digital-first mental health and wellbeing platform serving employers, insurers and universities. The platform covers proactive wellbeing tools, digital therapy, EAP, and clinical triage through a single access point — making it well positioned to replace the fragmented point-solutions most employers and insurers were managing.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>Spectrum.Life was founded in Dublin in 2018 by Stuart McGoldrick and Stephen Costello. It operates a digital-first mental health and wellbeing platform serving employers, insurers and universities. The platform covers proactive wellbeing tools, digital therapy, EAP, and clinical triage through a single access point — making it well positioned to replace the fragmented point-solutions most employers and insurers were managing.</p>', 1, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 2) THEN
+    UPDATE content_bodies SET body_text = '<p>By 2024, the company served more than 4,000 corporate clients and 7.5 million insurance members. It raised a €17 million Series B round in May 2024 from Act Venture Capital and existing investors to fund international expansion — naming Australia as a target. In October 2024, it crossed 300 staff globally, and publicly targeted 500 by end of 2025 and revenue of €100 million by 2028.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 2;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>By 2024, the company served more than 4,000 corporate clients and 7.5 million insurance members. It raised a €17 million Series B round in May 2024 from Act Venture Capital and existing investors to fund international expansion — naming Australia as a target. In October 2024, it crossed 300 staff globally, and publicly targeted 500 by end of 2025 and revenue of €100 million by 2028.</p>', 2, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 3) THEN
+    UPDATE content_bodies SET body_text = '<p>Australia presented a near-perfect storm of demand drivers. Mental health-related workers'' compensation claims had risen 37 percent since 2017–18. Life insurance TPD claims for mental health among people in their 30s had risen by 732 percent over a decade. Employers were under pressure from new psychosocial safety obligations introduced in Australian WHS laws. And the EAP provider market remained fragmented, largely phone-based, and resistant to digital change.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 3;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>Australia presented a near-perfect storm of demand drivers. Mental health-related workers'' compensation claims had risen 37 percent since 2017–18. Life insurance TPD claims for mental health among people in their 30s had risen by 732 percent over a decade. Employers were under pressure from new psychosocial safety obligations introduced in Australian WHS laws. And the EAP provider market remained fragmented, largely phone-based, and resistant to digital change.</p>', 3, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 4) THEN
+    UPDATE content_bodies SET body_text = '<p>Spectrum.Life had already demonstrated in Ireland and the UK that a digitally-led, outcomes-focused model could win enterprise clients quickly. Australia replicated those macro conditions — regulatory tailwind, insurer pressure, employer demand — and offered a large enough addressable market to justify major investment.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 4;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>Spectrum.Life had already demonstrated in Ireland and the UK that a digitally-led, outcomes-focused model could win enterprise clients quickly. Australia replicated those macro conditions — regulatory tailwind, insurer pressure, employer demand — and offered a large enough addressable market to justify major investment.</p>', 4, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 5) THEN
+    UPDATE content_bodies SET body_text = '<p>On 17 March 2026, Spectrum.Life announced the simultaneous acquisition of three Australian businesses: MindFit at Work (Melbourne), We Lysn (Sydney) and Valion Health (Sydney). The company was explicit that it chose not to enter organically — it wanted immediate clinical depth, local regulatory familiarity and customer relationships that only established local operators could provide.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 5;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>On 17 March 2026, Spectrum.Life announced the simultaneous acquisition of three Australian businesses: MindFit at Work (Melbourne), We Lysn (Sydney) and Valion Health (Sydney). The company was explicit that it chose not to enter organically — it wanted immediate clinical depth, local regulatory familiarity and customer relationships that only established local operators could provide.</p>', 5, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 6) THEN
+    UPDATE content_bodies SET body_text = '<ul><li><strong>MindFit at Work</strong> — Melbourne <em>(Evidence-based workplace mental health and psychosocial risk programmes; APAC coverage including Singapore)</em></li><li><strong>We Lysn</strong> — Sydney <em>(Digital mental health, EAP, telehealth counselling (same/next-day access))</em></li><li><strong>Valion Health</strong> — Sydney <em>(ACHS-accredited specialist virtual care (cancer, metabolic, chronic conditions))</em></li></ul>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 6;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<ul><li><strong>MindFit at Work</strong> — Melbourne <em>(Evidence-based workplace mental health and psychosocial risk programmes; APAC coverage including Singapore)</em></li><li><strong>We Lysn</strong> — Sydney <em>(Digital mental health, EAP, telehealth counselling (same/next-day access))</em></li><li><strong>Valion Health</strong> — Sydney <em>(ACHS-accredited specialist virtual care (cancer, metabolic, chronic conditions))</em></li></ul>', 6, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 7) THEN
+    UPDATE content_bodies SET body_text = '<p>The three businesses were highly complementary. Together they gave Spectrum.Life an employer-facing prevention product, a frontline digital counselling service, and a specialist insurer pathway — covering the full spectrum from early intervention to complex case management.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 7;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>The three businesses were highly complementary. Together they gave Spectrum.Life an employer-facing prevention product, a frontline digital counselling service, and a specialist insurer pathway — covering the full spectrum from early intervention to complex case management.</p>', 7, 'case_study');
+  END IF;
+
+  -- Section: success-factors
+  SELECT id INTO v_sec_success FROM content_sections
+   WHERE content_id = v_id AND slug = 'success-factors';
+  IF v_sec_success IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Success Factors', 'success-factors', 2, true)
+    RETURNING id INTO v_sec_success;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Success Factors', sort_order = 2, is_active = true
+      WHERE id = v_sec_success;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_success AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p><em>&ldquo;We chose to make a long-term strategic commitment to Australia. One platform. One clinical pathway. 24/7 clinical access. Measurable outcomes.&rdquo; <span style="color: var(--muted);">— Stephen Costello, CEO, Spectrum.Life (March 2026)</span></em></p>', updated_at = now()
+      WHERE section_id = v_sec_success AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_success, '<p><em>&ldquo;We chose to make a long-term strategic commitment to Australia. One platform. One clinical pathway. 24/7 clinical access. Measurable outcomes.&rdquo; <span style="color: var(--muted);">— Stephen Costello, CEO, Spectrum.Life (March 2026)</span></em></p>', 1, 'case_study');
+  END IF;
+
+  -- Section: key-metrics
+  SELECT id INTO v_sec_metrics FROM content_sections
+   WHERE content_id = v_id AND slug = 'key-metrics';
+  IF v_sec_metrics IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Key Metrics & Performance', 'key-metrics', 3, true)
+    RETURNING id INTO v_sec_metrics;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Key Metrics & Performance', sort_order = 3, is_active = true
+      WHERE id = v_sec_metrics;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_metrics AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<ul><li><strong>Australian employees at launch</strong> — 35 <em>(Healthcare & Protection, March 2026)</em></li><li><strong>New AU roles planned (12 months)</strong> — 100+ <em>(CFO Tech / Spectrum.Life press release)</em></li><li><strong>Global members at entry</strong> — 15 million+ <em>(Spectrum.Life funding announcement 2024)</em></li><li><strong>Global corporate clients</strong> — 4,000+ corporate / 7.5M insurance members <em>(InsurTech Insights interview, Nov 2024)</em></li><li><strong>Deloitte Fast 50 Ireland 2024 rank</strong> — 41st <em>(WireNews, November 2024)</em></li><li><strong>Revenue target</strong> — €100M by 2028 <em>(Business & Finance Q&A, June 2025)</em></li></ul>', updated_at = now()
+      WHERE section_id = v_sec_metrics AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_metrics, '<ul><li><strong>Australian employees at launch</strong> — 35 <em>(Healthcare & Protection, March 2026)</em></li><li><strong>New AU roles planned (12 months)</strong> — 100+ <em>(CFO Tech / Spectrum.Life press release)</em></li><li><strong>Global members at entry</strong> — 15 million+ <em>(Spectrum.Life funding announcement 2024)</em></li><li><strong>Global corporate clients</strong> — 4,000+ corporate / 7.5M insurance members <em>(InsurTech Insights interview, Nov 2024)</em></li><li><strong>Deloitte Fast 50 Ireland 2024 rank</strong> — 41st <em>(WireNews, November 2024)</em></li><li><strong>Revenue target</strong> — €100M by 2028 <em>(Business & Finance Q&A, June 2025)</em></li></ul>', 1, 'case_study');
+  END IF;
+
+  -- Section: lessons-learned
+  SELECT id INTO v_sec_lessons FROM content_sections
+   WHERE content_id = v_id AND slug = 'lessons-learned';
+  IF v_sec_lessons IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Lessons Learned', 'lessons-learned', 4, true)
+    RETURNING id INTO v_sec_lessons;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Lessons Learned', sort_order = 4, is_active = true
+      WHERE id = v_sec_lessons;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_lessons AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p>For Irish operators considering ANZ entry, Spectrum.Life''s playbook offers a clear template. The lessons below distil Spectrum.Life''s entry decisions, partner choices, and milestones in Australia &amp; New Zealand.</p>', updated_at = now()
+      WHERE section_id = v_sec_lessons AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_lessons, '<p>For Irish operators considering ANZ entry, Spectrum.Life''s playbook offers a clear template. The lessons below distil Spectrum.Life''s entry decisions, partner choices, and milestones in Australia &amp; New Zealand.</p>', 1, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_lessons AND sort_order = 2) THEN
+    UPDATE content_bodies SET body_text = '<ul><li><strong>Use one expansion market to validate the next</strong> — Built UK scale and proof points before targeting Australia. UK became the case study that made the Australia investment case. <em>(Sequence markets deliberately. Your second market is easier to enter if your first market has already proved the model works internationally.)</em></li><li><strong>Bundle complementary acquisitions</strong> — Bought three firms covering different parts of the care pathway simultaneously — employer prevention, frontline access, specialist care. <em>(When a category is fragmented, acquire breadth rather than build each component. Speed and coverage compound faster than organic build.)</em></li><li><strong>Use market data to justify the entry</strong> — Cited the 37% rise in AU mental health claims to underpin the commercial rationale in media and to prospects. <em>(Lead with the market problem, not the company. Local data makes your entry story immediately relevant to customers, partners and press.)</em></li><li><strong>Announce jobs alongside acquisitions</strong> — Committed to 100+ new roles within 12 months at the time of the acquisition announcement. <em>(Hiring commitments signal permanence to customers, regulators and local government. They also generate media coverage beyond the deal itself.)</em></li><li><strong>Lead with outcomes language</strong> — Positioned the combined platform around measurable outcomes and 24/7 clinical access — not features. <em>(In health and insurance, procurement teams respond to outcome architecture and accountability language, not feature lists.)</em></li></ul>', updated_at = now()
+      WHERE section_id = v_sec_lessons AND sort_order = 2;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_lessons, '<ul><li><strong>Use one expansion market to validate the next</strong> — Built UK scale and proof points before targeting Australia. UK became the case study that made the Australia investment case. <em>(Sequence markets deliberately. Your second market is easier to enter if your first market has already proved the model works internationally.)</em></li><li><strong>Bundle complementary acquisitions</strong> — Bought three firms covering different parts of the care pathway simultaneously — employer prevention, frontline access, specialist care. <em>(When a category is fragmented, acquire breadth rather than build each component. Speed and coverage compound faster than organic build.)</em></li><li><strong>Use market data to justify the entry</strong> — Cited the 37% rise in AU mental health claims to underpin the commercial rationale in media and to prospects. <em>(Lead with the market problem, not the company. Local data makes your entry story immediately relevant to customers, partners and press.)</em></li><li><strong>Announce jobs alongside acquisitions</strong> — Committed to 100+ new roles within 12 months at the time of the acquisition announcement. <em>(Hiring commitments signal permanence to customers, regulators and local government. They also generate media coverage beyond the deal itself.)</em></li><li><strong>Lead with outcomes language</strong> — Positioned the combined platform around measurable outcomes and 24/7 clinical access — not features. <em>(In health and insurance, procurement teams respond to outcome architecture and accountability language, not feature lists.)</em></li></ul>', 2, 'case_study');
+  END IF;
+
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Healthcare & Protection — triple acquisition announcement', 'https://healthcareandprotection.com/spectrum-life-expands-into-australia-through-mindfit-we-lysn-and-valion-acquisitions/', 1, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Spectrum.Life official press release', 'https://www.spectrum.life/resources/press-releases/spectrum-life-expands-into-australia-with-long-term-strategic-commitment/', 2, 'company_blog')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'CFO Tech Australia — triple acquisition coverage', 'https://cfotech.com.au/story/spectrum-life-buys-three-aussie-digital-health-firms', 3, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Melbourne Insider — Australia expansion story', 'https://melbourne-insider.au/spectrum-life-australia-expansion/', 4, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Silicon Republic — Series B funding announcement', 'https://www.siliconrepublic.com/start-ups/spectrum-life-funding-digital-health-ireland-uk', 5, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Spectrum.Life €17M funding announcement (official)', 'https://www.spectrum.life/resources/spectrum-life-funding-announcement-may-2024/', 6, 'company_blog')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'EIN Presswire — €17M round details and international growth plans', 'https://www.einpresswire.com/article/714935154/spectrum-life-closes-17m-investment-round-to-accelerate-international-growth', 7, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'InsurTech Insights — CEO Stephen Costello interview', 'https://www.insurtechinsights.com/startup-story-spectrum-life-ceo-and-co-founder-stephen-costello-talks-technology-and-wellbeing/', 8, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'TechBuzz Ireland — 300 staff milestone', 'https://techbuzzireland.com/2024/10/09/spectrum-life-surpasses-300-employees-and-eyes-growth-to-500-by-end-of-2025/', 9, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'WireNews — Deloitte Fast 50 Ireland 2024 ranking', 'https://www.wirenn.com/post/spectrum-life-ranked-41st-in-the-deloitte-ireland-2024-technology-fast-50-awards', 10, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Business & Finance Q&A — Stephen Costello on mission and €100M target', 'https://businessandfinance.com/news/my-primary-focus-is-delivering-on-our-mission-to-save-and-change-as-many-lives-as-possible-qanda-with-stephen-costello/', 11, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'AIHS.org.au — 37% mental health claims rise in Australian workers'' compensation', 'https://aihs.org.au/Web/Web/Advocacy-Media/All-News/2024/03-March/Mental-health-conditions-jump-37-per-cent-in-workers-compensation-claims.aspx', 12, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Valion Health — about page (founded by Michael Marthick)', 'https://valionhealth.com.au/about-valion/', 13, 'company_blog')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'SBS News — We Lysn founding story', 'https://www.sbs.com.au/news/small-business-secrets/article/how-start-up-lysn-is-removing-the-stigma-surrounding-seeking-mental-health-support/0x1cd1dtu', 14, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+END
+$do_block$;

--- a/scripts/irish_tier1_import_blocks/03-t-pro-anz-market-entry.sql
+++ b/scripts/irish_tier1_import_blocks/03-t-pro-anz-market-entry.sql
@@ -1,0 +1,170 @@
+DO $do_block$
+DECLARE
+  v_id uuid;
+  v_sec_entry uuid;
+  v_sec_success uuid;
+  v_sec_metrics uuid;
+  v_sec_lessons uuid;
+BEGIN
+  INSERT INTO content_items (
+    slug, title, subtitle, category_id, content_type, status, featured,
+    read_time, tldr, quick_facts, researched_by, style_version
+  ) VALUES (
+    't-pro-anz-market-entry', 'How T-Pro Entered the ANZ Market', 'How a Dublin-founded healthcare speech and documentation company expanded across Australia and New Zealand through three targeted acquisitions — buying local customer relationships and clinical workflow knowledge faster than any organic sales team could build them.',
+    '6a837ef6-c7b5-457c-8069-2b8da9c85716'::uuid, 'case_study', 'published', false,
+    2, ARRAY['How a Dublin-founded healthcare speech and documentation company expanded across Australia and New Zealand through three targeted acquisitions — buying local customer relationships and clinical workflow knowledge faster than any organic sales team could build them.', 'T-Pro is an Irish healthcare technology company specialising in speech recognition, clinical documentation and AI-enabled workflow tools for healthcare providers.']::text[], '[{"icon": "MapPin", "label": "HQ", "value": "Ireland"}, {"icon": "Briefcase", "label": "Sector", "value": "Healthcare AI"}, {"icon": "Globe", "label": "Target Market", "value": "Australia & New Zealand"}]'::jsonb, 'Stephen Browne', 2
+  )
+  ON CONFLICT (slug) DO UPDATE SET
+    title = EXCLUDED.title,
+    subtitle = EXCLUDED.subtitle,
+    category_id = EXCLUDED.category_id,
+    status = EXCLUDED.status,
+    read_time = EXCLUDED.read_time,
+    tldr = EXCLUDED.tldr,
+    quick_facts = EXCLUDED.quick_facts,
+    researched_by = EXCLUDED.researched_by,
+    style_version = EXCLUDED.style_version
+  RETURNING id INTO v_id;
+
+  IF NOT EXISTS (SELECT 1 FROM content_company_profiles WHERE content_id = v_id) THEN
+    INSERT INTO content_company_profiles (
+      content_id, company_name, origin_country, target_market,
+      entry_date, industry, founder_count, employee_count, is_profitable
+    ) VALUES (
+      v_id, 'T-Pro', 'Ireland', 'Australia & New Zealand',
+      NULL, 'Healthcare AI', NULL, NULL, NULL
+    );
+  END IF;
+
+  -- Section: entry-strategy
+  SELECT id INTO v_sec_entry FROM content_sections
+   WHERE content_id = v_id AND slug = 'entry-strategy';
+  IF v_sec_entry IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Entry Strategy', 'entry-strategy', 1, true)
+    RETURNING id INTO v_sec_entry;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Entry Strategy', sort_order = 1, is_active = true
+      WHERE id = v_sec_entry;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p>T-Pro is an Irish healthcare technology company specialising in speech recognition, clinical documentation and AI-enabled workflow tools for healthcare providers. Its technology reduces the administrative burden on clinicians by automating documentation tasks from dictation to structured clinical notes.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>T-Pro is an Irish healthcare technology company specialising in speech recognition, clinical documentation and AI-enabled workflow tools for healthcare providers. Its technology reduces the administrative burden on clinicians by automating documentation tasks from dictation to structured clinical notes.</p>', 1, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 2) THEN
+    UPDATE content_bodies SET body_text = '<p>T-Pro''s ANZ expansion strategy was acquisition-led from the outset. Rather than entering with its own sales team or a channel partner, it identified established local documentation and transcription businesses that already had deep relationships with hospitals, clinics and healthcare networks — then acquired them and layered its AI documentation platform over the existing operations.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 2;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>T-Pro''s ANZ expansion strategy was acquisition-led from the outset. Rather than entering with its own sales team or a channel partner, it identified established local documentation and transcription businesses that already had deep relationships with hospitals, clinics and healthcare networks — then acquired them and layered its AI documentation platform over the existing operations.</p>', 2, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 3) THEN
+    UPDATE content_bodies SET body_text = '<ul><li><strong>2022</strong> — SyberScribe <em>(Melbourne, Australia)</em></li><li><strong>2022</strong> — Livingbridge investment <em>(UK PE backing)</em></li><li><strong>2023</strong> — NTS Transcriptions <em>(Australia)</em></li><li><strong>2025</strong> — Sound Business Systems (SBS) <em>(New Zealand + Australia)</em></li></ul>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 3;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<ul><li><strong>2022</strong> — SyberScribe <em>(Melbourne, Australia)</em></li><li><strong>2022</strong> — Livingbridge investment <em>(UK PE backing)</em></li><li><strong>2023</strong> — NTS Transcriptions <em>(Australia)</em></li><li><strong>2025</strong> — Sound Business Systems (SBS) <em>(New Zealand + Australia)</em></li></ul>', 3, 'case_study');
+  END IF;
+
+  -- Section: success-factors
+  SELECT id INTO v_sec_success FROM content_sections
+   WHERE content_id = v_id AND slug = 'success-factors';
+  IF v_sec_success IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Success Factors', 'success-factors', 2, true)
+    RETURNING id INTO v_sec_success;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Success Factors', sort_order = 2, is_active = true
+      WHERE id = v_sec_success;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_success AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p>Healthcare documentation sits at the intersection of clinician behaviour, data compliance and hospital IT infrastructure. Local relationships matter enormously because switching documentation tools requires clinical workflow change management — something hospitals only do when they trust the vendor deeply. T-Pro''s acquisition strategy meant it inherited trusted local operators rather than asking customers to take a risk on a remote Irish startup.</p>', updated_at = now()
+      WHERE section_id = v_sec_success AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_success, '<p>Healthcare documentation sits at the intersection of clinician behaviour, data compliance and hospital IT infrastructure. Local relationships matter enormously because switching documentation tools requires clinical workflow change management — something hospitals only do when they trust the vendor deeply. T-Pro''s acquisition strategy meant it inherited trusted local operators rather than asking customers to take a risk on a remote Irish startup.</p>', 1, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_success AND sort_order = 2) THEN
+    UPDATE content_bodies SET body_text = '<p>By acquiring three ANZ businesses rather than one, T-Pro built a narrative of regional commitment and demonstrated to healthcare networks that it was building a long-term APAC presence rather than testing the market opportunistically.</p>', updated_at = now()
+      WHERE section_id = v_sec_success AND sort_order = 2;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_success, '<p>By acquiring three ANZ businesses rather than one, T-Pro built a narrative of regional commitment and demonstrated to healthcare networks that it was building a long-term APAC presence rather than testing the market opportunistically.</p>', 2, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_success AND sort_order = 3) THEN
+    UPDATE content_bodies SET body_text = '<p><em>T-Pro''s ANZ story shows that in specialist enterprise categories, acquisitions function simultaneously as distribution, localisation and trust-building — compressing years of relationship development into a single transaction.</em></p>', updated_at = now()
+      WHERE section_id = v_sec_success AND sort_order = 3;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_success, '<p><em>T-Pro''s ANZ story shows that in specialist enterprise categories, acquisitions function simultaneously as distribution, localisation and trust-building — compressing years of relationship development into a single transaction.</em></p>', 3, 'case_study');
+  END IF;
+
+  -- Section: key-metrics
+  SELECT id INTO v_sec_metrics FROM content_sections
+   WHERE content_id = v_id AND slug = 'key-metrics';
+  IF v_sec_metrics IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Key Metrics & Performance', 'key-metrics', 3, true)
+    RETURNING id INTO v_sec_metrics;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Key Metrics & Performance', sort_order = 3, is_active = true
+      WHERE id = v_sec_metrics;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_metrics AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<ul><li><strong>Founded</strong>: Ireland</li><li><strong>Entry mode</strong>: Serial acquisition</li><li><strong>Acquisition 1</strong>: SyberScribe, Melbourne (2022)</li><li><strong>Acquisition 2</strong>: NTS Transcriptions, AU (2023)</li><li><strong>Acquisition 3</strong>: Sound Business Systems, NZ/AU (2025)</li><li><strong>PE backing</strong>: Livingbridge (2022)</li></ul>', updated_at = now()
+      WHERE section_id = v_sec_metrics AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_metrics, '<ul><li><strong>Founded</strong>: Ireland</li><li><strong>Entry mode</strong>: Serial acquisition</li><li><strong>Acquisition 1</strong>: SyberScribe, Melbourne (2022)</li><li><strong>Acquisition 2</strong>: NTS Transcriptions, AU (2023)</li><li><strong>Acquisition 3</strong>: Sound Business Systems, NZ/AU (2025)</li><li><strong>PE backing</strong>: Livingbridge (2022)</li></ul>', 1, 'case_study');
+  END IF;
+
+  -- Section: lessons-learned
+  SELECT id INTO v_sec_lessons FROM content_sections
+   WHERE content_id = v_id AND slug = 'lessons-learned';
+  IF v_sec_lessons IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Lessons Learned', 'lessons-learned', 4, true)
+    RETURNING id INTO v_sec_lessons;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Lessons Learned', sort_order = 4, is_active = true
+      WHERE id = v_sec_lessons;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_lessons AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p>For Irish operators considering ANZ entry, T-Pro''s playbook offers a clear template. The lessons below distil T-Pro''s entry decisions, partner choices, and milestones in Australia &amp; New Zealand.</p>', updated_at = now()
+      WHERE section_id = v_sec_lessons AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_lessons, '<p>For Irish operators considering ANZ entry, T-Pro''s playbook offers a clear template. The lessons below distil T-Pro''s entry decisions, partner choices, and milestones in Australia &amp; New Zealand.</p>', 1, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_lessons AND sort_order = 2) THEN
+    UPDATE content_bodies SET body_text = '<ul><li><strong>Let acquisitions replace the sales team</strong> — Each acquired business brought its own hospital and clinic relationships. <em>(In enterprise healthcare, distribution IS the product. Buying an established operator often beats hiring a country manager and starting from zero.)</em></li><li><strong>Layer technology over trusted operations</strong> — T-Pro applied its AI documentation platform over acquired businesses rather than replacing them. <em>(Don''t replace what works locally. Add your IP on top of existing customer trust.)</em></li><li><strong>Build a serial acquisition narrative</strong> — Three acquisitions created a regional expansion story that one deal could not. <em>(Announcing a second and third acquisition compounds the credibility signal from the first. You stop looking like an experiment and start looking like a regional player.)</em></li></ul>', updated_at = now()
+      WHERE section_id = v_sec_lessons AND sort_order = 2;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_lessons, '<ul><li><strong>Let acquisitions replace the sales team</strong> — Each acquired business brought its own hospital and clinic relationships. <em>(In enterprise healthcare, distribution IS the product. Buying an established operator often beats hiring a country manager and starting from zero.)</em></li><li><strong>Layer technology over trusted operations</strong> — T-Pro applied its AI documentation platform over acquired businesses rather than replacing them. <em>(Don''t replace what works locally. Add your IP on top of existing customer trust.)</em></li><li><strong>Build a serial acquisition narrative</strong> — Three acquisitions created a regional expansion story that one deal could not. <em>(Announcing a second and third acquisition compounds the credibility signal from the first. You stop looking like an experiment and start looking like a regional player.)</em></li></ul>', 2, 'case_study');
+  END IF;
+
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Silicon Republic — T-Pro acquires SyberScribe (2022)', 'https://www.siliconrepublic.com/business/t-pro-syberscribe-acquisition-australia-speech-transcription-technology', 1, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'ThinkBusiness — T-Pro voice AI and NTS (2024 profile)', 'https://www.thinkbusiness.ie/articles/tpro-voice-ai-speech-technology/', 2, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'T-Pro blog — Sound Business Systems joins the group', 'https://blog.tpro.io/sbs-part-of-tpro', 3, 'company_blog')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Livingbridge — T-Pro acquires SBS (PE announcement)', 'https://www.livingbridge.com/livingroom/t-pro-acquires-sound-business-systems-expanding-global-healthcare-ai-reach', 4, 'company_blog')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Sound Business Systems — corporate site', 'https://soundbusiness.co.nz', 5, 'company_blog')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+END
+$do_block$;

--- a/scripts/irish_tier1_import_blocks/04-fexco-anz-market-entry.sql
+++ b/scripts/irish_tier1_import_blocks/04-fexco-anz-market-entry.sql
@@ -1,0 +1,169 @@
+DO $do_block$
+DECLARE
+  v_id uuid;
+  v_sec_entry uuid;
+  v_sec_success uuid;
+  v_sec_metrics uuid;
+  v_sec_lessons uuid;
+BEGIN
+  INSERT INTO content_items (
+    slug, title, subtitle, category_id, content_type, status, featured,
+    read_time, tldr, quick_facts, researched_by, style_version
+  ) VALUES (
+    'fexco-anz-market-entry', 'How Fexco Entered the ANZ Market', 'How a Kerry-founded payments and FX group used New Zealand as its Pacific base for over a decade, built a 400-person regional operation, and then used that platform to launch into Australian retail with hard numbers behind the expansion story.',
+    '0563b826-2123-4627-b912-14f63e9fbfb6'::uuid, 'case_study', 'published', false,
+    3, ARRAY['How a Kerry-founded payments and FX group used New Zealand as its Pacific base for over a decade, built a 400-person regional operation, and then used that platform to launch into Australian retail with hard numbers behind the expansion story.', 'Fexco is one of Ireland''s largest private companies, founded in 1981 in Killorglin, County Kerry by Brian McCarthy.']::text[], '[{"icon": "MapPin", "label": "HQ", "value": "Ireland"}, {"icon": "Briefcase", "label": "Sector", "value": "Fintech"}, {"icon": "Globe", "label": "Target Market", "value": "Australia & New Zealand"}]'::jsonb, 'Stephen Browne', 2
+  )
+  ON CONFLICT (slug) DO UPDATE SET
+    title = EXCLUDED.title,
+    subtitle = EXCLUDED.subtitle,
+    category_id = EXCLUDED.category_id,
+    status = EXCLUDED.status,
+    read_time = EXCLUDED.read_time,
+    tldr = EXCLUDED.tldr,
+    quick_facts = EXCLUDED.quick_facts,
+    researched_by = EXCLUDED.researched_by,
+    style_version = EXCLUDED.style_version
+  RETURNING id INTO v_id;
+
+  IF NOT EXISTS (SELECT 1 FROM content_company_profiles WHERE content_id = v_id) THEN
+    INSERT INTO content_company_profiles (
+      content_id, company_name, origin_country, target_market,
+      entry_date, industry, founder_count, employee_count, is_profitable
+    ) VALUES (
+      v_id, 'Fexco', 'Ireland', 'Australia & New Zealand',
+      '2009-01-01', 'Fintech', 1, NULL, NULL
+    );
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM content_founders WHERE content_id = v_id) THEN
+    INSERT INTO content_founders (content_id, name, title, is_primary)
+    VALUES (v_id, 'Brian McCarthy', 'Founder', true);
+  END IF;
+
+  -- Section: entry-strategy
+  SELECT id INTO v_sec_entry FROM content_sections
+   WHERE content_id = v_id AND slug = 'entry-strategy';
+  IF v_sec_entry IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Entry Strategy', 'entry-strategy', 1, true)
+    RETURNING id INTO v_sec_entry;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Entry Strategy', sort_order = 1, is_active = true
+      WHERE id = v_sec_entry;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p>Fexco is one of Ireland''s largest private companies, founded in 1981 in Killorglin, County Kerry by Brian McCarthy. It operates across payments, foreign exchange, financial services and business outsourcing. In the Pacific, its brand is anchored around currency exchange and remittance services under the No1 Currency banner, operating as a major Western Union master agent across the region.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>Fexco is one of Ireland''s largest private companies, founded in 1981 in Killorglin, County Kerry by Brian McCarthy. It operates across payments, foreign exchange, financial services and business outsourcing. In the Pacific, its brand is anchored around currency exchange and remittance services under the No1 Currency banner, operating as a major Western Union master agent across the region.</p>', 1, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 2) THEN
+    UPDATE content_bodies SET body_text = '<p>Fexco''s ANZ story begins in New Zealand. In 2009 it acquired Federal Pacific in Auckland, which it later renamed Fexco Pacific. From that base it expanded across New Zealand and Pacific island markets — building a network of 24 stores in New Zealand, over 100 offices and outlets across the Pacific, and a team of more than 400 staff. With more than two million transactions per year, Fexco Pacific became a significant financial services operation in its own right.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 2;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>Fexco''s ANZ story begins in New Zealand. In 2009 it acquired Federal Pacific in Auckland, which it later renamed Fexco Pacific. From that base it expanded across New Zealand and Pacific island markets — building a network of 24 stores in New Zealand, over 100 offices and outlets across the Pacific, and a team of more than 400 staff. With more than two million transactions per year, Fexco Pacific became a significant financial services operation in its own right.</p>', 2, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 3) THEN
+    UPDATE content_bodies SET body_text = '<p>In September 2024, Fexco took the next logical step and opened two No1 Currency stores in Sydney — at Westfield Hurstville and Westfield Liverpool. The company explicitly framed this as the start of a broader Australian rollout, with plans for more than 20 outlets and 80-plus local jobs.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 3;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>In September 2024, Fexco took the next logical step and opened two No1 Currency stores in Sydney — at Westfield Hurstville and Westfield Liverpool. The company explicitly framed this as the start of a broader Australian rollout, with plans for more than 20 outlets and 80-plus local jobs.</p>', 3, 'case_study');
+  END IF;
+
+  -- Section: success-factors
+  SELECT id INTO v_sec_success FROM content_sections
+   WHERE content_id = v_id AND slug = 'success-factors';
+  IF v_sec_success IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Success Factors', 'success-factors', 2, true)
+    RETURNING id INTO v_sec_success;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Success Factors', sort_order = 2, is_active = true
+      WHERE id = v_sec_success;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_success AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p>Most market-entry advice assumes Australia is the primary target and New Zealand is an afterthought. Fexco inverts this entirely. It built 15 years of Pacific operating experience before entering Australian retail — and when it did, it arrived with proven unit economics, brand recognition among Pacific diaspora communities, and a credible expansion narrative backed by real numbers.</p>', updated_at = now()
+      WHERE section_id = v_sec_success AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_success, '<p>Most market-entry advice assumes Australia is the primary target and New Zealand is an afterthought. Fexco inverts this entirely. It built 15 years of Pacific operating experience before entering Australian retail — and when it did, it arrived with proven unit economics, brand recognition among Pacific diaspora communities, and a credible expansion narrative backed by real numbers.</p>', 1, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_success AND sort_order = 2) THEN
+    UPDATE content_bodies SET body_text = '<p>Fexco also had an indirect Australian connection through its co-ownership of PICA Group, one of Australia''s largest strata property services companies. This gave the Fexco leadership team long-running familiarity with the Australian operating and regulatory environment before the currency retail rollout.</p>', updated_at = now()
+      WHERE section_id = v_sec_success AND sort_order = 2;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_success, '<p>Fexco also had an indirect Australian connection through its co-ownership of PICA Group, one of Australia''s largest strata property services companies. This gave the Fexco leadership team long-running familiarity with the Australian operating and regulatory environment before the currency retail rollout.</p>', 2, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_success AND sort_order = 3) THEN
+    UPDATE content_bodies SET body_text = '<p><em>New Zealand doesn''t have to be a test market or a secondary afterthought. For the right business, it can be the foundation of a decade-long Pacific operation that makes Australia a more confident expansion, not a speculative one.</em></p>', updated_at = now()
+      WHERE section_id = v_sec_success AND sort_order = 3;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_success, '<p><em>New Zealand doesn''t have to be a test market or a secondary afterthought. For the right business, it can be the foundation of a decade-long Pacific operation that makes Australia a more confident expansion, not a speculative one.</em></p>', 3, 'case_study');
+  END IF;
+
+  -- Section: key-metrics
+  SELECT id INTO v_sec_metrics FROM content_sections
+   WHERE content_id = v_id AND slug = 'key-metrics';
+  IF v_sec_metrics IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Key Metrics & Performance', 'key-metrics', 3, true)
+    RETURNING id INTO v_sec_metrics;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Key Metrics & Performance', sort_order = 3, is_active = true
+      WHERE id = v_sec_metrics;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_metrics AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<ul><li><strong>Founded</strong>: 1981, Killorglin, Kerry</li><li><strong>NZ entry</strong>: 2009 (Federal Pacific acquisition)</li><li><strong>Pacific staff</strong>: 400+</li><li><strong>NZ stores</strong>: 24</li><li><strong>AU entry</strong>: Sept 2024 (2 Sydney stores)</li><li><strong>AU plan</strong>: 20+ outlets, 80+ jobs</li></ul>', updated_at = now()
+      WHERE section_id = v_sec_metrics AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_metrics, '<ul><li><strong>Founded</strong>: 1981, Killorglin, Kerry</li><li><strong>NZ entry</strong>: 2009 (Federal Pacific acquisition)</li><li><strong>Pacific staff</strong>: 400+</li><li><strong>NZ stores</strong>: 24</li><li><strong>AU entry</strong>: Sept 2024 (2 Sydney stores)</li><li><strong>AU plan</strong>: 20+ outlets, 80+ jobs</li></ul>', 1, 'case_study');
+  END IF;
+
+  -- Section: lessons-learned
+  SELECT id INTO v_sec_lessons FROM content_sections
+   WHERE content_id = v_id AND slug = 'lessons-learned';
+  IF v_sec_lessons IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Lessons Learned', 'lessons-learned', 4, true)
+    RETURNING id INTO v_sec_lessons;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Lessons Learned', sort_order = 4, is_active = true
+      WHERE id = v_sec_lessons;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_lessons AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p>For Irish operators considering ANZ entry, Fexco''s playbook offers a clear template. The lessons below distil Fexco''s entry decisions, partner choices, and milestones in Australia &amp; New Zealand.</p>', updated_at = now()
+      WHERE section_id = v_sec_lessons AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_lessons, '<p>For Irish operators considering ANZ entry, Fexco''s playbook offers a clear template. The lessons below distil Fexco''s entry decisions, partner choices, and milestones in Australia &amp; New Zealand.</p>', 1, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_lessons AND sort_order = 2) THEN
+    UPDATE content_bodies SET body_text = '<ul><li><strong>NZ as a genuine operating base</strong> — Built 400+ staff, 24 stores and 2M+ annual transactions before moving into Australia. <em>(NZ is a real market, not a stepping stone. The operating depth you build there is real credibility when you want to expand.)</em></li><li><strong>Pacific network as a moat</strong> — Became the largest Western Union master agent in the Pacific — hard to replicate quickly. <em>(In financial services and adjacent sectors, network infrastructure is a durable moat. Build the network before expanding the brand.)</em></li><li><strong>Lead the Australia announcement with jobs and footprint</strong> — Announced exact store locations, job creation numbers and a multi-year rollout plan. <em>(Specific commitments — named locations, headcount, timelines — earn media and government goodwill. Vague expansion plans do not.)</em></li></ul>', updated_at = now()
+      WHERE section_id = v_sec_lessons AND sort_order = 2;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_lessons, '<ul><li><strong>NZ as a genuine operating base</strong> — Built 400+ staff, 24 stores and 2M+ annual transactions before moving into Australia. <em>(NZ is a real market, not a stepping stone. The operating depth you build there is real credibility when you want to expand.)</em></li><li><strong>Pacific network as a moat</strong> — Became the largest Western Union master agent in the Pacific — hard to replicate quickly. <em>(In financial services and adjacent sectors, network infrastructure is a durable moat. Build the network before expanding the brand.)</em></li><li><strong>Lead the Australia announcement with jobs and footprint</strong> — Announced exact store locations, job creation numbers and a multi-year rollout plan. <em>(Specific commitments — named locations, headcount, timelines — earn media and government goodwill. Vague expansion plans do not.)</em></li></ul>', 2, 'case_study');
+  END IF;
+
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Fexco — Sydney store launch announcement (Oct 2024)', 'https://www.fexco.com/news-and-insights/fexco-expands-global-presence-with-launch-of-two-new-no1-currency-stores-in-sydney-australia/', 1, 'company_blog')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Fexco Pacific LinkedIn — network size and description', 'https://nz.linkedin.com/company/fexco-pacific-ltd', 2, 'linkedin')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Fexco corporate homepage', 'https://www.fexco.com', 3, 'company_blog')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+END
+$do_block$;

--- a/scripts/irish_tier1_import_blocks/05-learnupon-anz-market-entry.sql
+++ b/scripts/irish_tier1_import_blocks/05-learnupon-anz-market-entry.sql
@@ -1,0 +1,170 @@
+DO $do_block$
+DECLARE
+  v_id uuid;
+  v_sec_entry uuid;
+  v_sec_success uuid;
+  v_sec_metrics uuid;
+  v_sec_lessons uuid;
+BEGIN
+  INSERT INTO content_items (
+    slug, title, subtitle, category_id, content_type, status, featured,
+    read_time, tldr, quick_facts, researched_by, style_version
+  ) VALUES (
+    'learnupon-anz-market-entry', 'How LearnUpon Entered the ANZ Market', 'How a Dublin-founded learning management system company grew to 100+ APAC enterprise customers, 80% headcount growth in two years, and a bigger Sydney HQ — by proving demand first globally and then investing in regional density when the customer base justified it.',
+    '6a837ef6-c7b5-457c-8069-2b8da9c85716'::uuid, 'case_study', 'published', false,
+    2, ARRAY['How a Dublin-founded learning management system company grew to 100+ APAC enterprise customers, 80% headcount growth in two years, and a bigger Sydney HQ — by proving demand first globally and then investing in regional density when the customer base justified it.', 'LearnUpon was founded in June 2012 by Brendan Noud (CEO) and Des Anderson (CTO) in Dublin.']::text[], '[{"icon": "MapPin", "label": "HQ", "value": "Ireland"}, {"icon": "Briefcase", "label": "Sector", "value": "Edtech"}, {"icon": "Globe", "label": "Target Market", "value": "Australia & New Zealand"}]'::jsonb, 'Stephen Browne', 2
+  )
+  ON CONFLICT (slug) DO UPDATE SET
+    title = EXCLUDED.title,
+    subtitle = EXCLUDED.subtitle,
+    category_id = EXCLUDED.category_id,
+    status = EXCLUDED.status,
+    read_time = EXCLUDED.read_time,
+    tldr = EXCLUDED.tldr,
+    quick_facts = EXCLUDED.quick_facts,
+    researched_by = EXCLUDED.researched_by,
+    style_version = EXCLUDED.style_version
+  RETURNING id INTO v_id;
+
+  IF NOT EXISTS (SELECT 1 FROM content_company_profiles WHERE content_id = v_id) THEN
+    INSERT INTO content_company_profiles (
+      content_id, company_name, origin_country, target_market,
+      entry_date, industry, founder_count, employee_count, is_profitable
+    ) VALUES (
+      v_id, 'LearnUpon', 'Ireland', 'Australia & New Zealand',
+      NULL, 'Edtech', 2, NULL, NULL
+    );
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM content_founders WHERE content_id = v_id) THEN
+    INSERT INTO content_founders (content_id, name, title, is_primary)
+    VALUES (v_id, 'Brendan Noud', 'Co-founder & CEO', true);
+    INSERT INTO content_founders (content_id, name, title, is_primary)
+    VALUES (v_id, 'Des Anderson', 'Co-founder & CTO', false);
+  END IF;
+
+  -- Section: entry-strategy
+  SELECT id INTO v_sec_entry FROM content_sections
+   WHERE content_id = v_id AND slug = 'entry-strategy';
+  IF v_sec_entry IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Entry Strategy', 'entry-strategy', 1, true)
+    RETURNING id INTO v_sec_entry;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Entry Strategy', sort_order = 1, is_active = true
+      WHERE id = v_sec_entry;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p>LearnUpon was founded in June 2012 by Brendan Noud (CEO) and Des Anderson (CTO) in Dublin. It builds learning management software that companies use to train employees, customers and partners at scale. By 2026 it served more than 1,500 global customers across 40+ countries, with over 20 million active users and 150 million completed courses on the platform.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>LearnUpon was founded in June 2012 by Brendan Noud (CEO) and Des Anderson (CTO) in Dublin. It builds learning management software that companies use to train employees, customers and partners at scale. By 2026 it served more than 1,500 global customers across 40+ countries, with over 20 million active users and 150 million completed courses on the platform.</p>', 1, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 2) THEN
+    UPDATE content_bodies SET body_text = '<p>In October 2020, LearnUpon raised a $56 million Series A from Summit Partners — one of Ireland''s largest edtech funding rounds — which accelerated product investment and international hiring. Australia and the broader APAC region were priorities in that growth plan.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 2;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>In October 2020, LearnUpon raised a $56 million Series A from Summit Partners — one of Ireland''s largest edtech funding rounds — which accelerated product investment and international hiring. Australia and the broader APAC region were priorities in that growth plan.</p>', 2, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 3) THEN
+    UPDATE content_bodies SET body_text = '<p>LearnUpon''s Sydney office had been operational for more than six years by early 2026. Rather than a dramatic launch, its ANZ presence was built incrementally — winning enterprise customers, building a local support function and growing the team as APAC revenue justified investment. In June 2024, it appointed Fiona Sweeney as APAC Director, signalling stronger regional leadership commitment.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 3;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>LearnUpon''s Sydney office had been operational for more than six years by early 2026. Rather than a dramatic launch, its ANZ presence was built incrementally — winning enterprise customers, building a local support function and growing the team as APAC revenue justified investment. In June 2024, it appointed Fiona Sweeney as APAC Director, signalling stronger regional leadership commitment.</p>', 3, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 4) THEN
+    UPDATE content_bodies SET body_text = '<p>In March 2026, LearnUpon announced it was accelerating APAC expansion through a larger Sydney headquarters at JustCo, deeper regional investment and the integration of Courseau — an AI-native course creation platform it had recently acquired. The announcement confirmed 100+ customers in the APAC region and said local headcount had grown 80% over two years.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 4;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>In March 2026, LearnUpon announced it was accelerating APAC expansion through a larger Sydney headquarters at JustCo, deeper regional investment and the integration of Courseau — an AI-native course creation platform it had recently acquired. The announcement confirmed 100+ customers in the APAC region and said local headcount had grown 80% over two years.</p>', 4, 'case_study');
+  END IF;
+
+  -- Section: success-factors
+  SELECT id INTO v_sec_success FROM content_sections
+   WHERE content_id = v_id AND slug = 'success-factors';
+  IF v_sec_success IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Success Factors', 'success-factors', 2, true)
+    RETURNING id INTO v_sec_success;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Success Factors', sort_order = 2, is_active = true
+      WHERE id = v_sec_success;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_success AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p><em>LearnUpon''s APAC story is a counterpoint to acquisition-led entries. Sometimes the right move is not to buy — it''s to serve the customers who find you, then invest in local density once the concentration justifies it.</em></p>', updated_at = now()
+      WHERE section_id = v_sec_success AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_success, '<p><em>LearnUpon''s APAC story is a counterpoint to acquisition-led entries. Sometimes the right move is not to buy — it''s to serve the customers who find you, then invest in local density once the concentration justifies it.</em></p>', 1, 'case_study');
+  END IF;
+
+  -- Section: key-metrics
+  SELECT id INTO v_sec_metrics FROM content_sections
+   WHERE content_id = v_id AND slug = 'key-metrics';
+  IF v_sec_metrics IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Key Metrics & Performance', 'key-metrics', 3, true)
+    RETURNING id INTO v_sec_metrics;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Key Metrics & Performance', sort_order = 3, is_active = true
+      WHERE id = v_sec_metrics;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_metrics AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<ul><li><strong>Healthcare Australia</strong> — Healthcare / Staffing <em>(Workforce learning and compliance training)</em></li><li><strong>WorkPac</strong> — Labour hire <em>(Onboarding and skills training at scale)</em></li><li><strong>Jetpilot</strong> — Consumer goods <em>(Product knowledge and dealer training)</em></li><li><strong>Montu</strong> — Pharmaceutical <em>(Regulatory and clinical learning)</em></li><li><strong>Morningstar</strong> — Financial services <em>(Professional development)</em></li><li><strong>ACSO</strong> — Corrections/Justice <em>(Staff training and compliance)</em></li></ul>', updated_at = now()
+      WHERE section_id = v_sec_metrics AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_metrics, '<ul><li><strong>Healthcare Australia</strong> — Healthcare / Staffing <em>(Workforce learning and compliance training)</em></li><li><strong>WorkPac</strong> — Labour hire <em>(Onboarding and skills training at scale)</em></li><li><strong>Jetpilot</strong> — Consumer goods <em>(Product knowledge and dealer training)</em></li><li><strong>Montu</strong> — Pharmaceutical <em>(Regulatory and clinical learning)</em></li><li><strong>Morningstar</strong> — Financial services <em>(Professional development)</em></li><li><strong>ACSO</strong> — Corrections/Justice <em>(Staff training and compliance)</em></li></ul>', 1, 'case_study');
+  END IF;
+
+  -- Section: lessons-learned
+  SELECT id INTO v_sec_lessons FROM content_sections
+   WHERE content_id = v_id AND slug = 'lessons-learned';
+  IF v_sec_lessons IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Lessons Learned', 'lessons-learned', 4, true)
+    RETURNING id INTO v_sec_lessons;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Lessons Learned', sort_order = 4, is_active = true
+      WHERE id = v_sec_lessons;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_lessons AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p>For Irish operators considering ANZ entry, LearnUpon''s playbook offers a clear template. The lessons below distil LearnUpon''s entry decisions, partner choices, and milestones in Australia &amp; New Zealand.</p>', updated_at = now()
+      WHERE section_id = v_sec_lessons AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_lessons, '<p>For Irish operators considering ANZ entry, LearnUpon''s playbook offers a clear template. The lessons below distil LearnUpon''s entry decisions, partner choices, and milestones in Australia &amp; New Zealand.</p>', 1, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_lessons AND sort_order = 2) THEN
+    UPDATE content_bodies SET body_text = '<ul><li><strong>Let customer pull justify local investment</strong> — Grew APAC organically for six-plus years before making a bigger local commitment. <em>(Don''t invest in regional office and leadership before the customer demand exists. Let inbound traction tell you when the market is ready for more investment.)</em></li><li><strong>Add AI to accelerate regional relevance</strong> — Used the Courseau acquisition to offer AI course creation as a local differentiator. <em>(An AI acquisition can refresh the expansion story in a region that already knows your product.)</em></li><li><strong>Name the local headcount growth</strong> — Cited 80% headcount growth in two years as a proof point in expansion announcement. <em>(Percentage headcount growth is a powerful signal — it shows the region is a real business unit, not a satellite sales office.)</em></li></ul>', updated_at = now()
+      WHERE section_id = v_sec_lessons AND sort_order = 2;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_lessons, '<ul><li><strong>Let customer pull justify local investment</strong> — Grew APAC organically for six-plus years before making a bigger local commitment. <em>(Don''t invest in regional office and leadership before the customer demand exists. Let inbound traction tell you when the market is ready for more investment.)</em></li><li><strong>Add AI to accelerate regional relevance</strong> — Used the Courseau acquisition to offer AI course creation as a local differentiator. <em>(An AI acquisition can refresh the expansion story in a region that already knows your product.)</em></li><li><strong>Name the local headcount growth</strong> — Cited 80% headcount growth in two years as a proof point in expansion announcement. <em>(Percentage headcount growth is a powerful signal — it shows the region is a real business unit, not a satellite sales office.)</em></li></ul>', 2, 'case_study');
+  END IF;
+
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'LearnUpon — APAC expansion announcement (newsroom)', 'https://www.learnupon.com/newsroom/learnupon-accelerates-apac-expansion/', 1, 'company_blog')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'IT Brief Australia — APAC growth and Courseau', 'https://itbrief.com.au/story/learnupon-boosts-apac-growth-with-ai-course-platform', 2, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Medianet — Sydney HQ and Courseau acquisition', 'https://newshub.medianet.com.au/2026/03/learnupon-accelerates-apac-expansion-with-new-sydney-headquarters-and-ai-native-courseau/144128/', 3, 'press_release')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Mirage News — APAC Sydney HQ update', 'https://www.miragenews.com/learnupon-expands-apac-with-sydney-hq-ai-1637940/', 4, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'BusinessWire — 2025 year-end performance and global recognition', 'https://www.businesswire.com/news/home/20260129847362/en/LearnUpon-Ends-2025-With-Breakthrough-Growth-Product-Innovation-and-Global-Recognition', 5, 'press_release')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+END
+$do_block$;

--- a/scripts/irish_tier1_import_blocks/06-kyckr-anz-market-entry.sql
+++ b/scripts/irish_tier1_import_blocks/06-kyckr-anz-market-entry.sql
@@ -1,0 +1,181 @@
+DO $do_block$
+DECLARE
+  v_id uuid;
+  v_sec_entry uuid;
+  v_sec_success uuid;
+  v_sec_metrics uuid;
+  v_sec_lessons uuid;
+BEGIN
+  INSERT INTO content_items (
+    slug, title, subtitle, category_id, content_type, status, featured,
+    read_time, tldr, quick_facts, researched_by, style_version
+  ) VALUES (
+    'kyckr-anz-market-entry', 'How Kyckr Entered the ANZ Market', 'How a Waterford-founded company registry intelligence startup used the Australian Securities Exchange not just as a capital-raising tool but as a market-entry strategy — gaining Australian institutional credibility, local investor visibility, and a listed-company governance structure that resonated with its compliance-focused customers.',
+    '0563b826-2123-4627-b912-14f63e9fbfb6'::uuid, 'case_study', 'published', false,
+    2, ARRAY['How a Waterford-founded company registry intelligence startup used the Australian Securities Exchange not just as a capital-raising tool but as a market-entry strategy — gaining Australian institutional credibility, local investor visibility, and a listed-company governance structure that resonated with its compliance-focused customers.', 'Kyckr was founded in Waterford in March 2007 by Ben Cronin, Rob Leslie, John Murray and Richard Wood.']::text[], '[{"icon": "MapPin", "label": "HQ", "value": "Ireland"}, {"icon": "Briefcase", "label": "Sector", "value": "RegTech"}, {"icon": "Globe", "label": "Target Market", "value": "Australia & New Zealand"}]'::jsonb, 'Stephen Browne', 2
+  )
+  ON CONFLICT (slug) DO UPDATE SET
+    title = EXCLUDED.title,
+    subtitle = EXCLUDED.subtitle,
+    category_id = EXCLUDED.category_id,
+    status = EXCLUDED.status,
+    read_time = EXCLUDED.read_time,
+    tldr = EXCLUDED.tldr,
+    quick_facts = EXCLUDED.quick_facts,
+    researched_by = EXCLUDED.researched_by,
+    style_version = EXCLUDED.style_version
+  RETURNING id INTO v_id;
+
+  IF NOT EXISTS (SELECT 1 FROM content_company_profiles WHERE content_id = v_id) THEN
+    INSERT INTO content_company_profiles (
+      content_id, company_name, origin_country, target_market,
+      entry_date, industry, founder_count, employee_count, is_profitable
+    ) VALUES (
+      v_id, 'Kyckr', 'Ireland', 'Australia & New Zealand',
+      '2016-01-01', 'RegTech', 4, NULL, NULL
+    );
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM content_founders WHERE content_id = v_id) THEN
+    INSERT INTO content_founders (content_id, name, title, is_primary)
+    VALUES (v_id, 'Ben Cronin', 'Co-founder', true);
+    INSERT INTO content_founders (content_id, name, title, is_primary)
+    VALUES (v_id, 'Rob Leslie', 'Co-founder', false);
+    INSERT INTO content_founders (content_id, name, title, is_primary)
+    VALUES (v_id, 'John Murray', 'Co-founder', false);
+    INSERT INTO content_founders (content_id, name, title, is_primary)
+    VALUES (v_id, 'Richard Wood', 'Co-founder', false);
+  END IF;
+
+  -- Section: entry-strategy
+  SELECT id INTO v_sec_entry FROM content_sections
+   WHERE content_id = v_id AND slug = 'entry-strategy';
+  IF v_sec_entry IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Entry Strategy', 'entry-strategy', 1, true)
+    RETURNING id INTO v_sec_entry;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Entry Strategy', sort_order = 1, is_active = true
+      WHERE id = v_sec_entry;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p>Kyckr was founded in Waterford in March 2007 by Ben Cronin, Rob Leslie, John Murray and Richard Wood. The company built a real-time registry intelligence platform that gave compliance teams at banks, financial institutions and corporates direct access to official company registry data across 300+ jurisdictions — removing the need to manually check registries or rely on outdated static databases.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>Kyckr was founded in Waterford in March 2007 by Ben Cronin, Rob Leslie, John Murray and Richard Wood. The company built a real-time registry intelligence platform that gave compliance teams at banks, financial institutions and corporates direct access to official company registry data across 300+ jurisdictions — removing the need to manually check registries or rely on outdated static databases.</p>', 1, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 2) THEN
+    UPDATE content_bodies SET body_text = '<p>Its core product addressed a genuine compliance burden: banks performing KYC, AML and onboarding checks needed accurate, current company ownership and incorporation data at speed. Kyckr automated this by connecting directly to primary regulatory sources.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 2;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>Its core product addressed a genuine compliance burden: banks performing KYC, AML and onboarding checks needed accurate, current company ownership and incorporation data at speed. Kyckr automated this by connecting directly to primary regulatory sources.</p>', 2, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 3) THEN
+    UPDATE content_bodies SET body_text = '<p>In September 2016, Kyckr listed on the Australian Securities Exchange under the ticker KYK, raising A$5 million with a fully diluted market capitalisation of approximately A$26 million. Enterprise Ireland had backed the company with a €250,000 investment ahead of the listing.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 3;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>In September 2016, Kyckr listed on the Australian Securities Exchange under the ticker KYK, raising A$5 million with a fully diluted market capitalisation of approximately A$26 million. Enterprise Ireland had backed the company with a €250,000 investment ahead of the listing.</p>', 3, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_entry AND sort_order = 4) THEN
+    UPDATE content_bodies SET body_text = '<p>This was not a conventional market-entry play. Kyckr was not simply raising capital on a convenient exchange. It was choosing to make Australia its listed domicile — which gave it Australian institutional shareholder support, regular ASX reporting obligations, and a profile in the Australian financial services sector precisely where its target customers operated. For a compliance-focused product, being a listed entity with transparent public reporting was itself a trust signal.</p>', updated_at = now()
+      WHERE section_id = v_sec_entry AND sort_order = 4;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_entry, '<p>This was not a conventional market-entry play. Kyckr was not simply raising capital on a convenient exchange. It was choosing to make Australia its listed domicile — which gave it Australian institutional shareholder support, regular ASX reporting obligations, and a profile in the Australian financial services sector precisely where its target customers operated. For a compliance-focused product, being a listed entity with transparent public reporting was itself a trust signal.</p>', 4, 'case_study');
+  END IF;
+
+  -- Section: success-factors
+  SELECT id INTO v_sec_success FROM content_sections
+   WHERE content_id = v_id AND slug = 'success-factors';
+  IF v_sec_success IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Success Factors', 'success-factors', 2, true)
+    RETURNING id INTO v_sec_success;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Success Factors', sort_order = 2, is_active = true
+      WHERE id = v_sec_success;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_success AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p><em>A public listing is not just a capital event. For a compliance-first product, it can be a trust signal, a market-entry mechanism and a talent-attraction tool — all at the same time.</em></p>', updated_at = now()
+      WHERE section_id = v_sec_success AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_success, '<p><em>A public listing is not just a capital event. For a compliance-first product, it can be a trust signal, a market-entry mechanism and a talent-attraction tool — all at the same time.</em></p>', 1, 'case_study');
+  END IF;
+
+  -- Section: key-metrics
+  SELECT id INTO v_sec_metrics FROM content_sections
+   WHERE content_id = v_id AND slug = 'key-metrics';
+  IF v_sec_metrics IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Key Metrics & Performance', 'key-metrics', 3, true)
+    RETURNING id INTO v_sec_metrics;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Key Metrics & Performance', sort_order = 3, is_active = true
+      WHERE id = v_sec_metrics;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_metrics AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p>After listing, Kyckr grew its product to cover more than 120 million businesses from 300-plus primary regulatory sources across more than 100 countries. In FY2017 it reported $1.54 million in revenue, up 34%. By FY2019 revenue had reached $2.14 million, representing growth of more than 25%. Clients included Citi Commercial Bank and Commerzbank.</p>', updated_at = now()
+      WHERE section_id = v_sec_metrics AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_metrics, '<p>After listing, Kyckr grew its product to cover more than 120 million businesses from 300-plus primary regulatory sources across more than 100 countries. In FY2017 it reported $1.54 million in revenue, up 34%. By FY2019 revenue had reached $2.14 million, representing growth of more than 25%. Clients included Citi Commercial Bank and Commerzbank.</p>', 1, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_metrics AND sort_order = 2) THEN
+    UPDATE content_bodies SET body_text = '<p>In November 2022, Richard White — the founder of WiseTech Global, one of Australia''s most successful technology companies — completed the acquisition of the remaining 77.24% stake in Kyckr he did not already own and delisted the company. The acquisition validated Kyckr''s technology and validated the ANZ market-entry approach by attracting strategic attention from one of Australia''s most respected technology founders.</p>', updated_at = now()
+      WHERE section_id = v_sec_metrics AND sort_order = 2;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_metrics, '<p>In November 2022, Richard White — the founder of WiseTech Global, one of Australia''s most successful technology companies — completed the acquisition of the remaining 77.24% stake in Kyckr he did not already own and delisted the company. The acquisition validated Kyckr''s technology and validated the ANZ market-entry approach by attracting strategic attention from one of Australia''s most respected technology founders.</p>', 2, 'case_study');
+  END IF;
+
+  -- Section: lessons-learned
+  SELECT id INTO v_sec_lessons FROM content_sections
+   WHERE content_id = v_id AND slug = 'lessons-learned';
+  IF v_sec_lessons IS NULL THEN
+    INSERT INTO content_sections (content_id, title, slug, sort_order, is_active)
+    VALUES (v_id, 'Lessons Learned', 'lessons-learned', 4, true)
+    RETURNING id INTO v_sec_lessons;
+  ELSE
+    UPDATE content_sections
+      SET title = 'Lessons Learned', sort_order = 4, is_active = true
+      WHERE id = v_sec_lessons;
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_lessons AND sort_order = 1) THEN
+    UPDATE content_bodies SET body_text = '<p>For Irish operators considering ANZ entry, Kyckr''s playbook offers a clear template. The lessons below distil Kyckr''s entry decisions, partner choices, and milestones in Australia &amp; New Zealand.</p>', updated_at = now()
+      WHERE section_id = v_sec_lessons AND sort_order = 1;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_lessons, '<p>For Irish operators considering ANZ entry, Kyckr''s playbook offers a clear template. The lessons below distil Kyckr''s entry decisions, partner choices, and milestones in Australia &amp; New Zealand.</p>', 1, 'case_study');
+  END IF;
+  IF EXISTS (SELECT 1 FROM content_bodies WHERE section_id = v_sec_lessons AND sort_order = 2) THEN
+    UPDATE content_bodies SET body_text = '<ul><li><strong>Use capital markets as an entry mechanism</strong> — Listed on ASX to gain Australian institutional credibility alongside capital. <em>(In regulated B2B sectors, a public listing can be more effective than a sales office. It makes trust transparent and permanent.)</em></li><li><strong>Match the entry mechanism to the product''s trust requirements</strong> — A compliance product for banks needed to demonstrate governance. A listed company structure did exactly that. <em>(Think about what signal your customers need most and choose an entry mechanism that delivers it.)</em></li><li><strong>Build toward strategic acquirers</strong> — Kyckr''s data infrastructure attracted WiseTech founder Richard White as a personal acquirer. <em>(If your product is genuinely valuable infrastructure, ANZ exits to global tech leaders are achievable.)</em></li></ul>', updated_at = now()
+      WHERE section_id = v_sec_lessons AND sort_order = 2;
+  ELSE
+    INSERT INTO content_bodies (content_id, section_id, body_text, sort_order, content_type)
+    VALUES (v_id, v_sec_lessons, '<ul><li><strong>Use capital markets as an entry mechanism</strong> — Listed on ASX to gain Australian institutional credibility alongside capital. <em>(In regulated B2B sectors, a public listing can be more effective than a sales office. It makes trust transparent and permanent.)</em></li><li><strong>Match the entry mechanism to the product''s trust requirements</strong> — A compliance product for banks needed to demonstrate governance. A listed company structure did exactly that. <em>(Think about what signal your customers need most and choose an entry mechanism that delivers it.)</em></li><li><strong>Build toward strategic acquirers</strong> — Kyckr''s data infrastructure attracted WiseTech founder Richard White as a personal acquirer. <em>(If your product is genuinely valuable infrastructure, ANZ exits to global tech leaders are achievable.)</em></li></ul>', 2, 'case_study');
+  END IF;
+
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Fora.ie — Kyckr ASX IPO announcement (Sept 2016)', 'https://fora.ie/kyckr-waterford-ipo-2968390-Sep2016/', 1, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'MarketScreener — Richard White acquires remaining Kyckr stake (Nov 2022)', 'https://in.marketscreener.com/quote/stock/KYCKR-LIMITED-27546659/news/Richard-White-completed-the-acquisition-of-the-remaining-77.24-stake-in-Kyckr-Limited-42171348/', 2, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Addisons — Kyckr ASX KYK acquisition by RealWise (legal announcement)', 'https://addisons.com/announcement/addisons-advises-kyckr-asx-kyk-on-its-acquisition-by-realwise/', 3, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Wikipedia — Kyckr company article', 'https://en.wikipedia.org/wiki/Kyckr', 4, 'other')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+  INSERT INTO case_study_sources (case_study_id, label, url, citation_number, source_type)
+  VALUES (v_id, 'Finovate — Kyckr archive (product and financial service context)', 'https://finovate.com/category/kyckr/', 5, 'news')
+  ON CONFLICT (case_study_id, url) DO NOTHING;
+END
+$do_block$;

--- a/scripts/parse_irish_tier1.py
+++ b/scripts/parse_irish_tier1.py
@@ -1,0 +1,554 @@
+"""Parse data/case-studies/irish_tier1_anz_research.html into MES-shaped JSON.
+
+Source format: a Perplexity-produced HTML page with 6 case studies wrapped in
+<section class="case-study">. Each case has a fixed structure:
+
+  - <span class="case-num">  → "Case Study NN · Sector"
+  - <span class="slug-code">  → "slug: foo-bar"  (kept as legacy_slug)
+  - <h2>                      → title
+  - <p class="tagline">       → subtitle
+  - <div class="meta-strip">  → Founded / Founders / dates / etc.
+  - <div class="section-title">{Heading}</div> + sibling content blocks
+  - <div class="callout">     → editorial lesson (boxed quote)
+  - <span class="tag">        → mes_tags
+  - <div class="src-item">    → numbered citation list
+
+Slug normalisation: the source uses ad-hoc slugs (clanwilliam-anz, etc.) but
+the MES platform standard is `<company>-anz-market-entry` (matches the
+existing 25 published case studies). We normalise on import; the original
+source slug is preserved in `legacy_slug` for traceability.
+
+Output keyed shape mirrors `parsed_uk_enriched.json` so the existing import
+pipeline patterns can be reused.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from bs4 import BeautifulSoup, NavigableString, Tag
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INPUT_PATH = REPO_ROOT / "data" / "case-studies" / "irish_tier1_anz_research.html"
+OUTPUT_PATH = REPO_ROOT / "scripts" / "parsed_irish_tier1.json"
+
+# Source slug → MES standard slug
+SLUG_NORMALISATION = {
+    "clanwilliam-anz": "clanwilliam-anz-market-entry",
+    "spectrumlife-australia": "spectrum-life-anz-market-entry",
+    "tpro-apac": "t-pro-anz-market-entry",
+    "fexco-pacific-australia": "fexco-anz-market-entry",
+    "learnupon-apac": "learnupon-anz-market-entry",
+    "kyckr-asx": "kyckr-anz-market-entry",
+}
+
+# Source sector → MES category (matches existing 25 cases' split)
+CATEGORY_BY_SLUG = {
+    "clanwilliam-anz-market-entry": "Technology Market Entry",  # Healthtech
+    "spectrum-life-anz-market-entry": "Fintech Success",         # Insurtech / EAP / wellbeing
+    "t-pro-anz-market-entry": "Technology Market Entry",          # Healthcare AI
+    "fexco-anz-market-entry": "Fintech Success",                  # FX / payments
+    "learnupon-anz-market-entry": "Technology Market Entry",      # Edtech / SaaS
+    "kyckr-anz-market-entry": "Fintech Success",                  # RegTech
+}
+
+INDUSTRY_BY_SLUG = {
+    "clanwilliam-anz-market-entry": "Healthtech",
+    "spectrum-life-anz-market-entry": "Insurtech",
+    "t-pro-anz-market-entry": "Healthcare AI",
+    "fexco-anz-market-entry": "Fintech",
+    "learnupon-anz-market-entry": "Edtech",
+    "kyckr-anz-market-entry": "RegTech",
+}
+
+COMPANY_NAME_BY_SLUG = {
+    "clanwilliam-anz-market-entry": "Clanwilliam",
+    "spectrum-life-anz-market-entry": "Spectrum.Life",
+    "t-pro-anz-market-entry": "T-Pro",
+    "fexco-anz-market-entry": "Fexco",
+    "learnupon-anz-market-entry": "LearnUpon",
+    "kyckr-anz-market-entry": "Kyckr",
+}
+
+# Founders: pulled from meta-strip (where present) or from prose for cases
+# that don't include a Founders meta-cell (Clanwilliam, Fexco, T-Pro, Kyckr).
+FOUNDERS_BY_SLUG: dict[str, list[dict[str, Any]]] = {
+    "clanwilliam-anz-market-entry": [
+        {"name": "Howard Beggs", "title": "Founder", "is_primary": True},
+    ],
+    "spectrum-life-anz-market-entry": [
+        {"name": "Stuart McGoldrick", "title": "Co-founder", "is_primary": True},
+        {"name": "Stephen Costello", "title": "Co-founder", "is_primary": False},
+    ],
+    "t-pro-anz-market-entry": [],
+    "fexco-anz-market-entry": [
+        {"name": "Brian McCarthy", "title": "Founder", "is_primary": True},
+    ],
+    "learnupon-anz-market-entry": [
+        {"name": "Brendan Noud", "title": "Co-founder & CEO", "is_primary": True},
+        {"name": "Des Anderson", "title": "Co-founder & CTO", "is_primary": False},
+    ],
+    "kyckr-anz-market-entry": [
+        {"name": "Ben Cronin", "title": "Co-founder", "is_primary": True},
+        {"name": "Rob Leslie", "title": "Co-founder", "is_primary": False},
+        {"name": "John Murray", "title": "Co-founder", "is_primary": False},
+        {"name": "Richard Wood", "title": "Co-founder", "is_primary": False},
+    ],
+}
+
+# Map source section headings to canonical MES section slugs.
+# Order in the output JSON follows the MES convention: entry → success → metrics → lessons.
+SECTION_ROUTING: list[tuple[str, list[str]]] = [
+    (
+        "entry-strategy",
+        [
+            "Overview",
+            "Company overview",
+            "Why ANZ was the right market",
+            "Why Australia was the right market",
+            "Market entry journey",
+            "ANZ market entry journey",
+            "ANZ and APAC market entry journey",
+            "The ASX as a market-entry strategy",
+        ],
+    ),
+    (
+        "success-factors",
+        [
+            "What founders can copy (MES Playbook)",
+            "MES Playbook",
+            "Why this approach worked",
+            "Why this pattern matters for MES",
+        ],
+    ),
+    (
+        "key-metrics",
+        ["Key outcomes", "APAC customer base", "Growth and exit"],
+    ),
+    (
+        "lessons-learned",
+        ["What founders can copy (MES Playbook)", "MES Playbook"],
+    ),
+]
+
+# Source type detection (domain-only, matches the UK enrichment heuristic).
+def _domain_of(url: str) -> str:
+    m = re.match(r"^https?://([^/]+)", url.lower())
+    return m.group(1) if m else url.lower()
+
+
+PRESS_DOMAINS = {
+    "newshub.medianet.com.au", "via.ritzau.dk", "pressreleases.responsesource.com",
+    "businesswire.com", "www.businesswire.com",
+}
+COMPANY_DOMAINS = {
+    "www.clanwilliam.com", "clanwilliam.com",
+    "www.healthlink.com.au", "healthlink.com.au",
+    "www.telstrahealth.com", "telstrahealth.com",
+    "spectrum.life", "www.spectrum.life",
+    "blog.tpro.io", "tpro.io",
+    "valionhealth.com.au", "soundbusiness.co.nz",
+    "www.fexco.com", "fexco.com", "no1currency.com", "www.no1currency.com",
+    "www.learnupon.com", "learnupon.com",
+    "kyckr.com", "www.kyckr.com",
+    "www.livingbridge.com", "livingbridge.com",
+    "www.minterellison.com", "minterellison.com",
+    "www.waterman.co.nz",
+}
+
+
+def detect_source_type(url: str) -> str:
+    domain = _domain_of(url)
+    if "linkedin.com" in domain:
+        return "linkedin"
+    if domain.endswith(".gov.au") or domain.endswith(".gov.uk") or ".gov." in domain:
+        return "government"
+    if "wikipedia.org" in domain:
+        return "other"
+    if domain in PRESS_DOMAINS:
+        return "press_release"
+    if domain in COMPANY_DOMAINS:
+        return "company_blog"
+    return "news"
+
+
+# ---------------------------------------------------------------------------
+# Inline-content rendering helpers
+# ---------------------------------------------------------------------------
+
+_WS_RE = re.compile(r"\s+")
+
+
+def _flatten_text(node: Tag | NavigableString) -> str:
+    """Collect text content from a node, preserving inline anchors as plain text."""
+    if isinstance(node, NavigableString):
+        return str(node)
+    parts: list[str] = []
+    for child in node.children:
+        if isinstance(child, NavigableString):
+            parts.append(str(child))
+        elif isinstance(child, Tag):
+            if child.name == "a":
+                parts.append(child.get_text(" ", strip=False))
+            elif child.name in {"em", "strong", "b", "i"}:
+                inner = _flatten_text(child)
+                tag = "strong" if child.name in {"strong", "b"} else "em"
+                parts.append(f"<{tag}>{inner}</{tag}>")
+            else:
+                parts.append(_flatten_text(child))
+    return "".join(parts)
+
+
+def _normalise_ws(s: str) -> str:
+    return _WS_RE.sub(" ", s).strip()
+
+
+def _p_html(text: str) -> str:
+    text = _normalise_ws(text)
+    if not text:
+        return ""
+    return f"<p>{text}</p>"
+
+
+_STRIP_INNER_STRONG = re.compile(r"</?strong>")
+
+
+def _strip_inner_strong(s: str) -> str:
+    return _STRIP_INNER_STRONG.sub("", s)
+
+
+def _table_to_ul(table: Tag) -> str:
+    """Render a 2- or 3-column table as a single <ul> bullet list.
+
+    Uses the first <th> column heading to detect 'Year' / 'Metric' / 'Customer' /
+    'Play' rows.  Drops the header row. Inline <strong> in cells is stripped
+    so wrapping the whole cell in <strong> for emphasis doesn't nest tags.
+    """
+    headers = [_normalise_ws(_flatten_text(th)) for th in table.select("thead th")]
+    rows = []
+    for tr in table.select("tbody tr"):
+        cells = [_normalise_ws(_flatten_text(td)) for td in tr.find_all("td")]
+        if cells:
+            rows.append(cells)
+    if not rows:
+        return ""
+    lis: list[str] = []
+    for cells in rows:
+        if len(cells) >= 3:
+            head = _strip_inner_strong(cells[0])
+            mid, tail = cells[1], cells[2]
+            lis.append(
+                f"<li><strong>{head}</strong> — {mid} <em>({tail})</em></li>"
+            )
+        elif len(cells) == 2:
+            head = _strip_inner_strong(cells[0])
+            lis.append(f"<li><strong>{head}</strong>: {cells[1]}</li>")
+        elif len(cells) == 1:
+            lis.append(f"<li>{cells[0]}</li>")
+    return f"<ul>{''.join(lis)}</ul>"
+
+
+def _section_block_to_html(block: Tag) -> tuple[str, list[str]]:
+    """Convert a <div class='section-block'> → (heading, [body html paragraphs])."""
+    heading_div = block.find("div", class_="section-title")
+    heading = _normalise_ws(_flatten_text(heading_div)) if heading_div else ""
+    bodies: list[str] = []
+    for child in block.children:
+        if not isinstance(child, Tag):
+            continue
+        if child is heading_div:
+            continue
+        if child.name == "p":
+            html = _p_html(_flatten_text(child))
+            if html:
+                bodies.append(html)
+        elif child.name == "div" and "tbl-wrap" in (child.get("class") or []):
+            table = child.find("table")
+            if table:
+                rendered = _table_to_ul(table)
+                if rendered:
+                    bodies.append(rendered)
+        elif child.name == "div" and "tag-row" in (child.get("class") or []):
+            # tags are captured separately
+            continue
+        elif child.name == "div" and "schema-box" in (child.get("class") or []):
+            continue
+    return heading, bodies
+
+
+def _meta_strip_to_kv(strip: Tag) -> list[tuple[str, str]]:
+    out: list[tuple[str, str]] = []
+    for cell in strip.select(".meta-cell"):
+        label_div = cell.find("div", class_="label")
+        value_div = cell.find("div", class_="value")
+        if label_div and value_div:
+            out.append((
+                _normalise_ws(_flatten_text(label_div)),
+                _normalise_ws(_flatten_text(value_div)),
+            ))
+    return out
+
+
+def _meta_to_quick_facts(meta: list[tuple[str, str]], industry: str) -> list[dict]:
+    """Take the source's Founded/EntryMode/etc. and project into MES quick_facts."""
+    qf: list[dict] = [
+        {"icon": "MapPin", "label": "HQ", "value": "Ireland"},
+        {"icon": "Briefcase", "label": "Sector", "value": industry},
+        {"icon": "Globe", "label": "Target Market", "value": "Australia & New Zealand"},
+    ]
+    return qf
+
+
+def _entry_year_from_meta(meta: list[tuple[str, str]]) -> str | None:
+    for label, value in meta:
+        if any(kw in label.lower() for kw in ("anz entry", "australia entry", "nz entry", "first anz", "asx listing", "anz division")):
+            m = re.search(r"((?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\w*\s+)?(\d{4})", value, re.I)
+            if m:
+                return m.group(2)
+    return None
+
+
+def _company_founded_from_meta(meta: list[tuple[str, str]]) -> str | None:
+    for label, value in meta:
+        if label.lower() == "founded":
+            m = re.search(r"(\d{4})", value)
+            if m:
+                return m.group(1)
+    return None
+
+
+def _extract_callout(card_body: Tag) -> str | None:
+    callout = card_body.find("div", class_="callout")
+    if not callout:
+        return None
+    # Pull the quote and the cite separately so we can render cleanly.
+    cite_tag = callout.find("cite")
+    cite_text = ""
+    if cite_tag:
+        cite_text = _normalise_ws(_flatten_text(cite_tag))
+        cite_tag.extract()  # remove from tree before flattening the rest
+    quote_text = _normalise_ws(_flatten_text(callout))
+    # Strip surrounding quotes (straight or curly).
+    quote_text = quote_text.strip().strip('"“”').strip()
+    # Drop the generic editorial-lesson attribution; keep named attributions
+    # (e.g. "— Stephen Costello, CEO, …").
+    if cite_text and "MES editorial lesson" not in cite_text:
+        return f"&ldquo;{quote_text}&rdquo; <span style=\"color: var(--muted);\">{cite_text}</span>"
+    return quote_text or None
+
+
+def _extract_sources(card_body: Tag) -> list[dict]:
+    sources: list[dict] = []
+    src_block = card_body.find("div", class_="sources-block")
+    if not src_block:
+        return sources
+    for item in src_block.select(".src-item"):
+        num_div = item.find("div", class_="src-num")
+        label_div = item.find("div", class_="src-label")
+        link = item.find("a", href=True)
+        if not link:
+            continue
+        try:
+            n = int(_normalise_ws(_flatten_text(num_div))) if num_div else None
+        except (TypeError, ValueError):
+            n = None
+        url = link["href"].strip()
+        label = _normalise_ws(_flatten_text(label_div)) if label_div else url
+        sources.append({
+            "citation_number": n,
+            "url": url,
+            "label": label,
+            "source_type": detect_source_type(url),
+        })
+    return sources
+
+
+def _extract_tags(card_body: Tag) -> list[str]:
+    return [
+        _normalise_ws(_flatten_text(tag))
+        for tag in card_body.select(".tag-row .tag")
+    ]
+
+
+def _build_section_map(card_body: Tag) -> dict[str, list[str]]:
+    """heading-text → list[<html body>] over all section-blocks in card_body."""
+    out: dict[str, list[str]] = {}
+    for block in card_body.find_all("div", class_="section-block", recursive=True):
+        heading, bodies = _section_block_to_html(block)
+        if heading and bodies:
+            out.setdefault(heading, []).extend(bodies)
+    return out
+
+
+def parse_case(section: Tag) -> dict[str, Any]:
+    # ---- header ----
+    case_num = _normalise_ws(_flatten_text(section.find("span", class_="case-num"))) if section.find("span", class_="case-num") else ""
+    slug_code = _normalise_ws(_flatten_text(section.find("span", class_="slug-code"))) if section.find("span", class_="slug-code") else ""
+    legacy_slug = slug_code.replace("slug:", "").strip()
+    new_slug = SLUG_NORMALISATION.get(legacy_slug)
+    if not new_slug:
+        raise RuntimeError(f"Unknown source slug: {legacy_slug!r}")
+
+    title_h2 = section.find("h2")
+    source_title = _normalise_ws(_flatten_text(title_h2)) if title_h2 else ""
+
+    tagline = ""
+    tagline_p = section.select_one("p.tagline")
+    if tagline_p:
+        tagline = _normalise_ws(_flatten_text(tagline_p))
+
+    company = COMPANY_NAME_BY_SLUG[new_slug]
+    industry = INDUSTRY_BY_SLUG[new_slug]
+    category = CATEGORY_BY_SLUG[new_slug]
+
+    # ---- meta strip ----
+    meta_strip = section.find("div", class_="meta-strip")
+    meta = _meta_strip_to_kv(meta_strip) if meta_strip else []
+    company_founded = _company_founded_from_meta(meta)
+    entry_year = _entry_year_from_meta(meta)
+    quick_facts = _meta_to_quick_facts(meta, industry)
+
+    card_body = section.find("div", class_="card-body")
+    if not card_body:
+        raise RuntimeError(f"Missing card-body for slug {legacy_slug}")
+
+    section_map = _build_section_map(card_body)
+    callout = _extract_callout(card_body)
+
+    # ---- Map source headings → MES sections ----
+    entry_html: list[str] = []
+    for h in ["Overview", "Company overview"]:
+        if h in section_map:
+            entry_html.extend(section_map[h])
+    for h in [
+        "Why ANZ was the right market",
+        "Why Australia was the right market",
+    ]:
+        if h in section_map:
+            entry_html.extend(section_map[h])
+    for h in [
+        "Market entry journey",
+        "ANZ market entry journey",
+        "ANZ and APAC market entry journey",
+        "The ASX as a market-entry strategy",
+    ]:
+        if h in section_map:
+            entry_html.extend(section_map[h])
+
+    success_html: list[str] = []
+    for h in [
+        "Why this approach worked",
+        "Why this pattern matters for MES",
+    ]:
+        if h in section_map:
+            success_html.extend(section_map[h])
+    if callout:
+        success_html.append(f"<p><em>{callout}</em></p>")
+
+    metrics_html: list[str] = []
+    for h in ["Key outcomes", "APAC customer base", "Growth and exit"]:
+        if h in section_map:
+            metrics_html.extend(section_map[h])
+    # Fallback: if the source has no Key outcomes table, synthesize one from
+    # the meta-strip so every case has a consistent 4-section MES shape.
+    if not metrics_html and meta:
+        items = "".join(f"<li><strong>{lbl}</strong>: {val}</li>" for lbl, val in meta)
+        metrics_html.append(f"<ul>{items}</ul>")
+
+    lessons_html: list[str] = []
+    intro_p = (
+        f"<p>For Irish operators considering ANZ entry, {company}'s playbook offers "
+        f"a clear template. The lessons below distil {company}'s entry decisions, "
+        f"partner choices, and milestones in Australia &amp; New Zealand.</p>"
+    )
+    lessons_html.append(intro_p)
+    for h in ["What founders can copy (MES Playbook)", "MES Playbook"]:
+        if h in section_map:
+            lessons_html.extend(section_map[h])
+
+    # If the success-factors block is empty (no "Why this approach worked"
+    # heading), back-fill it with the playbook table so the section never
+    # renders blank.
+    if not success_html:
+        for h in ["What founders can copy (MES Playbook)", "MES Playbook"]:
+            if h in section_map:
+                success_html.extend(section_map[h])
+                break
+
+    sections = [
+        {"title": "Entry Strategy", "slug": "entry-strategy", "bodies": entry_html},
+        {"title": "Success Factors", "slug": "success-factors", "bodies": success_html},
+        {"title": "Key Metrics & Performance", "slug": "key-metrics", "bodies": metrics_html},
+        {"title": "Lessons Learned", "slug": "lessons-learned", "bodies": lessons_html},
+    ]
+    sections = [s for s in sections if s["bodies"]]
+
+    sources = _extract_sources(card_body)
+    tags = _extract_tags(card_body)
+
+    # ---- Top-level fields ----
+    title = f"How {company} Entered the ANZ Market"
+    subtitle = tagline or None
+    tldr: list[str] = []
+    if tagline:
+        tldr.append(tagline)
+    if entry_html:
+        first = re.sub(r"<[^>]+>", "", entry_html[0])
+        first_sentence = re.split(r"(?<=[.!?])\s+", first.strip())[0]
+        if first_sentence and first_sentence not in tldr:
+            tldr.append(first_sentence)
+
+    # rough read-time estimate (200 wpm)
+    word_count = sum(len(re.sub(r"<[^>]+>", " ", b).split()) for s in sections for b in s["bodies"])
+    read_time = max(2, round(word_count / 200))
+
+    return {
+        "slug": new_slug,
+        "legacy_slug": legacy_slug,
+        "title": title,
+        "subtitle": subtitle,
+        "category": category,
+        "company_name": company,
+        "origin_country": "Ireland",
+        "target_market": "Australia & New Zealand",
+        "industry": industry,
+        "company_founded": company_founded,
+        "entry_year": entry_year,
+        "tagline": tagline,
+        "tldr": tldr,
+        "quick_facts": quick_facts,
+        "founders": FOUNDERS_BY_SLUG.get(new_slug, []),
+        "sections": sections,
+        "sources": sources,
+        "mes_tags": tags,
+        "read_time": read_time,
+        "status": "published",
+        "source_title": source_title,
+        "case_num": case_num,
+    }
+
+
+def main() -> None:
+    soup = BeautifulSoup(INPUT_PATH.read_text(encoding="utf-8"), "lxml")
+    cases = []
+    for section in soup.select("section.case-study"):
+        cases.append(parse_case(section))
+    OUTPUT_PATH.write_text(
+        json.dumps(cases, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    print(f"Parsed {len(cases)} Irish Tier 1 case studies → {OUTPUT_PATH}")
+    for c in cases:
+        sec_summary = ", ".join(f"{s['slug']}({len(s['bodies'])})" for s in c["sections"])
+        print(
+            f"  {c['slug']:42s} legacy={c['legacy_slug']:30s} "
+            f"sections=[{sec_summary}] sources={len(c['sources'])} "
+            f"founders={len(c['founders'])} tags={len(c['mes_tags'])}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/parsed_irish_tier1.json
+++ b/scripts/parsed_irish_tier1.json
@@ -1,0 +1,818 @@
+[
+  {
+    "slug": "clanwilliam-anz-market-entry",
+    "legacy_slug": "clanwilliam-anz",
+    "title": "How Clanwilliam Entered the ANZ Market",
+    "subtitle": "How a Dublin-founded healthtech group turned a series of ANZ acquisitions into a dominant clinical communications and connected-care platform spanning Australia and New Zealand.",
+    "category": "Technology Market Entry",
+    "company_name": "Clanwilliam",
+    "origin_country": "Ireland",
+    "target_market": "Australia & New Zealand",
+    "industry": "Healthtech",
+    "company_founded": "1996",
+    "entry_year": "2017",
+    "tagline": "How a Dublin-founded healthtech group turned a series of ANZ acquisitions into a dominant clinical communications and connected-care platform spanning Australia and New Zealand.",
+    "tldr": [
+      "How a Dublin-founded healthtech group turned a series of ANZ acquisitions into a dominant clinical communications and connected-care platform spanning Australia and New Zealand.",
+      "Clanwilliam is an Irish healthcare technology group founded in 1996 by Howard Beggs."
+    ],
+    "quick_facts": [
+      {
+        "icon": "MapPin",
+        "label": "HQ",
+        "value": "Ireland"
+      },
+      {
+        "icon": "Briefcase",
+        "label": "Sector",
+        "value": "Healthtech"
+      },
+      {
+        "icon": "Globe",
+        "label": "Target Market",
+        "value": "Australia & New Zealand"
+      }
+    ],
+    "founders": [
+      {
+        "name": "Howard Beggs",
+        "title": "Founder",
+        "is_primary": true
+      }
+    ],
+    "sections": [
+      {
+        "title": "Entry Strategy",
+        "slug": "entry-strategy",
+        "bodies": [
+          "<p>Clanwilliam is an Irish healthcare technology group founded in 1996 by Howard Beggs. Its ANZ story is one of the clearest examples in the MES library of a company using acquisition to buy embedded market trust rather than attempting to build it from scratch against entrenched local competitors.</p>",
+          "<p>Rather than launch a sales operation into an unfamiliar healthcare system, Clanwilliam acquired businesses that were already woven into clinical workflows across Australian and New Zealand healthcare. That strategy gave it immediate network effects, customer relationships, and regulatory familiarity that would have taken years to replicate organically.</p>",
+          "<p>Australian and New Zealand healthcare offered a compelling structural opportunity: both markets were digitising clinical communications but remained fragmented, with legacy secure messaging providers sitting alongside newer referral and data-exchange tools. Clanwilliam identified that connecting these silos was a solvable problem — but only if you owned or operated key pieces of the exchange infrastructure.</p>",
+          "<p>The English-language operating environment, a shared regulatory philosophy with Ireland, and strong government investment in digital health infrastructure made ANZ particularly accessible for an Irish company with deep healthcare workflow expertise.</p>",
+          "<ul><li><strong>2017</strong> — Acquired HealthLink (NZ-founded, ANZ coverage) <em>(Gained an established health messaging network across ANZ, including 15,000+ connected medical organisations.)</em></li><li><strong>2017–18</strong> — Acquired Konnect NET <em>(Added pharmacy connectivity and additional healthcare workflow capability in Australia.)</em></li><li><strong>Dec 2020</strong> — Merged HealthLink and Konnect NET <em>(Reduced regional operational fragmentation and created a cleaner ANZ platform structure ahead of further growth.)</em></li><li><strong>Mar 2024</strong> — Launched formal ANZ Division <em>(Formalised regional leadership (David Young as MD Australia, Mike Weiss as MD NZ) with four products: HealthLink, Konnect NET, Toniq, MBS.)</em></li><li><strong>Jan 2024</strong> — HealthLink acquired Telstra Health's Argus, Connecting Care and eReferrals assets <em>(Consolidated a major competitor/complementary player; deepened secure messaging and e-referral market share across Australian healthcare.)</em></li></ul>"
+        ]
+      },
+      {
+        "title": "Success Factors",
+        "slug": "success-factors",
+        "bodies": [
+          "<p><em>In regulated health markets, the fastest route to credibility is to buy trust that is already embedded in the workflow — then consolidate around interoperability.</em></p>"
+        ]
+      },
+      {
+        "title": "Key Metrics & Performance",
+        "slug": "key-metrics",
+        "bodies": [
+          "<ul><li><strong>Medical organisations connected</strong> — 15,000+ across Australasia <em>(HealthLink network data (healthlink.com.au))</em></li><li><strong>Clinical messages per year</strong> — 100 million+ <em>(HealthLink network data)</em></li><li><strong>ANZ Division product count</strong> — 4 (HealthLink, Konnect NET, Toniq, MBS) <em>(ANZ Division launch announcement, March 2024)</em></li><li><strong>Telstra Health assets acquired</strong> — Argus, Connecting Care, eReferrals <em>(MinterEllison deal announcement, Jan 2024)</em></li></ul>"
+        ]
+      },
+      {
+        "title": "Lessons Learned",
+        "slug": "lessons-learned",
+        "bodies": [
+          "<p>For Irish operators considering ANZ entry, Clanwilliam's playbook offers a clear template. The lessons below distil Clanwilliam's entry decisions, partner choices, and milestones in Australia &amp; New Zealand.</p>",
+          "<ul><li><strong>Buy installed trust</strong> — Acquired HealthLink's embedded clinical messaging network rather than building one. <em>(In complex systems, distribution is often acquired, not invented. Look for businesses with workflow lock-in.)</em></li><li><strong>Integrate before scaling</strong> — Merged HealthLink and Konnect NET before launching a formal ANZ division. <em>(Operational coherence should precede expansion messaging. Don't promote fragmented assets.)</em></li><li><strong>Consolidate adjacencies</strong> — Acquired Telstra Health's overlapping secure messaging and e-referrals footprint. <em>(Once inside a workflow category, strengthen the moat by absorbing complementary infrastructure before a competitor does.)</em></li><li><strong>Formalise with leadership</strong> — Appointed dedicated MD for Australia and MD for NZ as part of division launch. <em>(A named regional leader signals permanence to customers, partners and regulators more than any press release.)</em></li></ul>"
+        ]
+      }
+    ],
+    "sources": [
+      {
+        "citation_number": 1,
+        "url": "https://insurtechnz.org.nz/2024/03/12/clanwilliam-launches-anz-division-in-a-commitment-to-the-future-of-healthcare-across-australia-and-new-zealand/",
+        "label": "ANZ Division launch announcement",
+        "source_type": "news"
+      },
+      {
+        "citation_number": 2,
+        "url": "https://www.minterellison.com/articles/minterellison-advises-clanwilliam-on-telstra-health-acquisition",
+        "label": "MinterEllison on Telstra Health acquisition",
+        "source_type": "company_blog"
+      },
+      {
+        "citation_number": 3,
+        "url": "https://www.telstrahealth.com/healthlink-acquires-telstra-health-argus-connecting-care-and-ereferrals-business/",
+        "label": "Telstra Health sale announcement",
+        "source_type": "company_blog"
+      },
+      {
+        "citation_number": 4,
+        "url": "https://www.waterman.co.nz/news/healthlink-acquired-by-global-healthcare-technology-specialist/",
+        "label": "HealthLink acquisition background (Waterman)",
+        "source_type": "company_blog"
+      },
+      {
+        "citation_number": 5,
+        "url": "https://www.pulseit.news/australian-digital-health/healthlink-swoops-on-telstra-healths-secure-messaging-and-ereferrals-business/",
+        "label": "Pulse IT on Telstra Health Argus deal",
+        "source_type": "news"
+      },
+      {
+        "citation_number": 6,
+        "url": "https://www.healthlink.com.au/clanwilliams-healthlink-acquires-telstra-healths-argus-connecting-care-and-ereferrals-business/",
+        "label": "HealthLink network scale (corporate site)",
+        "source_type": "company_blog"
+      }
+    ],
+    "mes_tags": [
+      "Healthtech",
+      "Acquisition-led entry",
+      "Healthcare infrastructure",
+      "Australia",
+      "New Zealand",
+      "ANZ Division build-out",
+      "Category consolidation",
+      "B2B",
+      "Ireland → ANZ",
+      "Enterprise"
+    ],
+    "read_time": 3,
+    "status": "published",
+    "source_title": "Clanwilliam: building ANZ healthcare infrastructure through staged acquisition and category consolidation",
+    "case_num": "Case Study 01 · Healthtech"
+  },
+  {
+    "slug": "spectrum-life-anz-market-entry",
+    "legacy_slug": "spectrumlife-australia",
+    "title": "How Spectrum.Life Entered the ANZ Market",
+    "subtitle": "How a Dublin-founded digital wellbeing platform skipped the greenfield build and entered Australia simultaneously across three complementary verticals — workplace mental health, EAP, and specialist virtual care — by acquiring three local businesses on the same day.",
+    "category": "Fintech Success",
+    "company_name": "Spectrum.Life",
+    "origin_country": "Ireland",
+    "target_market": "Australia & New Zealand",
+    "industry": "Insurtech",
+    "company_founded": "2018",
+    "entry_year": "2026",
+    "tagline": "How a Dublin-founded digital wellbeing platform skipped the greenfield build and entered Australia simultaneously across three complementary verticals — workplace mental health, EAP, and specialist virtual care — by acquiring three local businesses on the same day.",
+    "tldr": [
+      "How a Dublin-founded digital wellbeing platform skipped the greenfield build and entered Australia simultaneously across three complementary verticals — workplace mental health, EAP, and specialist virtual care — by acquiring three local businesses on the same day.",
+      "Spectrum.Life was founded in Dublin in 2018 by Stuart McGoldrick and Stephen Costello."
+    ],
+    "quick_facts": [
+      {
+        "icon": "MapPin",
+        "label": "HQ",
+        "value": "Ireland"
+      },
+      {
+        "icon": "Briefcase",
+        "label": "Sector",
+        "value": "Insurtech"
+      },
+      {
+        "icon": "Globe",
+        "label": "Target Market",
+        "value": "Australia & New Zealand"
+      }
+    ],
+    "founders": [
+      {
+        "name": "Stuart McGoldrick",
+        "title": "Co-founder",
+        "is_primary": true
+      },
+      {
+        "name": "Stephen Costello",
+        "title": "Co-founder",
+        "is_primary": false
+      }
+    ],
+    "sections": [
+      {
+        "title": "Entry Strategy",
+        "slug": "entry-strategy",
+        "bodies": [
+          "<p>Spectrum.Life was founded in Dublin in 2018 by Stuart McGoldrick and Stephen Costello. It operates a digital-first mental health and wellbeing platform serving employers, insurers and universities. The platform covers proactive wellbeing tools, digital therapy, EAP, and clinical triage through a single access point — making it well positioned to replace the fragmented point-solutions most employers and insurers were managing.</p>",
+          "<p>By 2024, the company served more than 4,000 corporate clients and 7.5 million insurance members. It raised a €17 million Series B round in May 2024 from Act Venture Capital and existing investors to fund international expansion — naming Australia as a target. In October 2024, it crossed 300 staff globally, and publicly targeted 500 by end of 2025 and revenue of €100 million by 2028.</p>",
+          "<p>Australia presented a near-perfect storm of demand drivers. Mental health-related workers' compensation claims had risen 37 percent since 2017–18. Life insurance TPD claims for mental health among people in their 30s had risen by 732 percent over a decade. Employers were under pressure from new psychosocial safety obligations introduced in Australian WHS laws. And the EAP provider market remained fragmented, largely phone-based, and resistant to digital change.</p>",
+          "<p>Spectrum.Life had already demonstrated in Ireland and the UK that a digitally-led, outcomes-focused model could win enterprise clients quickly. Australia replicated those macro conditions — regulatory tailwind, insurer pressure, employer demand — and offered a large enough addressable market to justify major investment.</p>",
+          "<p>On 17 March 2026, Spectrum.Life announced the simultaneous acquisition of three Australian businesses: MindFit at Work (Melbourne), We Lysn (Sydney) and Valion Health (Sydney). The company was explicit that it chose not to enter organically — it wanted immediate clinical depth, local regulatory familiarity and customer relationships that only established local operators could provide.</p>",
+          "<ul><li><strong>MindFit at Work</strong> — Melbourne <em>(Evidence-based workplace mental health and psychosocial risk programmes; APAC coverage including Singapore)</em></li><li><strong>We Lysn</strong> — Sydney <em>(Digital mental health, EAP, telehealth counselling (same/next-day access))</em></li><li><strong>Valion Health</strong> — Sydney <em>(ACHS-accredited specialist virtual care (cancer, metabolic, chronic conditions))</em></li></ul>",
+          "<p>The three businesses were highly complementary. Together they gave Spectrum.Life an employer-facing prevention product, a frontline digital counselling service, and a specialist insurer pathway — covering the full spectrum from early intervention to complex case management.</p>"
+        ]
+      },
+      {
+        "title": "Success Factors",
+        "slug": "success-factors",
+        "bodies": [
+          "<p><em>&ldquo;We chose to make a long-term strategic commitment to Australia. One platform. One clinical pathway. 24/7 clinical access. Measurable outcomes.&rdquo; <span style=\"color: var(--muted);\">— Stephen Costello, CEO, Spectrum.Life (March 2026)</span></em></p>"
+        ]
+      },
+      {
+        "title": "Key Metrics & Performance",
+        "slug": "key-metrics",
+        "bodies": [
+          "<ul><li><strong>Australian employees at launch</strong> — 35 <em>(Healthcare & Protection, March 2026)</em></li><li><strong>New AU roles planned (12 months)</strong> — 100+ <em>(CFO Tech / Spectrum.Life press release)</em></li><li><strong>Global members at entry</strong> — 15 million+ <em>(Spectrum.Life funding announcement 2024)</em></li><li><strong>Global corporate clients</strong> — 4,000+ corporate / 7.5M insurance members <em>(InsurTech Insights interview, Nov 2024)</em></li><li><strong>Deloitte Fast 50 Ireland 2024 rank</strong> — 41st <em>(WireNews, November 2024)</em></li><li><strong>Revenue target</strong> — €100M by 2028 <em>(Business & Finance Q&A, June 2025)</em></li></ul>"
+        ]
+      },
+      {
+        "title": "Lessons Learned",
+        "slug": "lessons-learned",
+        "bodies": [
+          "<p>For Irish operators considering ANZ entry, Spectrum.Life's playbook offers a clear template. The lessons below distil Spectrum.Life's entry decisions, partner choices, and milestones in Australia &amp; New Zealand.</p>",
+          "<ul><li><strong>Use one expansion market to validate the next</strong> — Built UK scale and proof points before targeting Australia. UK became the case study that made the Australia investment case. <em>(Sequence markets deliberately. Your second market is easier to enter if your first market has already proved the model works internationally.)</em></li><li><strong>Bundle complementary acquisitions</strong> — Bought three firms covering different parts of the care pathway simultaneously — employer prevention, frontline access, specialist care. <em>(When a category is fragmented, acquire breadth rather than build each component. Speed and coverage compound faster than organic build.)</em></li><li><strong>Use market data to justify the entry</strong> — Cited the 37% rise in AU mental health claims to underpin the commercial rationale in media and to prospects. <em>(Lead with the market problem, not the company. Local data makes your entry story immediately relevant to customers, partners and press.)</em></li><li><strong>Announce jobs alongside acquisitions</strong> — Committed to 100+ new roles within 12 months at the time of the acquisition announcement. <em>(Hiring commitments signal permanence to customers, regulators and local government. They also generate media coverage beyond the deal itself.)</em></li><li><strong>Lead with outcomes language</strong> — Positioned the combined platform around measurable outcomes and 24/7 clinical access — not features. <em>(In health and insurance, procurement teams respond to outcome architecture and accountability language, not feature lists.)</em></li></ul>"
+        ]
+      }
+    ],
+    "sources": [
+      {
+        "citation_number": 1,
+        "url": "https://healthcareandprotection.com/spectrum-life-expands-into-australia-through-mindfit-we-lysn-and-valion-acquisitions/",
+        "label": "Healthcare & Protection — triple acquisition announcement",
+        "source_type": "news"
+      },
+      {
+        "citation_number": 2,
+        "url": "https://www.spectrum.life/resources/press-releases/spectrum-life-expands-into-australia-with-long-term-strategic-commitment/",
+        "label": "Spectrum.Life official press release",
+        "source_type": "company_blog"
+      },
+      {
+        "citation_number": 3,
+        "url": "https://cfotech.com.au/story/spectrum-life-buys-three-aussie-digital-health-firms",
+        "label": "CFO Tech Australia — triple acquisition coverage",
+        "source_type": "news"
+      },
+      {
+        "citation_number": 4,
+        "url": "https://melbourne-insider.au/spectrum-life-australia-expansion/",
+        "label": "Melbourne Insider — Australia expansion story",
+        "source_type": "news"
+      },
+      {
+        "citation_number": 5,
+        "url": "https://www.siliconrepublic.com/start-ups/spectrum-life-funding-digital-health-ireland-uk",
+        "label": "Silicon Republic — Series B funding announcement",
+        "source_type": "news"
+      },
+      {
+        "citation_number": 6,
+        "url": "https://www.spectrum.life/resources/spectrum-life-funding-announcement-may-2024/",
+        "label": "Spectrum.Life €17M funding announcement (official)",
+        "source_type": "company_blog"
+      },
+      {
+        "citation_number": 7,
+        "url": "https://www.einpresswire.com/article/714935154/spectrum-life-closes-17m-investment-round-to-accelerate-international-growth",
+        "label": "EIN Presswire — €17M round details and international growth plans",
+        "source_type": "news"
+      },
+      {
+        "citation_number": 8,
+        "url": "https://www.insurtechinsights.com/startup-story-spectrum-life-ceo-and-co-founder-stephen-costello-talks-technology-and-wellbeing/",
+        "label": "InsurTech Insights — CEO Stephen Costello interview",
+        "source_type": "news"
+      },
+      {
+        "citation_number": 9,
+        "url": "https://techbuzzireland.com/2024/10/09/spectrum-life-surpasses-300-employees-and-eyes-growth-to-500-by-end-of-2025/",
+        "label": "TechBuzz Ireland — 300 staff milestone",
+        "source_type": "news"
+      },
+      {
+        "citation_number": 10,
+        "url": "https://www.wirenn.com/post/spectrum-life-ranked-41st-in-the-deloitte-ireland-2024-technology-fast-50-awards",
+        "label": "WireNews — Deloitte Fast 50 Ireland 2024 ranking",
+        "source_type": "news"
+      },
+      {
+        "citation_number": 11,
+        "url": "https://businessandfinance.com/news/my-primary-focus-is-delivering-on-our-mission-to-save-and-change-as-many-lives-as-possible-qanda-with-stephen-costello/",
+        "label": "Business & Finance Q&A — Stephen Costello on mission and €100M target",
+        "source_type": "news"
+      },
+      {
+        "citation_number": 12,
+        "url": "https://aihs.org.au/Web/Web/Advocacy-Media/All-News/2024/03-March/Mental-health-conditions-jump-37-per-cent-in-workers-compensation-claims.aspx",
+        "label": "AIHS.org.au — 37% mental health claims rise in Australian workers' compensation",
+        "source_type": "news"
+      },
+      {
+        "citation_number": 13,
+        "url": "https://valionhealth.com.au/about-valion/",
+        "label": "Valion Health — about page (founded by Michael Marthick)",
+        "source_type": "company_blog"
+      },
+      {
+        "citation_number": 14,
+        "url": "https://www.sbs.com.au/news/small-business-secrets/article/how-start-up-lysn-is-removing-the-stigma-surrounding-seeking-mental-health-support/0x1cd1dtu",
+        "label": "SBS News — We Lysn founding story",
+        "source_type": "news"
+      }
+    ],
+    "mes_tags": [
+      "Digital health",
+      "Mental health",
+      "EAP",
+      "Insurtech",
+      "Acquisition-led entry",
+      "Australia",
+      "Triple acquisition",
+      "B2B",
+      "Ireland → ANZ",
+      "Series B",
+      "Employer wellbeing"
+    ],
+    "read_time": 4,
+    "status": "published",
+    "source_title": "Spectrum.Life: entering Australia through a triple acquisition rather than an organic launch",
+    "case_num": "Case Study 02 · Digital Mental Health"
+  },
+  {
+    "slug": "t-pro-anz-market-entry",
+    "legacy_slug": "tpro-apac",
+    "title": "How T-Pro Entered the ANZ Market",
+    "subtitle": "How a Dublin-founded healthcare speech and documentation company expanded across Australia and New Zealand through three targeted acquisitions — buying local customer relationships and clinical workflow knowledge faster than any organic sales team could build them.",
+    "category": "Technology Market Entry",
+    "company_name": "T-Pro",
+    "origin_country": "Ireland",
+    "target_market": "Australia & New Zealand",
+    "industry": "Healthcare AI",
+    "company_founded": null,
+    "entry_year": null,
+    "tagline": "How a Dublin-founded healthcare speech and documentation company expanded across Australia and New Zealand through three targeted acquisitions — buying local customer relationships and clinical workflow knowledge faster than any organic sales team could build them.",
+    "tldr": [
+      "How a Dublin-founded healthcare speech and documentation company expanded across Australia and New Zealand through three targeted acquisitions — buying local customer relationships and clinical workflow knowledge faster than any organic sales team could build them.",
+      "T-Pro is an Irish healthcare technology company specialising in speech recognition, clinical documentation and AI-enabled workflow tools for healthcare providers."
+    ],
+    "quick_facts": [
+      {
+        "icon": "MapPin",
+        "label": "HQ",
+        "value": "Ireland"
+      },
+      {
+        "icon": "Briefcase",
+        "label": "Sector",
+        "value": "Healthcare AI"
+      },
+      {
+        "icon": "Globe",
+        "label": "Target Market",
+        "value": "Australia & New Zealand"
+      }
+    ],
+    "founders": [],
+    "sections": [
+      {
+        "title": "Entry Strategy",
+        "slug": "entry-strategy",
+        "bodies": [
+          "<p>T-Pro is an Irish healthcare technology company specialising in speech recognition, clinical documentation and AI-enabled workflow tools for healthcare providers. Its technology reduces the administrative burden on clinicians by automating documentation tasks from dictation to structured clinical notes.</p>",
+          "<p>T-Pro's ANZ expansion strategy was acquisition-led from the outset. Rather than entering with its own sales team or a channel partner, it identified established local documentation and transcription businesses that already had deep relationships with hospitals, clinics and healthcare networks — then acquired them and layered its AI documentation platform over the existing operations.</p>",
+          "<ul><li><strong>2022</strong> — SyberScribe <em>(Melbourne, Australia)</em></li><li><strong>2022</strong> — Livingbridge investment <em>(UK PE backing)</em></li><li><strong>2023</strong> — NTS Transcriptions <em>(Australia)</em></li><li><strong>2025</strong> — Sound Business Systems (SBS) <em>(New Zealand + Australia)</em></li></ul>"
+        ]
+      },
+      {
+        "title": "Success Factors",
+        "slug": "success-factors",
+        "bodies": [
+          "<p>Healthcare documentation sits at the intersection of clinician behaviour, data compliance and hospital IT infrastructure. Local relationships matter enormously because switching documentation tools requires clinical workflow change management — something hospitals only do when they trust the vendor deeply. T-Pro's acquisition strategy meant it inherited trusted local operators rather than asking customers to take a risk on a remote Irish startup.</p>",
+          "<p>By acquiring three ANZ businesses rather than one, T-Pro built a narrative of regional commitment and demonstrated to healthcare networks that it was building a long-term APAC presence rather than testing the market opportunistically.</p>",
+          "<p><em>T-Pro's ANZ story shows that in specialist enterprise categories, acquisitions function simultaneously as distribution, localisation and trust-building — compressing years of relationship development into a single transaction.</em></p>"
+        ]
+      },
+      {
+        "title": "Key Metrics & Performance",
+        "slug": "key-metrics",
+        "bodies": [
+          "<ul><li><strong>Founded</strong>: Ireland</li><li><strong>Entry mode</strong>: Serial acquisition</li><li><strong>Acquisition 1</strong>: SyberScribe, Melbourne (2022)</li><li><strong>Acquisition 2</strong>: NTS Transcriptions, AU (2023)</li><li><strong>Acquisition 3</strong>: Sound Business Systems, NZ/AU (2025)</li><li><strong>PE backing</strong>: Livingbridge (2022)</li></ul>"
+        ]
+      },
+      {
+        "title": "Lessons Learned",
+        "slug": "lessons-learned",
+        "bodies": [
+          "<p>For Irish operators considering ANZ entry, T-Pro's playbook offers a clear template. The lessons below distil T-Pro's entry decisions, partner choices, and milestones in Australia &amp; New Zealand.</p>",
+          "<ul><li><strong>Let acquisitions replace the sales team</strong> — Each acquired business brought its own hospital and clinic relationships. <em>(In enterprise healthcare, distribution IS the product. Buying an established operator often beats hiring a country manager and starting from zero.)</em></li><li><strong>Layer technology over trusted operations</strong> — T-Pro applied its AI documentation platform over acquired businesses rather than replacing them. <em>(Don't replace what works locally. Add your IP on top of existing customer trust.)</em></li><li><strong>Build a serial acquisition narrative</strong> — Three acquisitions created a regional expansion story that one deal could not. <em>(Announcing a second and third acquisition compounds the credibility signal from the first. You stop looking like an experiment and start looking like a regional player.)</em></li></ul>"
+        ]
+      }
+    ],
+    "sources": [
+      {
+        "citation_number": 1,
+        "url": "https://www.siliconrepublic.com/business/t-pro-syberscribe-acquisition-australia-speech-transcription-technology",
+        "label": "Silicon Republic — T-Pro acquires SyberScribe (2022)",
+        "source_type": "news"
+      },
+      {
+        "citation_number": 2,
+        "url": "https://www.thinkbusiness.ie/articles/tpro-voice-ai-speech-technology/",
+        "label": "ThinkBusiness — T-Pro voice AI and NTS (2024 profile)",
+        "source_type": "news"
+      },
+      {
+        "citation_number": 3,
+        "url": "https://blog.tpro.io/sbs-part-of-tpro",
+        "label": "T-Pro blog — Sound Business Systems joins the group",
+        "source_type": "company_blog"
+      },
+      {
+        "citation_number": 4,
+        "url": "https://www.livingbridge.com/livingroom/t-pro-acquires-sound-business-systems-expanding-global-healthcare-ai-reach",
+        "label": "Livingbridge — T-Pro acquires SBS (PE announcement)",
+        "source_type": "company_blog"
+      },
+      {
+        "citation_number": 5,
+        "url": "https://soundbusiness.co.nz",
+        "label": "Sound Business Systems — corporate site",
+        "source_type": "company_blog"
+      }
+    ],
+    "mes_tags": [
+      "Healthcare AI",
+      "Clinical documentation",
+      "Speech recognition",
+      "Serial acquisition",
+      "Australia",
+      "New Zealand",
+      "B2B",
+      "Ireland → APAC",
+      "PE-backed"
+    ],
+    "read_time": 2,
+    "status": "published",
+    "source_title": "T-Pro: serial acquisitions to build an APAC healthcare documentation AI footprint",
+    "case_num": "Case Study 03 · Healthcare AI"
+  },
+  {
+    "slug": "fexco-anz-market-entry",
+    "legacy_slug": "fexco-pacific-australia",
+    "title": "How Fexco Entered the ANZ Market",
+    "subtitle": "How a Kerry-founded payments and FX group used New Zealand as its Pacific base for over a decade, built a 400-person regional operation, and then used that platform to launch into Australian retail with hard numbers behind the expansion story.",
+    "category": "Fintech Success",
+    "company_name": "Fexco",
+    "origin_country": "Ireland",
+    "target_market": "Australia & New Zealand",
+    "industry": "Fintech",
+    "company_founded": "1981",
+    "entry_year": "2009",
+    "tagline": "How a Kerry-founded payments and FX group used New Zealand as its Pacific base for over a decade, built a 400-person regional operation, and then used that platform to launch into Australian retail with hard numbers behind the expansion story.",
+    "tldr": [
+      "How a Kerry-founded payments and FX group used New Zealand as its Pacific base for over a decade, built a 400-person regional operation, and then used that platform to launch into Australian retail with hard numbers behind the expansion story.",
+      "Fexco is one of Ireland's largest private companies, founded in 1981 in Killorglin, County Kerry by Brian McCarthy."
+    ],
+    "quick_facts": [
+      {
+        "icon": "MapPin",
+        "label": "HQ",
+        "value": "Ireland"
+      },
+      {
+        "icon": "Briefcase",
+        "label": "Sector",
+        "value": "Fintech"
+      },
+      {
+        "icon": "Globe",
+        "label": "Target Market",
+        "value": "Australia & New Zealand"
+      }
+    ],
+    "founders": [
+      {
+        "name": "Brian McCarthy",
+        "title": "Founder",
+        "is_primary": true
+      }
+    ],
+    "sections": [
+      {
+        "title": "Entry Strategy",
+        "slug": "entry-strategy",
+        "bodies": [
+          "<p>Fexco is one of Ireland's largest private companies, founded in 1981 in Killorglin, County Kerry by Brian McCarthy. It operates across payments, foreign exchange, financial services and business outsourcing. In the Pacific, its brand is anchored around currency exchange and remittance services under the No1 Currency banner, operating as a major Western Union master agent across the region.</p>",
+          "<p>Fexco's ANZ story begins in New Zealand. In 2009 it acquired Federal Pacific in Auckland, which it later renamed Fexco Pacific. From that base it expanded across New Zealand and Pacific island markets — building a network of 24 stores in New Zealand, over 100 offices and outlets across the Pacific, and a team of more than 400 staff. With more than two million transactions per year, Fexco Pacific became a significant financial services operation in its own right.</p>",
+          "<p>In September 2024, Fexco took the next logical step and opened two No1 Currency stores in Sydney — at Westfield Hurstville and Westfield Liverpool. The company explicitly framed this as the start of a broader Australian rollout, with plans for more than 20 outlets and 80-plus local jobs.</p>"
+        ]
+      },
+      {
+        "title": "Success Factors",
+        "slug": "success-factors",
+        "bodies": [
+          "<p>Most market-entry advice assumes Australia is the primary target and New Zealand is an afterthought. Fexco inverts this entirely. It built 15 years of Pacific operating experience before entering Australian retail — and when it did, it arrived with proven unit economics, brand recognition among Pacific diaspora communities, and a credible expansion narrative backed by real numbers.</p>",
+          "<p>Fexco also had an indirect Australian connection through its co-ownership of PICA Group, one of Australia's largest strata property services companies. This gave the Fexco leadership team long-running familiarity with the Australian operating and regulatory environment before the currency retail rollout.</p>",
+          "<p><em>New Zealand doesn't have to be a test market or a secondary afterthought. For the right business, it can be the foundation of a decade-long Pacific operation that makes Australia a more confident expansion, not a speculative one.</em></p>"
+        ]
+      },
+      {
+        "title": "Key Metrics & Performance",
+        "slug": "key-metrics",
+        "bodies": [
+          "<ul><li><strong>Founded</strong>: 1981, Killorglin, Kerry</li><li><strong>NZ entry</strong>: 2009 (Federal Pacific acquisition)</li><li><strong>Pacific staff</strong>: 400+</li><li><strong>NZ stores</strong>: 24</li><li><strong>AU entry</strong>: Sept 2024 (2 Sydney stores)</li><li><strong>AU plan</strong>: 20+ outlets, 80+ jobs</li></ul>"
+        ]
+      },
+      {
+        "title": "Lessons Learned",
+        "slug": "lessons-learned",
+        "bodies": [
+          "<p>For Irish operators considering ANZ entry, Fexco's playbook offers a clear template. The lessons below distil Fexco's entry decisions, partner choices, and milestones in Australia &amp; New Zealand.</p>",
+          "<ul><li><strong>NZ as a genuine operating base</strong> — Built 400+ staff, 24 stores and 2M+ annual transactions before moving into Australia. <em>(NZ is a real market, not a stepping stone. The operating depth you build there is real credibility when you want to expand.)</em></li><li><strong>Pacific network as a moat</strong> — Became the largest Western Union master agent in the Pacific — hard to replicate quickly. <em>(In financial services and adjacent sectors, network infrastructure is a durable moat. Build the network before expanding the brand.)</em></li><li><strong>Lead the Australia announcement with jobs and footprint</strong> — Announced exact store locations, job creation numbers and a multi-year rollout plan. <em>(Specific commitments — named locations, headcount, timelines — earn media and government goodwill. Vague expansion plans do not.)</em></li></ul>"
+        ]
+      }
+    ],
+    "sources": [
+      {
+        "citation_number": 1,
+        "url": "https://www.fexco.com/news-and-insights/fexco-expands-global-presence-with-launch-of-two-new-no1-currency-stores-in-sydney-australia/",
+        "label": "Fexco — Sydney store launch announcement (Oct 2024)",
+        "source_type": "company_blog"
+      },
+      {
+        "citation_number": 2,
+        "url": "https://nz.linkedin.com/company/fexco-pacific-ltd",
+        "label": "Fexco Pacific LinkedIn — network size and description",
+        "source_type": "linkedin"
+      },
+      {
+        "citation_number": 3,
+        "url": "https://www.fexco.com",
+        "label": "Fexco corporate homepage",
+        "source_type": "company_blog"
+      }
+    ],
+    "mes_tags": [
+      "Fintech",
+      "FX / Payments",
+      "New Zealand first",
+      "Pacific expansion",
+      "Australia",
+      "Retail rollout",
+      "Ireland → Pacific",
+      "B2C",
+      "Long-term play"
+    ],
+    "read_time": 3,
+    "status": "published",
+    "source_title": "Fexco: building a Pacific network through New Zealand, then expanding into Australia with proven regional economics",
+    "case_num": "Case Study 04 · Fintech / FX"
+  },
+  {
+    "slug": "learnupon-anz-market-entry",
+    "legacy_slug": "learnupon-apac",
+    "title": "How LearnUpon Entered the ANZ Market",
+    "subtitle": "How a Dublin-founded learning management system company grew to 100+ APAC enterprise customers, 80% headcount growth in two years, and a bigger Sydney HQ — by proving demand first globally and then investing in regional density when the customer base justified it.",
+    "category": "Technology Market Entry",
+    "company_name": "LearnUpon",
+    "origin_country": "Ireland",
+    "target_market": "Australia & New Zealand",
+    "industry": "Edtech",
+    "company_founded": "2012",
+    "entry_year": null,
+    "tagline": "How a Dublin-founded learning management system company grew to 100+ APAC enterprise customers, 80% headcount growth in two years, and a bigger Sydney HQ — by proving demand first globally and then investing in regional density when the customer base justified it.",
+    "tldr": [
+      "How a Dublin-founded learning management system company grew to 100+ APAC enterprise customers, 80% headcount growth in two years, and a bigger Sydney HQ — by proving demand first globally and then investing in regional density when the customer base justified it.",
+      "LearnUpon was founded in June 2012 by Brendan Noud (CEO) and Des Anderson (CTO) in Dublin."
+    ],
+    "quick_facts": [
+      {
+        "icon": "MapPin",
+        "label": "HQ",
+        "value": "Ireland"
+      },
+      {
+        "icon": "Briefcase",
+        "label": "Sector",
+        "value": "Edtech"
+      },
+      {
+        "icon": "Globe",
+        "label": "Target Market",
+        "value": "Australia & New Zealand"
+      }
+    ],
+    "founders": [
+      {
+        "name": "Brendan Noud",
+        "title": "Co-founder & CEO",
+        "is_primary": true
+      },
+      {
+        "name": "Des Anderson",
+        "title": "Co-founder & CTO",
+        "is_primary": false
+      }
+    ],
+    "sections": [
+      {
+        "title": "Entry Strategy",
+        "slug": "entry-strategy",
+        "bodies": [
+          "<p>LearnUpon was founded in June 2012 by Brendan Noud (CEO) and Des Anderson (CTO) in Dublin. It builds learning management software that companies use to train employees, customers and partners at scale. By 2026 it served more than 1,500 global customers across 40+ countries, with over 20 million active users and 150 million completed courses on the platform.</p>",
+          "<p>In October 2020, LearnUpon raised a $56 million Series A from Summit Partners — one of Ireland's largest edtech funding rounds — which accelerated product investment and international hiring. Australia and the broader APAC region were priorities in that growth plan.</p>",
+          "<p>LearnUpon's Sydney office had been operational for more than six years by early 2026. Rather than a dramatic launch, its ANZ presence was built incrementally — winning enterprise customers, building a local support function and growing the team as APAC revenue justified investment. In June 2024, it appointed Fiona Sweeney as APAC Director, signalling stronger regional leadership commitment.</p>",
+          "<p>In March 2026, LearnUpon announced it was accelerating APAC expansion through a larger Sydney headquarters at JustCo, deeper regional investment and the integration of Courseau — an AI-native course creation platform it had recently acquired. The announcement confirmed 100+ customers in the APAC region and said local headcount had grown 80% over two years.</p>"
+        ]
+      },
+      {
+        "title": "Success Factors",
+        "slug": "success-factors",
+        "bodies": [
+          "<p><em>LearnUpon's APAC story is a counterpoint to acquisition-led entries. Sometimes the right move is not to buy — it's to serve the customers who find you, then invest in local density once the concentration justifies it.</em></p>"
+        ]
+      },
+      {
+        "title": "Key Metrics & Performance",
+        "slug": "key-metrics",
+        "bodies": [
+          "<ul><li><strong>Healthcare Australia</strong> — Healthcare / Staffing <em>(Workforce learning and compliance training)</em></li><li><strong>WorkPac</strong> — Labour hire <em>(Onboarding and skills training at scale)</em></li><li><strong>Jetpilot</strong> — Consumer goods <em>(Product knowledge and dealer training)</em></li><li><strong>Montu</strong> — Pharmaceutical <em>(Regulatory and clinical learning)</em></li><li><strong>Morningstar</strong> — Financial services <em>(Professional development)</em></li><li><strong>ACSO</strong> — Corrections/Justice <em>(Staff training and compliance)</em></li></ul>"
+        ]
+      },
+      {
+        "title": "Lessons Learned",
+        "slug": "lessons-learned",
+        "bodies": [
+          "<p>For Irish operators considering ANZ entry, LearnUpon's playbook offers a clear template. The lessons below distil LearnUpon's entry decisions, partner choices, and milestones in Australia &amp; New Zealand.</p>",
+          "<ul><li><strong>Let customer pull justify local investment</strong> — Grew APAC organically for six-plus years before making a bigger local commitment. <em>(Don't invest in regional office and leadership before the customer demand exists. Let inbound traction tell you when the market is ready for more investment.)</em></li><li><strong>Add AI to accelerate regional relevance</strong> — Used the Courseau acquisition to offer AI course creation as a local differentiator. <em>(An AI acquisition can refresh the expansion story in a region that already knows your product.)</em></li><li><strong>Name the local headcount growth</strong> — Cited 80% headcount growth in two years as a proof point in expansion announcement. <em>(Percentage headcount growth is a powerful signal — it shows the region is a real business unit, not a satellite sales office.)</em></li></ul>"
+        ]
+      }
+    ],
+    "sources": [
+      {
+        "citation_number": 1,
+        "url": "https://www.learnupon.com/newsroom/learnupon-accelerates-apac-expansion/",
+        "label": "LearnUpon — APAC expansion announcement (newsroom)",
+        "source_type": "company_blog"
+      },
+      {
+        "citation_number": 2,
+        "url": "https://itbrief.com.au/story/learnupon-boosts-apac-growth-with-ai-course-platform",
+        "label": "IT Brief Australia — APAC growth and Courseau",
+        "source_type": "news"
+      },
+      {
+        "citation_number": 3,
+        "url": "https://newshub.medianet.com.au/2026/03/learnupon-accelerates-apac-expansion-with-new-sydney-headquarters-and-ai-native-courseau/144128/",
+        "label": "Medianet — Sydney HQ and Courseau acquisition",
+        "source_type": "press_release"
+      },
+      {
+        "citation_number": 4,
+        "url": "https://www.miragenews.com/learnupon-expands-apac-with-sydney-hq-ai-1637940/",
+        "label": "Mirage News — APAC Sydney HQ update",
+        "source_type": "news"
+      },
+      {
+        "citation_number": 5,
+        "url": "https://www.businesswire.com/news/home/20260129847362/en/LearnUpon-Ends-2025-With-Breakthrough-Growth-Product-Innovation-and-Global-Recognition",
+        "label": "BusinessWire — 2025 year-end performance and global recognition",
+        "source_type": "press_release"
+      }
+    ],
+    "mes_tags": [
+      "Edtech",
+      "LMS / Learning",
+      "SaaS",
+      "Australia",
+      "Sydney",
+      "Enterprise B2B",
+      "Ireland → APAC",
+      "Organic scaling",
+      "AI-enhanced product"
+    ],
+    "read_time": 2,
+    "status": "published",
+    "source_title": "LearnUpon: deepening a Sydney-led APAC operation after building global LMS scale from Dublin",
+    "case_num": "Case Study 05 · Edtech / SaaS"
+  },
+  {
+    "slug": "kyckr-anz-market-entry",
+    "legacy_slug": "kyckr-asx",
+    "title": "How Kyckr Entered the ANZ Market",
+    "subtitle": "How a Waterford-founded company registry intelligence startup used the Australian Securities Exchange not just as a capital-raising tool but as a market-entry strategy — gaining Australian institutional credibility, local investor visibility, and a listed-company governance structure that resonated with its compliance-focused customers.",
+    "category": "Fintech Success",
+    "company_name": "Kyckr",
+    "origin_country": "Ireland",
+    "target_market": "Australia & New Zealand",
+    "industry": "RegTech",
+    "company_founded": "2007",
+    "entry_year": "2016",
+    "tagline": "How a Waterford-founded company registry intelligence startup used the Australian Securities Exchange not just as a capital-raising tool but as a market-entry strategy — gaining Australian institutional credibility, local investor visibility, and a listed-company governance structure that resonated with its compliance-focused customers.",
+    "tldr": [
+      "How a Waterford-founded company registry intelligence startup used the Australian Securities Exchange not just as a capital-raising tool but as a market-entry strategy — gaining Australian institutional credibility, local investor visibility, and a listed-company governance structure that resonated with its compliance-focused customers.",
+      "Kyckr was founded in Waterford in March 2007 by Ben Cronin, Rob Leslie, John Murray and Richard Wood."
+    ],
+    "quick_facts": [
+      {
+        "icon": "MapPin",
+        "label": "HQ",
+        "value": "Ireland"
+      },
+      {
+        "icon": "Briefcase",
+        "label": "Sector",
+        "value": "RegTech"
+      },
+      {
+        "icon": "Globe",
+        "label": "Target Market",
+        "value": "Australia & New Zealand"
+      }
+    ],
+    "founders": [
+      {
+        "name": "Ben Cronin",
+        "title": "Co-founder",
+        "is_primary": true
+      },
+      {
+        "name": "Rob Leslie",
+        "title": "Co-founder",
+        "is_primary": false
+      },
+      {
+        "name": "John Murray",
+        "title": "Co-founder",
+        "is_primary": false
+      },
+      {
+        "name": "Richard Wood",
+        "title": "Co-founder",
+        "is_primary": false
+      }
+    ],
+    "sections": [
+      {
+        "title": "Entry Strategy",
+        "slug": "entry-strategy",
+        "bodies": [
+          "<p>Kyckr was founded in Waterford in March 2007 by Ben Cronin, Rob Leslie, John Murray and Richard Wood. The company built a real-time registry intelligence platform that gave compliance teams at banks, financial institutions and corporates direct access to official company registry data across 300+ jurisdictions — removing the need to manually check registries or rely on outdated static databases.</p>",
+          "<p>Its core product addressed a genuine compliance burden: banks performing KYC, AML and onboarding checks needed accurate, current company ownership and incorporation data at speed. Kyckr automated this by connecting directly to primary regulatory sources.</p>",
+          "<p>In September 2016, Kyckr listed on the Australian Securities Exchange under the ticker KYK, raising A$5 million with a fully diluted market capitalisation of approximately A$26 million. Enterprise Ireland had backed the company with a €250,000 investment ahead of the listing.</p>",
+          "<p>This was not a conventional market-entry play. Kyckr was not simply raising capital on a convenient exchange. It was choosing to make Australia its listed domicile — which gave it Australian institutional shareholder support, regular ASX reporting obligations, and a profile in the Australian financial services sector precisely where its target customers operated. For a compliance-focused product, being a listed entity with transparent public reporting was itself a trust signal.</p>"
+        ]
+      },
+      {
+        "title": "Success Factors",
+        "slug": "success-factors",
+        "bodies": [
+          "<p><em>A public listing is not just a capital event. For a compliance-first product, it can be a trust signal, a market-entry mechanism and a talent-attraction tool — all at the same time.</em></p>"
+        ]
+      },
+      {
+        "title": "Key Metrics & Performance",
+        "slug": "key-metrics",
+        "bodies": [
+          "<p>After listing, Kyckr grew its product to cover more than 120 million businesses from 300-plus primary regulatory sources across more than 100 countries. In FY2017 it reported $1.54 million in revenue, up 34%. By FY2019 revenue had reached $2.14 million, representing growth of more than 25%. Clients included Citi Commercial Bank and Commerzbank.</p>",
+          "<p>In November 2022, Richard White — the founder of WiseTech Global, one of Australia's most successful technology companies — completed the acquisition of the remaining 77.24% stake in Kyckr he did not already own and delisted the company. The acquisition validated Kyckr's technology and validated the ANZ market-entry approach by attracting strategic attention from one of Australia's most respected technology founders.</p>"
+        ]
+      },
+      {
+        "title": "Lessons Learned",
+        "slug": "lessons-learned",
+        "bodies": [
+          "<p>For Irish operators considering ANZ entry, Kyckr's playbook offers a clear template. The lessons below distil Kyckr's entry decisions, partner choices, and milestones in Australia &amp; New Zealand.</p>",
+          "<ul><li><strong>Use capital markets as an entry mechanism</strong> — Listed on ASX to gain Australian institutional credibility alongside capital. <em>(In regulated B2B sectors, a public listing can be more effective than a sales office. It makes trust transparent and permanent.)</em></li><li><strong>Match the entry mechanism to the product's trust requirements</strong> — A compliance product for banks needed to demonstrate governance. A listed company structure did exactly that. <em>(Think about what signal your customers need most and choose an entry mechanism that delivers it.)</em></li><li><strong>Build toward strategic acquirers</strong> — Kyckr's data infrastructure attracted WiseTech founder Richard White as a personal acquirer. <em>(If your product is genuinely valuable infrastructure, ANZ exits to global tech leaders are achievable.)</em></li></ul>"
+        ]
+      }
+    ],
+    "sources": [
+      {
+        "citation_number": 1,
+        "url": "https://fora.ie/kyckr-waterford-ipo-2968390-Sep2016/",
+        "label": "Fora.ie — Kyckr ASX IPO announcement (Sept 2016)",
+        "source_type": "news"
+      },
+      {
+        "citation_number": 2,
+        "url": "https://in.marketscreener.com/quote/stock/KYCKR-LIMITED-27546659/news/Richard-White-completed-the-acquisition-of-the-remaining-77.24-stake-in-Kyckr-Limited-42171348/",
+        "label": "MarketScreener — Richard White acquires remaining Kyckr stake (Nov 2022)",
+        "source_type": "news"
+      },
+      {
+        "citation_number": 3,
+        "url": "https://addisons.com/announcement/addisons-advises-kyckr-asx-kyk-on-its-acquisition-by-realwise/",
+        "label": "Addisons — Kyckr ASX KYK acquisition by RealWise (legal announcement)",
+        "source_type": "news"
+      },
+      {
+        "citation_number": 4,
+        "url": "https://en.wikipedia.org/wiki/Kyckr",
+        "label": "Wikipedia — Kyckr company article",
+        "source_type": "other"
+      },
+      {
+        "citation_number": 5,
+        "url": "https://finovate.com/category/kyckr/",
+        "label": "Finovate — Kyckr archive (product and financial service context)",
+        "source_type": "news"
+      }
+    ],
+    "mes_tags": [
+      "Fintech",
+      "Regtech",
+      "KYC / AML",
+      "ASX listing",
+      "Capital markets entry",
+      "Australia",
+      "Ireland → ANZ",
+      "B2B Enterprise",
+      "Exit to acquisition",
+      "Compliance"
+    ],
+    "read_time": 2,
+    "status": "published",
+    "source_title": "Kyckr: using an ASX listing as the market-entry mechanism for an Irish regtech",
+    "case_num": "Case Study 06 · Fintech / Regtech"
+  }
+]


### PR DESCRIPTION
## Summary
- Adds 6 net-new Irish ANZ case studies (Clanwilliam, Spectrum.Life, T-Pro, Fexco, LearnUpon, Kyckr) — all imported with `status='published'` and standardised 4-section MES shape.
- Normalises source slugs to `<company>-anz-market-entry` for consistency with the existing 45 case studies.
- DB delta: +6 `content_items`, +6 `content_company_profiles`, +10 `content_founders`, +24 `content_sections`, +55 `content_bodies`, +38 `case_study_sources`.

## How
- Persisted the signed-CloudFront source HTML verbatim to `data/case-studies/irish_tier1_anz_research.html` (so URL expiry doesn't break reproducibility).
- New BeautifulSoup parser (`scripts/parse_irish_tier1.py`) handles callouts (named cite vs generic editorial), strips inline `<strong>` from cells before wrapping (no nested tags), domain-based source_type detection, and synthesizes a Key Metrics section from the meta-strip when the source omits a "Key outcomes" table (T-Pro, Fexco) — so every case has a uniform 4-section shape.
- Idempotent SQL generator emits one DO block per case using `INSERT … ON CONFLICT (slug) DO UPDATE` + skip-if-exists guards + `ON CONFLICT (case_study_id, url) DO NOTHING`. Re-running any block is a no-op.

## Files added
- `data/case-studies/irish_tier1_anz_research.html` — verbatim source (75KB, 6 case studies, ~42 citations)
- `scripts/parse_irish_tier1.py`, `scripts/parsed_irish_tier1.json`, `scripts/generate_irish_tier1_sql.py`
- `scripts/irish_tier1_import.sql` + per-case blocks in `scripts/irish_tier1_import_blocks/`
- `reports/irish-tier1-import-summary-2026-05-08.md`

## Test plan
- [x] All 6 cases `status='published'` and `content_type='case_study'` (6/6)
- [x] Section sort_order contiguous (1..N) within each case (no gaps)
- [x] Body sort_order contiguous within each section (no gaps)
- [x] Zero duplicate `(section_id, sort_order)` pairs
- [x] HTML tag balance (`<p>`, `<ul>`, `<li>`, `<strong>`, `<em>`) — all balanced across all bodies
- [x] Frontend `useCaseStudy` compatibility — all `category_id` joins resolve, all `source_type` values within enum, all sections `is_active=true`
- [x] Idempotency — re-ran Clanwilliam, all counts unchanged
- [x] Pre-existing 45 case studies untouched (total `*-anz-market-entry` count now 31; full `case_study` count now 51)

https://claude.ai/code/session_019XostAF5uUGrgbR4nwtHft

---
_Generated by [Claude Code](https://claude.ai/code/session_019XostAF5uUGrgbR4nwtHft)_