### PR TITLE
Backfill T-Pro founders and verify Spectrum.Life + Fexco

### DIFF
--- a/scripts/irish_tier1_import.sql
+++ b/scripts/irish_tier1_import.sql
@@ -433,8 +433,15 @@ BEGIN
       entry_date, industry, founder_count, employee_count, is_profitable
     ) VALUES (
       v_id, 'T-Pro', 'Ireland', 'Australia & New Zealand',
-      NULL, 'Healthcare AI', NULL, NULL, NULL
+      NULL, 'Healthcare AI', 2, NULL, NULL
     );
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM content_founders WHERE content_id = v_id) THEN
+    INSERT INTO content_founders (content_id, name, title, is_primary)
+    VALUES (v_id, 'Jonathan Larbey', 'Founder & CEO', true);
+    INSERT INTO content_founders (content_id, name, title, is_primary)
+    VALUES (v_id, 'Mark Gilmartin', 'Co-founder & COO', false);
   END IF;
 
   -- Section: entry-strategy

--- a/scripts/irish_tier1_import_blocks/03-t-pro-anz-market-entry.sql
+++ b/scripts/irish_tier1_import_blocks/03-t-pro-anz-market-entry.sql
@@ -32,8 +32,15 @@ BEGIN
       entry_date, industry, founder_count, employee_count, is_profitable
     ) VALUES (
       v_id, 'T-Pro', 'Ireland', 'Australia & New Zealand',
-      NULL, 'Healthcare AI', NULL, NULL, NULL
+      NULL, 'Healthcare AI', 2, NULL, NULL
     );
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM content_founders WHERE content_id = v_id) THEN
+    INSERT INTO content_founders (content_id, name, title, is_primary)
+    VALUES (v_id, 'Jonathan Larbey', 'Founder & CEO', true);
+    INSERT INTO content_founders (content_id, name, title, is_primary)
+    VALUES (v_id, 'Mark Gilmartin', 'Co-founder & COO', false);
   END IF;
 
   -- Section: entry-strategy

--- a/scripts/parse_irish_tier1.py
+++ b/scripts/parse_irish_tier1.py
@@ -83,7 +83,10 @@ FOUNDERS_BY_SLUG: dict[str, list[dict[str, Any]]] = {
         {"name": "Stuart McGoldrick", "title": "Co-founder", "is_primary": True},
         {"name": "Stephen Costello", "title": "Co-founder", "is_primary": False},
     ],
-    "t-pro-anz-market-entry": [],
+    "t-pro-anz-market-entry": [
+        {"name": "Jonathan Larbey", "title": "Founder & CEO", "is_primary": True},
+        {"name": "Mark Gilmartin", "title": "Co-founder & COO", "is_primary": False},
+    ],
     "fexco-anz-market-entry": [
         {"name": "Brian McCarthy", "title": "Founder", "is_primary": True},
     ],

--- a/scripts/parsed_irish_tier1.json
+++ b/scripts/parsed_irish_tier1.json
@@ -351,7 +351,18 @@
         "value": "Australia & New Zealand"
       }
     ],
-    "founders": [],
+    "founders": [
+      {
+        "name": "Jonathan Larbey",
+        "title": "Founder & CEO",
+        "is_primary": true
+      },
+      {
+        "name": "Mark Gilmartin",
+        "title": "Co-founder & COO",
+        "is_primary": false
+      }
+    ],
     "sections": [
       {
         "title": "Entry Strategy",


### PR DESCRIPTION
## Summary
Two follow-ups to the Irish Tier 1 case-study import (#185):

1. **T-Pro founder backfill** — Adds Jonathan Larbey (Founder & CEO) and Mark Gilmartin (Co-founder & COO). T-Pro previously had `founder_count = NULL` because the source narrated the company without naming founders. Confirmed via Crunchbase, ThinkBusiness, and T-Pro's own About page.
2. **Verification stamp** — Marks T-Pro, Spectrum.Life, and Fexco with `last_verified_at = now()` after independently confirming the key facts via web search:
   - **Spectrum.Life:** 18 March 2026 announcement of MindFit at Work + We Lysn + Valion Health acquisitions confirmed (Pulse+IT, Health & Protection, official press release).
   - **Fexco:** Sydney store launch confirmed — Westfield Liverpool opened July 2024, Westfield Hurstville on 7 September 2024 (RTÉ, Inside Retail, Fexco newsroom).

DB delta: +2 `content_founders` rows for T-Pro, `content_company_profiles.founder_count = 2`, three `content_items.last_verified_at` updates.

## How
- Updated `FOUNDERS_BY_SLUG['t-pro-anz-market-entry']` in `scripts/parse_irish_tier1.py` so re-running the pipeline stays reproducible.
- Regenerated `scripts/parsed_irish_tier1.json` and `scripts/irish_tier1_import_blocks/03-t-pro-anz-market-entry.sql`.
- Applied the founder INSERT, founder_count UPDATE, and three `last_verified_at = now()` UPDATEs via Supabase MCP. All operations are idempotent.

## Test plan
- [x] T-Pro `content_founders` count = 2 (Jonathan Larbey, Mark Gilmartin)
- [x] T-Pro `content_company_profiles.founder_count` = 2
- [x] T-Pro / Spectrum.Life / Fexco `content_items.last_verified_at` = 2026-05-08
- [x] Parser map updated; running `scripts/parse_irish_tier1.py` produces the new founder rows for T-Pro
- [x] Pre-existing 50 case studies untouched

https://claude.ai/code/session_019XostAF5uUGrgbR4nwtHft

---
_Generated by [Claude Code](https://claude.ai/code/session_019XostAF5uUGrgbR4nwtHft)_