### PR TITLE
Events directory data-quality overhaul

### DIFF
--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react";
-import { Calendar, MapPin, Users, Clock, CalendarPlus } from "lucide-react";
+import { MapPin, Users, Clock } from "lucide-react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -7,8 +7,13 @@ import { BookmarkButton } from "@/components/BookmarkButton";
 import { AddToCalendarButton } from "@/components/events/AddToCalendarButton";
 import { Event } from "@/hooks/useEvents";
 import { Link } from "react-router-dom";
-import { differenceInDays, isPast, format } from "date-fns";
 import CompanyLogo from "@/components/shared/CompanyLogo";
+import {
+  formatEventDateBadge,
+  isEventPast as computeIsEventPast,
+  daysUntilLabel,
+  canAddToCalendar,
+} from "@/lib/eventDate";
 
 interface EventCardProps {
   event: Event;
@@ -17,11 +22,13 @@ interface EventCardProps {
 }
 
 export const EventCard = memo(({ event, onViewDetails, useModal = false }: EventCardProps) => {
-  const eventDate = new Date(event.date);
-  const isEventPast = isPast(eventDate);
-  const daysUntil = differenceInDays(eventDate, new Date());
-  const monthShort = format(eventDate, "MMM").toUpperCase();
-  const dayNum = format(eventDate, "d");
+  const isEventPast = computeIsEventPast(event);
+  const dateBadge = formatEventDateBadge(event);
+  const daysLabel = daysUntilLabel(event);
+  const showCalendarButton = !isEventPast && canAddToCalendar(event);
+  const isApproximateDate = (event.date_precision ?? "exact") !== "exact";
+  const timeLabel = event.time ?? (isApproximateDate ? "See website for time" : null);
+  const organizerLabel = event.organizer ?? "Organizer TBC";
 
   const handleViewDetails = (e: React.MouseEvent) => {
     if (useModal && onViewDetails) {
@@ -38,8 +45,12 @@ export const EventCard = memo(({ event, onViewDetails, useModal = false }: Event
           <div className="flex items-start gap-3 flex-1 min-w-0">
             {/* Date Badge */}
             <div className="flex-shrink-0 w-14 h-14 rounded-lg bg-primary/10 flex flex-col items-center justify-center text-center">
-              <span className="text-xs font-bold text-primary leading-none">{monthShort}</span>
-              <span className="text-lg font-bold text-primary leading-tight">{dayNum}</span>
+              <span className="text-xs font-bold text-primary leading-none">{dateBadge.top}</span>
+              {dateBadge.bottom ? (
+                <span className="text-lg font-bold text-primary leading-tight">{dateBadge.bottom}</span>
+              ) : (
+                <span className="text-[10px] font-medium text-primary/70 leading-tight mt-0.5">typical</span>
+              )}
             </div>
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-2 mb-2">
@@ -47,9 +58,13 @@ export const EventCard = memo(({ event, onViewDetails, useModal = false }: Event
                   <Badge variant="secondary" className="text-xs bg-muted text-muted-foreground">
                     Past Event
                   </Badge>
-                ) : daysUntil <= 14 ? (
+                ) : daysLabel ? (
                   <Badge className="text-xs bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
-                    {daysUntil === 0 ? "Today" : `In ${daysUntil} days`}
+                    {daysLabel}
+                  </Badge>
+                ) : isApproximateDate ? (
+                  <Badge variant="outline" className="text-xs">
+                    Date TBC
                   </Badge>
                 ) : null}
               </div>
@@ -92,10 +107,12 @@ export const EventCard = memo(({ event, onViewDetails, useModal = false }: Event
         </div>
         
         <div className="space-y-2 mb-4">
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <Clock className="w-4 h-4 flex-shrink-0" />
-            <span>{event.time}</span>
-          </div>
+          {timeLabel ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Clock className="w-4 h-4 flex-shrink-0" />
+              <span>{timeLabel}</span>
+            </div>
+          ) : null}
           <div className="flex items-center gap-2 text-sm text-muted-foreground">
             <MapPin className="w-4 h-4 flex-shrink-0" />
             <span className="truncate flex-1">{event.location}</span>
@@ -105,12 +122,12 @@ export const EventCard = memo(({ event, onViewDetails, useModal = false }: Event
               <CompanyLogo
                 websiteUrl={event.organizer_website || event.website_url}
                 existingLogoUrl={event.event_logo_url}
-                companyName={event.organizer}
+                companyName={organizerLabel}
                 size="sm"
                 className="rounded-full"
                 fallbackClassName="bg-primary/10 text-primary rounded-full"
               />
-              <span className="text-sm text-muted-foreground truncate">{event.organizer}</span>
+              <span className="text-sm text-muted-foreground truncate">{organizerLabel}</span>
             </div>
             <div className="flex items-center gap-1 text-sm text-muted-foreground flex-shrink-0">
               <Users className="w-4 h-4" />
@@ -130,12 +147,12 @@ export const EventCard = memo(({ event, onViewDetails, useModal = false }: Event
               <Link to={`/events/${event.slug}`}>View Details</Link>
             </Button>
           )}
-          {!isEventPast && (
+          {showCalendarButton && (
             <AddToCalendarButton
               title={event.title}
               description={event.description}
               date={event.date}
-              time={event.time}
+              time={event.time ?? ""}
               location={event.location}
               size="sm"
             />

--- a/src/components/EventModal.tsx
+++ b/src/components/EventModal.tsx
@@ -2,8 +2,9 @@
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Calendar, MapPin, Users, Clock, User, Mail, Globe } from "lucide-react";
+import { Calendar, MapPin, Users, Clock, User, Mail } from "lucide-react";
 import { Event } from "@/hooks/useEvents";
+import { formatEventDateLong } from "@/lib/eventDate";
 
 interface EventModalProps {
   event: Event | null;
@@ -14,10 +15,14 @@ interface EventModalProps {
 export const EventModal = ({ event, isOpen, onClose }: EventModalProps) => {
   if (!event) return null;
 
+  const isApproximateDate = (event.date_precision ?? "exact") !== "exact";
+  const timeLabel = event.time ?? (isApproximateDate ? "See website for time" : null);
+  const organizerLabel = event.organizer ?? "Organizer TBC";
+  const dateLabel = formatEventDateLong(event);
+
   const handleContactOrganizer = () => {
-    // Create a mailto link or show contact information
     const subject = encodeURIComponent(`Inquiry about ${event.title}`);
-    const body = encodeURIComponent(`Hi,\n\nI'm interested in learning more about the event "${event.title}" scheduled for ${new Date(event.date).toLocaleDateString()} at ${event.time}.\n\nPlease provide more details.\n\nBest regards`);
+    const body = encodeURIComponent(`Hi,\n\nI'm interested in learning more about the event "${event.title}" scheduled for ${dateLabel}${timeLabel ? ` at ${timeLabel}` : ""}.\n\nPlease provide more details.\n\nBest regards`);
     window.open(`mailto:?subject=${subject}&body=${body}`);
   };
 
@@ -34,20 +39,15 @@ export const EventModal = ({ event, isOpen, onClose }: EventModalProps) => {
             <div className="space-y-4">
               <div className="flex items-center gap-3 text-muted-foreground">
                 <Calendar className="w-5 h-5 text-primary" />
-                <span className="font-medium">
-                  {new Date(event.date).toLocaleDateString('en-AU', {
-                    weekday: 'long',
-                    year: 'numeric',
-                    month: 'long',
-                    day: 'numeric'
-                  })}
-                </span>
+                <span className="font-medium">{dateLabel}</span>
               </div>
 
-              <div className="flex items-center gap-3 text-muted-foreground">
-                <Clock className="w-5 h-5 text-primary" />
-                <span className="font-medium">{event.time}</span>
-              </div>
+              {timeLabel ? (
+                <div className="flex items-center gap-3 text-muted-foreground">
+                  <Clock className="w-5 h-5 text-primary" />
+                  <span className="font-medium">{timeLabel}</span>
+                </div>
+              ) : null}
 
               <div className="flex items-center gap-3 text-muted-foreground">
                 <MapPin className="w-5 h-5 text-primary" />
@@ -63,7 +63,7 @@ export const EventModal = ({ event, isOpen, onClose }: EventModalProps) => {
             <div className="space-y-4">
               <div className="flex items-center gap-3 text-muted-foreground">
                 <User className="w-5 h-5 text-primary" />
-                <span className="font-medium">Organized by {event.organizer}</span>
+                <span className="font-medium">Organized by {organizerLabel}</span>
               </div>
 
               <div className="flex gap-2">
@@ -93,7 +93,7 @@ export const EventModal = ({ event, isOpen, onClose }: EventModalProps) => {
                 <User className="w-6 h-6 text-primary" />
               </div>
               <div>
-                <p className="font-medium">{event.organizer}</p>
+                <p className="font-medium">{organizerLabel}</p>
                 <p className="text-sm text-muted-foreground">Event Organizer</p>
               </div>
             </div>

--- a/src/components/events/EventDetailContent.tsx
+++ b/src/components/events/EventDetailContent.tsx
@@ -78,7 +78,7 @@ export const EventDetailContent = ({ event, relatedEvents }: EventDetailContentP
                     <User className="w-6 h-6 text-primary" />
                   </div>
                   <div className="min-w-0">
-                    <p className="font-medium truncate">{event.organizer}</p>
+                    <p className="font-medium truncate">{event.organizer ?? "Organizer TBC"}</p>
                     <p className="text-sm text-muted-foreground">Organizer</p>
                   </div>
                 </div>

--- a/src/components/events/EventDetailHero.tsx
+++ b/src/components/events/EventDetailHero.tsx
@@ -5,17 +5,26 @@ import { BookmarkButton } from "@/components/BookmarkButton";
 import { AddToCalendarButton } from "./AddToCalendarButton";
 import { EventDetail } from "@/hooks/useEventBySlug";
 import { Link } from "react-router-dom";
-import { differenceInDays, isPast, format } from "date-fns";
 import CompanyLogo from "@/components/shared/CompanyLogo";
+import {
+  formatEventDateLong,
+  isEventPast as computeIsEventPast,
+  daysUntilLabel,
+  canAddToCalendar,
+} from "@/lib/eventDate";
 
 interface EventDetailHeroProps {
   event: EventDetail;
 }
 
 export const EventDetailHero = ({ event }: EventDetailHeroProps) => {
-  const eventDate = new Date(event.date);
-  const isEventPast = isPast(eventDate);
-  const daysUntil = differenceInDays(eventDate, new Date());
+  const isEventPast = computeIsEventPast(event);
+  const daysLabel = daysUntilLabel(event);
+  const dateLabel = formatEventDateLong(event);
+  const showCalendarButton = !isEventPast && canAddToCalendar(event);
+  const isApproximateDate = (event.date_precision ?? "exact") !== "exact";
+  const timeLabel = event.time ?? (isApproximateDate ? "See website for time" : null);
+  const organizerLabel = event.organizer ?? "Organizer TBC";
 
   return (
     <section className="bg-gradient-to-br from-primary/5 via-primary/10 to-accent/5 py-12 md:py-16">
@@ -37,7 +46,7 @@ export const EventDetailHero = ({ event }: EventDetailHeroProps) => {
               <CompanyLogo
                 websiteUrl={event.organizer_website || event.website_url}
                 existingLogoUrl={event.event_logo_url}
-                companyName={event.organizer || event.title}
+                companyName={organizerLabel || event.title}
                 size="xl"
                 className="w-20 h-20 rounded-xl border border-border"
                 fallbackClassName="bg-primary/10 text-primary"
@@ -54,10 +63,12 @@ export const EventDetailHero = ({ event }: EventDetailHeroProps) => {
                   <Badge variant="secondary" className="bg-muted text-muted-foreground">
                     Past Event
                   </Badge>
-                ) : daysUntil <= 30 ? (
+                ) : daysLabel ? (
                   <Badge className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
-                    {daysUntil === 0 ? "Today!" : `In ${daysUntil} days`}
+                    {daysLabel}
                   </Badge>
+                ) : isApproximateDate ? (
+                  <Badge variant="outline">Date TBC</Badge>
                 ) : null}
               </div>
 
@@ -68,14 +79,14 @@ export const EventDetailHero = ({ event }: EventDetailHeroProps) => {
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-6">
                 <div className="flex items-center gap-2 text-muted-foreground">
                   <Calendar className="w-5 h-5 text-primary flex-shrink-0" />
-                  <span>
-                    {format(eventDate, "EEEE, d MMMM yyyy")}
-                  </span>
+                  <span>{dateLabel}</span>
                 </div>
-                <div className="flex items-center gap-2 text-muted-foreground">
-                  <Clock className="w-5 h-5 text-primary flex-shrink-0" />
-                  <span>{event.time}</span>
-                </div>
+                {timeLabel ? (
+                  <div className="flex items-center gap-2 text-muted-foreground">
+                    <Clock className="w-5 h-5 text-primary flex-shrink-0" />
+                    <span>{timeLabel}</span>
+                  </div>
+                ) : null}
                 <div className="flex items-center gap-2 text-muted-foreground">
                   <MapPin className="w-5 h-5 text-primary flex-shrink-0" />
                   <span>{event.location}</span>
@@ -107,12 +118,12 @@ export const EventDetailHero = ({ event }: EventDetailHeroProps) => {
                     </a>
                   </Button>
                 )}
-                {!isEventPast && (
+                {showCalendarButton && (
                   <AddToCalendarButton
                     title={event.title}
                     description={event.description}
                     date={event.date}
-                    time={event.time}
+                    time={event.time ?? ""}
                     location={event.location}
                   />
                 )}
@@ -124,7 +135,7 @@ export const EventDetailHero = ({ event }: EventDetailHeroProps) => {
                   metadata={{
                     date: event.date,
                     location: event.location,
-                    organizer: event.organizer,
+                    organizer: organizerLabel,
                     category: event.category,
                   }}
                   variant="outline"

--- a/src/hooks/useEventBySlug.ts
+++ b/src/hooks/useEventBySlug.ts
@@ -1,18 +1,21 @@
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
+import type { DatePrecision } from "@/lib/eventDate";
 
 export interface EventDetail {
   id: string;
   title: string;
   slug: string;
   date: string;
-  time: string;
+  date_precision?: DatePrecision | null;
+  typical_month?: string | null;
+  time?: string | null;
   location: string;
   type: string;
   category: string;
   attendees: number;
   description: string;
-  organizer: string;
+  organizer?: string | null;
   event_logo_url?: string | null;
   sector?: string | null;
   website_url?: string | null;

--- a/src/hooks/useEvents.ts
+++ b/src/hooks/useEvents.ts
@@ -2,19 +2,24 @@ import { useState, useCallback, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { useDebounce } from '@/hooks/useDebounce';
+import { isEventPast } from '@/lib/eventDate';
+
+import type { DatePrecision } from "@/lib/eventDate";
 
 export interface Event {
   id: string;
   title: string;
   slug: string;
   date: string;
-  time: string;
+  date_precision?: DatePrecision | null;
+  typical_month?: string | null;
+  time?: string | null;
   location: string;
   type: string;
   category: string;
   attendees: number;
   description: string;
-  organizer: string;
+  organizer?: string | null;
   event_logo_url?: string | null;
   sector?: string | null;
   website_url?: string | null;
@@ -65,26 +70,21 @@ export const useEvents = () => {
     queryFn: () => fetchEvents(debouncedSearchQuery || undefined),
   });
 
-  // Split events into upcoming and past
+  // Split events into upcoming and past. Approximate-date events (month / tbc) are
+  // always treated as upcoming because their stored date is a sort key, not a real schedule.
   const { upcomingEvents, pastEvents } = useMemo(() => {
-    const now = new Date();
-    now.setHours(0, 0, 0, 0);
-
     const upcoming: Event[] = [];
     const past: Event[] = [];
 
     events.forEach(event => {
-      const eventDate = new Date(event.date);
-      if (eventDate >= now) {
-        upcoming.push(event);
-      } else {
+      if (isEventPast(event)) {
         past.push(event);
+      } else {
+        upcoming.push(event);
       }
     });
 
-    // Upcoming: nearest first
     upcoming.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
-    // Past: most recent first
     past.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
     return { upcomingEvents: upcoming, pastEvents: past };

--- a/src/lib/eventDate.ts
+++ b/src/lib/eventDate.ts
@@ -1,0 +1,53 @@
+import { format, isPast, differenceInDays } from "date-fns";
+
+export type DatePrecision = "exact" | "month" | "tbc";
+
+export interface EventDateFields {
+  date: string;
+  date_precision?: DatePrecision | null;
+  typical_month?: string | null;
+}
+
+const toDate = (input: string) => new Date(input);
+
+/** Long, human-friendly date string for hero/detail views. */
+export const formatEventDateLong = (event: EventDateFields): string => {
+  const precision = event.date_precision ?? "exact";
+  const d = toDate(event.date);
+  if (precision === "tbc") return "Date TBC";
+  if (precision === "month") {
+    const month = event.typical_month?.trim() || format(d, "MMMM");
+    return `Typically ${month} ${format(d, "yyyy")}`;
+  }
+  return format(d, "EEEE, d MMMM yyyy");
+};
+
+/** Short two-line date badge used on cards. Returns the day field as `null` when the date is approximate. */
+export const formatEventDateBadge = (event: EventDateFields): { top: string; bottom: string | null } => {
+  const precision = event.date_precision ?? "exact";
+  const d = toDate(event.date);
+  if (precision === "tbc") return { top: "TBC", bottom: null };
+  if (precision === "month") return { top: format(d, "MMM").toUpperCase(), bottom: null };
+  return { top: format(d, "MMM").toUpperCase(), bottom: format(d, "d") };
+};
+
+/** Whether the event is past, accounting for approximate dates (month/TBC precision are never "past"). */
+export const isEventPast = (event: EventDateFields): boolean => {
+  const precision = event.date_precision ?? "exact";
+  if (precision !== "exact") return false;
+  return isPast(toDate(event.date));
+};
+
+/** Days-until label for upcoming exact-date events, otherwise null. */
+export const daysUntilLabel = (event: EventDateFields): string | null => {
+  const precision = event.date_precision ?? "exact";
+  if (precision !== "exact") return null;
+  const days = differenceInDays(toDate(event.date), new Date());
+  if (days < 0 || days > 30) return null;
+  if (days === 0) return "Today";
+  return `In ${days} days`;
+};
+
+/** Whether to show the Add-to-Calendar action — only meaningful when the date is exact. */
+export const canAddToCalendar = (event: EventDateFields): boolean =>
+  (event.date_precision ?? "exact") === "exact";

--- a/supabase/migrations/20260508120000_events_data_quality_pass_1.sql
+++ b/supabase/migrations/20260508120000_events_data_quality_pass_1.sql
@@ -1,0 +1,38 @@
+-- Events data quality pass 1: introduce date_precision and stop displaying placeholder values.
+--
+-- Before this migration the events table had two cohorts: 22 legacy rows with real exact
+-- dates (mostly past) and 83 imported rows where date was synthetically set to the 1st of
+-- the typical month, time was "See website", organizer was "TBC" and price was "Varies".
+-- Cards rendered those placeholders as if they were real schedule information, and the
+-- upcoming/past split treated the synthetic 1st-of-month date as a real one.
+
+-- 1. date_precision column: 'exact' | 'month' | 'tbc'
+ALTER TABLE public.events
+  ADD COLUMN IF NOT EXISTS date_precision text NOT NULL DEFAULT 'exact'
+    CHECK (date_precision IN ('exact', 'month', 'tbc'));
+
+COMMENT ON COLUMN public.events.date_precision IS
+  'Precision of the date field. exact = real scheduled date; month = approximate (typical_month); tbc = unknown.';
+
+-- 2. Backfill: rows whose date is the 1st of the month AND have typical_month set AND time
+--    is the placeholder are month-precision.
+UPDATE public.events
+SET date_precision = 'month'
+WHERE typical_month IS NOT NULL
+  AND EXTRACT(DAY FROM date)::int = 1
+  AND (time = 'See website' OR time IS NULL);
+
+-- 3. Roll placeholder month-precision dates forward to the next future occurrence of their
+--    month so they sort sensibly and never appear past.
+UPDATE public.events
+SET date = CASE
+  WHEN make_date(EXTRACT(YEAR FROM CURRENT_DATE)::int, EXTRACT(MONTH FROM date)::int, 1) >= CURRENT_DATE
+    THEN make_date(EXTRACT(YEAR FROM CURRENT_DATE)::int, EXTRACT(MONTH FROM date)::int, 1)
+  ELSE make_date(EXTRACT(YEAR FROM CURRENT_DATE)::int + 1, EXTRACT(MONTH FROM date)::int, 1)
+END
+WHERE date_precision = 'month';
+
+-- 4. Nullify placeholder strings so completeness queries are honest.
+UPDATE public.events SET time = NULL WHERE time = 'See website';
+UPDATE public.events SET organizer = NULL WHERE organizer = 'TBC';
+UPDATE public.events SET price = NULL WHERE price = 'Varies';

--- a/supabase/migrations/20260508120000_events_data_quality_pass_1.sql
+++ b/supabase/migrations/20260508120000_events_data_quality_pass_1.sql
@@ -6,6 +6,19 @@
 -- Cards rendered those placeholders as if they were real schedule information, and the
 -- upcoming/past split treated the synthetic 1st-of-month date as a real one.
 
+-- 0. Schema repair for Preview Branches. These columns exist in production but were
+--    added via Supabase Studio without migration files, so a fresh Preview DB is missing
+--    them. ADD COLUMN IF NOT EXISTS is a no-op in production.
+ALTER TABLE public.events ADD COLUMN IF NOT EXISTS typical_month text;
+ALTER TABLE public.events ADD COLUMN IF NOT EXISTS attendees_label text;
+ALTER TABLE public.events ADD COLUMN IF NOT EXISTS venue text;
+ALTER TABLE public.events ADD COLUMN IF NOT EXISTS frequency text;
+ALTER TABLE public.events ADD COLUMN IF NOT EXISTS exhibitors integer;
+ALTER TABLE public.events ADD COLUMN IF NOT EXISTS exhibitors_label text;
+ALTER TABLE public.events ADD COLUMN IF NOT EXISTS city text;
+ALTER TABLE public.events ADD COLUMN IF NOT EXISTS state_region text;
+ALTER TABLE public.events ADD COLUMN IF NOT EXISTS location_id uuid;
+
 -- 1. date_precision column: 'exact' | 'month' | 'tbc'
 ALTER TABLE public.events
   ADD COLUMN IF NOT EXISTS date_precision text NOT NULL DEFAULT 'exact'

--- a/supabase/migrations/20260508120100_events_legacy_cleanup.sql
+++ b/supabase/migrations/20260508120100_events_legacy_cleanup.sql
@@ -1,0 +1,22 @@
+-- Events legacy cleanup: drop dead one-off meetups and convert legacy conferences to
+-- month-precision so they auto-roll-forward like the rest until research confirms a real date.
+
+-- 10 stale one-off meetups (past dates, no recurrence pattern, no enrichment) - delete
+DELETE FROM public.events
+WHERE date_precision = 'exact'
+  AND date < CURRENT_DATE
+  AND type = 'Meetup';
+
+-- The remaining past exact-date events are real annual conferences with stale years.
+-- Convert to month-precision until research agents confirm a real next-instance date.
+UPDATE public.events
+SET typical_month = to_char(date, 'FMMonth'),
+    date_precision = 'month',
+    date = CASE
+      WHEN make_date(EXTRACT(YEAR FROM CURRENT_DATE)::int, EXTRACT(MONTH FROM date)::int, 1) >= CURRENT_DATE
+        THEN make_date(EXTRACT(YEAR FROM CURRENT_DATE)::int, EXTRACT(MONTH FROM date)::int, 1)
+      ELSE make_date(EXTRACT(YEAR FROM CURRENT_DATE)::int + 1, EXTRACT(MONTH FROM date)::int, 1)
+    END,
+    time = NULL
+WHERE date_precision = 'exact'
+  AND date < CURRENT_DATE;

--- a/supabase/migrations/20260508120200_events_monthly_rollforward_cron.sql
+++ b/supabase/migrations/20260508120200_events_monthly_rollforward_cron.sql
@@ -1,0 +1,41 @@
+-- Schedules a monthly pg_cron job that rolls month-precision events forward to their
+-- next future occurrence. Idempotent: it only touches rows whose stored date is past.
+
+CREATE OR REPLACE FUNCTION public.roll_forward_month_precision_events()
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  rows_updated integer;
+BEGIN
+  UPDATE public.events
+  SET date = CASE
+    WHEN make_date(EXTRACT(YEAR FROM CURRENT_DATE)::int, EXTRACT(MONTH FROM date)::int, 1) >= CURRENT_DATE
+      THEN make_date(EXTRACT(YEAR FROM CURRENT_DATE)::int, EXTRACT(MONTH FROM date)::int, 1)
+    ELSE make_date(EXTRACT(YEAR FROM CURRENT_DATE)::int + 1, EXTRACT(MONTH FROM date)::int, 1)
+  END,
+  updated_at = now()
+  WHERE date_precision = 'month'
+    AND date < CURRENT_DATE;
+
+  GET DIAGNOSTICS rows_updated = ROW_COUNT;
+  RETURN rows_updated;
+END;
+$$;
+
+COMMENT ON FUNCTION public.roll_forward_month_precision_events() IS
+  'Rolls month-precision event dates forward to their next future occurrence. Run monthly via pg_cron.';
+
+-- Drop any existing schedule with the same name so this migration is re-runnable
+SELECT cron.unschedule(jobid)
+FROM cron.job
+WHERE jobname = 'roll-forward-month-precision-events';
+
+-- Schedule: 02:00 UTC on the 1st of every month
+SELECT cron.schedule(
+  'roll-forward-month-precision-events',
+  '0 2 1 * *',
+  $cron$ SELECT public.roll_forward_month_precision_events(); $cron$
+);

--- a/supabase/migrations/20260508120200_events_monthly_rollforward_cron.sql
+++ b/supabase/migrations/20260508120200_events_monthly_rollforward_cron.sql
@@ -28,14 +28,24 @@ $$;
 COMMENT ON FUNCTION public.roll_forward_month_precision_events() IS
   'Rolls month-precision event dates forward to their next future occurrence. Run monthly via pg_cron.';
 
--- Drop any existing schedule with the same name so this migration is re-runnable
-SELECT cron.unschedule(jobid)
-FROM cron.job
-WHERE jobname = 'roll-forward-month-precision-events';
+-- Schedule the monthly cron job. Wrapped in a DO block so the migration is a no-op on
+-- Preview branches that don't have pg_cron enabled (the function itself is still created,
+-- which is the only piece prod really needs to apply).
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+    -- Drop any existing schedule with the same name so this migration is re-runnable
+    PERFORM cron.unschedule(jobid)
+    FROM cron.job
+    WHERE jobname = 'roll-forward-month-precision-events';
 
--- Schedule: 02:00 UTC on the 1st of every month
-SELECT cron.schedule(
-  'roll-forward-month-precision-events',
-  '0 2 1 * *',
-  $cron$ SELECT public.roll_forward_month_precision_events(); $cron$
-);
+    -- Schedule: 02:00 UTC on the 1st of every month
+    PERFORM cron.schedule(
+      'roll-forward-month-precision-events',
+      '0 2 1 * *',
+      'SELECT public.roll_forward_month_precision_events();'
+    );
+  ELSE
+    RAISE NOTICE 'pg_cron extension is not enabled - skipping cron schedule. Enable pg_cron in the Supabase dashboard if you want monthly auto-rollforward.';
+  END IF;
+END $$;

--- a/supabase/migrations/20260508120300_events_clear_dead_logo_token_urls.sql
+++ b/supabase/migrations/20260508120300_events_clear_dead_logo_token_urls.sql
@@ -1,0 +1,7 @@
+-- The 83 logos using the dead pk_ZDgrKooYR4myUNCcckiOsg img.logo.dev token all return
+-- 401 "invalid api token". NULL them so the CompanyLogo component regenerates working
+-- logo URLs at render time using the live token in src/lib/logoUtils.ts.
+
+UPDATE public.events
+SET event_logo_url = NULL
+WHERE event_logo_url LIKE '%pk_ZDgrKooYR4myUNCcckiOsg%';

--- a/supabase/migrations/20260508120400_events_top30_research_backfill.sql
+++ b/supabase/migrations/20260508120400_events_top30_research_backfill.sql
@@ -1,0 +1,98 @@
+-- Research-backfill for the top 30 events by attendees: registration_url, organizer_email,
+-- image_url (hero photo), exhibitors count, and the next confirmed start date. Where a
+-- confirmed_date was found we flip date_precision back to 'exact'.
+-- Source: parallel research agents querying each event's official website on 2026-05-08.
+-- 1 event (CeBIT Australia) was deleted because the event was discontinued in 2019.
+
+-- Batch 1
+UPDATE public.events SET registration_url='https://airshow.com.au/visitors/trade-visitor/registration/', date='2027-02-23', date_precision='exact'
+WHERE id='13ff3038-0dc9-40a7-b196-8c854122582e'; -- Avalon International Airshow
+
+UPDATE public.events SET registration_url='https://www.sydneybuildexpo.com/register-interest', organizer_email='marketing@sydneybuildexpo.com', exhibitors=700, date='2027-04-28', date_precision='exact'
+WHERE id='5ac5151c-76e1-4c05-a164-44b72607efaf'; -- Sydney Build Expo
+
+UPDATE public.events SET organizer_email='expo@amda.com.au', exhibitors=900, date='2027-11-02', date_precision='exact'
+WHERE id='ba57133f-01e4-4a1f-9678-298a9cc77828'; -- INDO PACIFIC
+
+UPDATE public.events SET registration_url='https://finefoodaustralia.com.au/pre-qualification-form-2026/', organizer_email='finefood@divcom.net.au', exhibitors=900, date='2026-08-31', date_precision='exact'
+WHERE id='37b5b129-5b8c-44d4-bff5-58c0f27f3d11'; -- Fine Food Australia
+
+UPDATE public.events SET registration_url='https://tickets.lup.com.au/aus-manufacturing-brisbane26?cat=cat-registration', organizer_email='amw@amtil.com.au', exhibitors=230, date='2026-05-12', date_precision='exact'
+WHERE id='cd9a9606-fdf3-44b9-8fa9-71eb1ef5bc68'; -- AMW
+
+UPDATE public.events SET registration_url='https://foodserviceaustralia.com.au/registration-pricing/', organizer_email='customercare@nationalmedia.com.au', date='2026-05-25', date_precision='exact'
+WHERE id='a39ca567-2148-42ee-a312-4fd2a747ff0b'; -- Foodservice Australia
+
+-- Batch 2
+UPDATE public.events SET registration_url='https://hannoverfairs.eventsair.com/cemat-australia-2026/exhibition-visitor-registration/Site/Register', organizer_email='info@cemat.com.au', date='2026-06-23', date_precision='exact'
+WHERE id='c3f9f85c-fb4d-495e-b4f4-ad84fd02bd5b'; -- CeMAT Australia
+
+UPDATE public.events SET registration_url='https://reg.salesforce.com/flow/plus/wtsydney26/sessioncatalog', image_url='https://wp.sfdcdigital.com/en-au/wp-content/uploads/sites/12/2025/11/awtsyd26-hero.png?w=1024'
+WHERE id='795381ef-8340-416b-ae1a-e46b4aa1a331'; -- Salesforce Agentforce Sydney
+
+UPDATE public.events SET registration_url='https://www.appex.com.au/register', organizer_email='marketing@appex.com.au', image_url='https://cdn.asp.events/CLIENT_Exhibiti_030C4FB2_97AC_2262_74166DECA5FD4BAB/sites/AusPack-2022/media/appex-2027/1.png', exhibitors=400, date='2027-03-16', date_precision='exact'
+WHERE id='740506fc-2479-4048-a07d-54e1a79330d0'; -- AUSPACK
+
+UPDATE public.events SET registration_url='https://imarcglobal.com/register', organizer_email='operations@imarcglobal.com', date='2026-10-27', date_precision='exact'
+WHERE id='fd51e9b0-37b7-479b-803a-816968cd8de3'; -- IMARC
+
+UPDATE public.events SET registration_url='https://primecreative.eventsair.com/megatrans-bulk2026/mtar', date='2026-09-16', date_precision='exact'
+WHERE id='e62dae06-0678-418d-8317-bcaf76b82427'; -- MEGATRANS
+
+UPDATE public.events SET registration_url='https://events.cpaaustralia.com.au/XYW21Z', date='2026-10-20', date_precision='exact'
+WHERE id='760dfd9b-16c4-4180-8608-bf94fdab0a92'; -- CPA Congress
+
+-- Batch 3
+UPDATE public.events SET registration_url='https://pages.awscloud.com/aws-summit-sydney-2026-registration.html', organizer_email='aws-summit-sydney-info@amazon.com', image_url='https://d1.awsstatic.com/onedam/marketing-channels/website/aws/en_US/events/approved/images/f80c6282-4979-4fe1-a1d7-4764f24afb1a-aws-conference-stage-presentation-youtube-thumbnail-tpcl3k3xlbg-1280x720.c1244aef21430a60c70e0511b73822516a85c8e0.jpg', date='2026-05-13', date_precision='exact'
+WHERE id='0aacb588-2a21-491f-9f79-74eb60a09247'; -- AWS Summit Sydney
+
+UPDATE public.events SET registration_url='https://secure.terrapinn.com/V5/step1.aspx?E=11141', organizer_email='adminau@terrapinn.com', image_url='https://terrapinn-cdn.com/exhibition/accounting-business-expo/Img/abs700r.png', exhibitors=100, date='2027-03-17', date_precision='exact'
+WHERE id='9bf533fe-0a57-4ce0-a94f-81d0e0d65301'; -- Accounting & Business Expo
+
+UPDATE public.events SET registration_url='https://secure.terrapinn.com/V5/step1.aspx?E=11004', organizer_email='adminau@terrapinn.com', image_url='https://terrapinn-cdn.com/exhibition/edutech-australia/Img/edutech2025.png', exhibitors=320, date='2026-06-03', date_precision='exact'
+WHERE id='2a98599e-df59-4bac-8261-7ca7c9089d19'; -- EduTECH
+
+UPDATE public.events SET registration_url='https://melbournebuildexpo.com/register-ticket', organizer_email='marketing@melbournebuildexpo.com', image_url='https://cdn.asp.events/CLIENT_Oliver_K_15A4C8AE_5056_B739_54CFDE58102DEF33/sites/MBE2025/media/2025-edits/Hero-1-2025.png', exhibitors=350, date='2026-11-25', date_precision='exact'
+WHERE id='0039f4e5-0b74-45b9-91ad-bfb578613c78'; -- Melbourne Build Expo
+
+UPDATE public.events SET registration_url='https://foodproexpo.com/register', exhibitors=400, date='2026-07-26', date_precision='exact'
+WHERE id='6b9ac7be-d116-4f75-903e-712af24cc201'; -- foodpro
+
+-- CeBIT Australia: discontinued event (last held 2019), website dead. Hard-delete.
+DELETE FROM public.events WHERE id='7b908a7d-96a6-4f96-9d71-ae538f048418';
+
+-- Batch 4
+UPDATE public.events SET organizer_email='events@qldguild.org.au', exhibitors=450, date='2027-03-18', date_precision='exact'
+WHERE id='32d1b3fe-9b77-4ff4-b9e5-afbb940d4c19'; -- APP Conference
+
+UPDATE public.events SET registration_url='https://www.cognitoforms.com/BusinessShowMedia1/TBSOZ26TicketRegistration', organizer_email='enquiries.tbsau@bsmexpo.com', exhibitors=300, date='2026-11-25', date_precision='exact'
+WHERE id='fca5ac36-69e2-4be2-868d-1a22cdf05569'; -- The Business Show Australia
+
+UPDATE public.events SET registration_url='https://www.gevme.com/AIME2026-buyer-registration', image_url='https://cdn.asp.events/CLIENT_Talk2Med_555181CA_F9E2_80A6_42262F88172B8903/sites/aime-26/media/2026-photos/26007_0017.jpg', exhibitors=800, date='2027-02-15', date_precision='exact'
+WHERE id='9d5f0c55-6454-4899-83ea-86f20d79f30c'; -- AIME
+
+UPDATE public.events SET registration_url='https://www.salesforce.com/au/events/world-tour/melbourne26/', image_url='https://wp.sfdcdigital.com/en-au/wp-content/uploads/sites/12/2026/04/awtmelb26-hub.png?w=1024', date='2026-06-17', date_precision='exact'
+WHERE id='b8006246-5753-4280-9a6f-1f90f1aefe21'; -- Agentforce World Tour Melbourne
+
+UPDATE public.events SET registration_url='https://whsshow.com.au/melbourne-register/', organizer_email='spalermo@nationalmedia.com.au', exhibitors=160, date='2026-05-20', date_precision='exact'
+WHERE id='1bc800e3-0bc4-4410-b241-15dcf8cff2c8'; -- Workplace Health & Safety Show
+
+-- Build Brisbane Expo: site unreachable, no updates.
+
+-- Batch 5
+UPDATE public.events SET image_url='https://naturallygood.com.au/wp-content/uploads/sites/6/2025/05/hero-imagebubble.png'
+WHERE id='d4a16445-5f92-44dd-8d07-4a65b14f4821'; -- Naturally Good
+
+UPDATE public.events SET registration_url='https://www.ozwater.org/register/registration', organizer_email='ozwater@awa.asn.au', exhibitors=200, date='2026-05-25', date_precision='exact'
+WHERE id='2cd23531-4902-4570-a6ac-0934cc270a07'; -- Ozwater
+
+UPDATE public.events SET organizer_email='info@pausefest.com.au', image_url='https://cdn.prod.website-files.com/6830754254da06a01dffe2ed/683193900093b94feddf8f4d_PF%20landing%20Images2.jpg'
+WHERE id='92b92e71-0649-47d9-90ad-1763fb6327e1'; -- Pause Fest
+
+UPDATE public.events SET registration_url='https://www.gartner.com/en/conferences/apac/symposium-australia'
+WHERE id='0ec9f49c-6224-42a6-9390-80da0dacaed5'; -- Gartner IT Symposium
+
+UPDATE public.events SET registration_url='https://secure.terrapinn.com/V5/step1.aspx?E=11080&p=1', organizer_email='hello@digitalhealthfest.com.au', exhibitors=350, date='2026-05-20', date_precision='exact'
+WHERE id='e5baec3d-6601-47ae-9904-571f60fa321b'; -- Digital Health Festival
+
+-- Xerocon Australia: no AU 2026 instance announced yet, all NULLs from research.

--- a/supabase/migrations/20260508130000_events_pass2_research_backfill.sql
+++ b/supabase/migrations/20260508130000_events_pass2_research_backfill.sql
@@ -1,0 +1,69 @@
+-- Pass 2 research backfill: next 30 events by attendees, again driven by 5 parallel research
+-- agents querying official websites on 2026-05-08. As before, where a confirmed_date was
+-- found we flip date_precision back to 'exact'.
+
+-- Batch 6
+UPDATE public.events SET registration_url='https://secure.terrapinn.com/V5/step1.aspx?E=11072&p=1', organizer_email='meg.obrien@terrapinn.com', image_url='https://www.terrapinn-cdn.com/conference/technology-in-government/img/TIG242.png', exhibitors=150, date='2026-08-04', date_precision='exact'
+WHERE id='65c60628-bef2-4738-84b0-04e6aeee5a87'; -- Tech in Gov
+
+UPDATE public.events SET registration_url='https://summit.companydirectors.com.au/', organizer_email='nationalevents@aicd.com.au', date='2027-03-09', date_precision='exact'
+WHERE id='de994bbd-35a0-4502-9715-d735388bc14e'; -- AICD Australian Governance Summit
+
+UPDATE public.events SET registration_url='https://www.smallbizweek.com.au/2026/tickets-enquiry', organizer_email='info@abfgroup.com.au', date='2026-07-29', date_precision='exact'
+WHERE id='916a504c-d43a-4316-b8a2-be63d55da21d'; -- Small Business Expo Australia
+
+-- Build Brisbane Expo, Naturally Good (no future date), Pause Fest (no future date): no actionable updates.
+
+-- Batch 7
+UPDATE public.events SET image_url='https://res.cloudinary.com/startup-grind/image/upload/c_scale,w_2560/c_crop,h_640,w_2560,y_0.0_mul_h_sub_0.0_mul_640/c_crop,h_640,w_2560/c_fill,dpr_2.0,f_auto,g_center,q_auto:good/v1/gcs/platform-data-startupgrind/event_banners/apacArtboard%204_MSZ9Dky.png'
+WHERE id='f78fb20b-3105-4340-ae38-0cc172c8c513'; -- Startup Grind APAC
+
+UPDATE public.events SET registration_url='https://conference.ageingaustralia.asn.au/ageing-australia-nc-2026/', image_url='https://conference.ageingaustralia.asn.au/wp-content/uploads/2025/12/national-conference-banner-1320x175-1-scaled.jpg', exhibitors=220, date='2026-11-24', date_precision='exact'
+WHERE id='4908dbaa-948c-4a37-ae34-4ebf53e0825c'; -- Ageing Australia
+
+UPDATE public.events SET organizer_email='hello@southstart.co'
+WHERE id='a9952816-c159-4fad-9ccb-cf3879fba43a'; -- SouthStart
+
+UPDATE public.events SET registration_url='https://www.himss.org/events-overview/apac-conference-and-exhibition/', date='2026-08-23', date_precision='exact'
+WHERE id='2d67ea4e-fbf9-46bc-804c-11f854e5ef8e'; -- HIMSS Asia Pacific
+
+-- Xerocon AU, Pacific Mining Expo: site unreachable / no AU 2026 announced.
+
+-- Batch 8
+UPDATE public.events SET registration_url='https://6j2wdxu8ain.typeform.com/to/bY6yuOq0', image_url='https://cloud-1de12d.becdn.net/media/original/1ec463e25eda331c2e0dba5a9adabfe9/250917-IntersektDay1-72.jpg', date='2026-09-03', date_precision='exact'
+WHERE id='322f7329-3ac8-4f95-8533-eb77c273e1e8'; -- Intersekt
+
+UPDATE public.events SET registration_url='https://mumbrella.com.au/mumbrella360', date='2026-05-26', date_precision='exact'
+WHERE id='541c2376-2490-4ffb-80e2-568ba55933c8'; -- Mumbrella360
+
+UPDATE public.events SET registration_url='https://superannuation.asn.au/conference/pricing/', date='2026-11-17', date_precision='exact'
+WHERE id='ad7e3d0b-2287-4806-923c-279a8af94cd0'; -- ASFA Conference
+
+UPDATE public.events SET registration_url='https://intersektfestival.com', organizer_email='tori@fintechaustralia.org.au', image_url='https://images.squarespace-cdn.com/content/v1/63869d9c2ee34066ae2291a7/1764545619610-M9J9PHS28RZQIA5SN41F/Banner+Kat%27s+2024+%28169%29+%2843%29.png', date='2026-09-03', date_precision='exact'
+WHERE id='f7558608-bed7-45e6-8c40-af466c035fb3'; -- National Fintech Festival
+
+-- AHRI National Convention, Clean Energy Summit: nothing usable found.
+
+-- Batch 9
+UPDATE public.events SET registration_url='https://www.informa.com.au/registration/conference/nt-resources-week/', image_url='https://ntresourcesweek.com.au/wp-content/uploads/2024/08/NTRW-bgland-scape.jpg', date='2026-09-02', date_precision='exact'
+WHERE id='d738e2f9-b867-44e2-b99d-69b9227d4ab3'; -- NT Resources Week
+
+UPDATE public.events SET date='2026-11-05', date_precision='exact'
+WHERE id='4bc0ea48-2148-4010-8af6-c7f5cf857493'; -- Insurance Council of Australia Summit
+
+-- MFAA, SMSF Association, AIIA Reimagination, National Safety Convention SIA: nothing found.
+
+-- Batch 10
+UPDATE public.events SET registration_url='https://retailfest26-registration.personatech.com/', image_url='https://i0.wp.com/retailglobal.com.au/wp-content/uploads/2024/07/2024-04-16_RetailFest-110306.jpg?resize=800%2C534&ssl=1', exhibitors=100
+WHERE id='5ae9cc10-31f8-4366-8792-cc152ebd1052'; -- Retail Global (RetailFest 2026 just past, 2027 TBA)
+
+UPDATE public.events SET registration_url='https://westtechfest.com.au/event/2026-festival-passes/', organizer_email='westtechfest@curtin.edu.au', date='2026-12-07', date_precision='exact'
+WHERE id='54070890-028c-49df-b80c-98b7da8ede82'; -- West Tech Fest
+
+UPDATE public.events SET registration_url='https://yowcon.com/tech-leaders-melbourne-2026/registrations', organizer_email='info@yowconference.com', image_url='https://files.gotocon.com/uploads/files/73/original/1678077740_Tech%20Leaders%20Summit.png', date='2026-06-16', date_precision='exact'
+WHERE id='cb06a75a-d01e-4133-8c69-ec77f525a860'; -- YOW
+
+UPDATE public.events SET registration_url='https://www.riuexplorersconference.com.au/', organizer_email='info@verticalevents.com.au', image_url='https://static.wixstatic.com/media/9c283a_9f0739f2b3544b3aaca1960bfc15e4a2~mv2.jpg', date='2027-02-16', date_precision='exact'
+WHERE id='79c5f8ed-a104-4429-a4fc-6597dcb15fad'; -- RIU Explorers
+
+-- Aged Care Industry Summit, The Property Congress: nothing found.

--- a/supabase/migrations/20260508140000_events_pass3_research_backfill.sql
+++ b/supabase/migrations/20260508140000_events_pass3_research_backfill.sql
@@ -1,0 +1,62 @@
+-- Pass 3 research backfill: 27 fresh events ranked roughly 61-90 by attendees, again
+-- driven by 5 parallel research agents querying official websites on 2026-05-08.
+
+-- Batch 11
+UPDATE public.events SET registration_url='https://luma.com/rddem8i7', organizer_email='vc@fivevcapital.com', image_url='https://cdn.prod.website-files.com/65a3939fb6da371e2a36c8bc/692636ba6e3decd1d243c6c0_3.jpg', date='2026-05-13', date_precision='exact'
+WHERE id='46ee9868-46a5-4c7f-af19-ee885d517283'; -- SaaS Summit Australia
+
+UPDATE public.events SET registration_url='https://www.legalinnovationsea.com/upcoming-legal-events-register-interest', date='2027-04-28', date_precision='exact'
+WHERE id='831c64c6-28dd-4f62-bd28-ac58c76c2292'; -- Legal Innovation & Tech Fest
+
+-- AusMine, Mining Indaba AusMine, Agribusiness Australia, SHRM Australia: sites unreachable
+
+-- Batch 12
+UPDATE public.events SET registration_url='https://www.gevme.com/futureofmining-2026-registration', organizer_email='eventoperations@aspermont.com', date='2026-06-16', date_precision='exact'
+WHERE id='a3ff530d-743e-433f-b442-4021cc212d5a'; -- Future of Mining Australia
+
+UPDATE public.events SET registration_url='https://www.propertycouncil.com.au/event/national-retirement-living-summit-2026', date='2026-06-15', date_precision='exact'
+WHERE id='a0dd8f9e-603d-4df4-a92a-13dc126e054e'; -- National Retirement Living Summit
+
+UPDATE public.events SET image_url='https://www.apcsummit.org/sites/default/files/2025-12/SB-22.jpg', date='2027-09-15', date_precision='exact'
+WHERE id='4da0007e-8829-441f-ba63-40e6ebff29f6'; -- Asia Pacific Cities Summit
+
+UPDATE public.events SET registration_url='https://events.humanitix.com/cicada-x-tech23-2026-australias-biggest-deep-tech-festival?c=website', organizer_email='hello@tech23.com.au', image_url='https://images.humanitix.com/i/Z105NIFORhCUcJgn8sNH@responsive-1600.webp', exhibitors=23, date='2026-09-09', date_precision='exact'
+WHERE id='fc3fe119-5453-4263-b352-8a996f794ca3'; -- Cicada x Tech23
+
+-- Australian Venture Summit, Mental Health Congress Australia: sites unreachable
+
+-- Batch 13
+UPDATE public.events SET registration_url='https://www.nationalpropertyconference.com.au/register', organizer_email='events@api.org.au'
+WHERE id='d4b5a3cd-1b8f-4699-ba10-5884b55336e4'; -- API National Property Conference (May 4-6 2026 just past, no 2027 yet)
+
+UPDATE public.events SET registration_url='https://futureplace.swoogo.com/LSS/register', image_url='https://livingsectorssummit.com/wp-content/uploads/54920560398_b271e89530_k.jpg', exhibitors=40, date='2026-11-11', date_precision='exact'
+WHERE id='b2465003-472b-4658-90a9-373adf74f961'; -- Living Sectors Summit
+
+-- AIIA National Conference, RMITx Digital Innovation Summit, AgriFutures National Forum: nothing actionable
+
+-- Batch 14
+UPDATE public.events SET registration_url='https://procureconaustralia.wbresearch.com/srspricing', image_url='https://eco-cdn.iqpc.com/eco/images/uploaded_images/0g878J6wkICFt4yQs9CKdXnfukzdwlsUbPTO9cLG.jpg', date='2026-05-19', date_precision='exact'
+WHERE id='8552effb-9fc2-4194-9d3c-0e5bddb18676'; -- Procurement Australia Conference
+
+UPDATE public.events SET organizer_email='events@weldaustralia.com.au', image_url='https://manufacturingsummit.com.au/wp-content/uploads/2026/02/nms2026-banner.png'
+WHERE id='46238f44-7a03-4094-bbd3-c442ad782c0b'; -- National Manufacturing Summit (postponed)
+
+UPDATE public.events SET registration_url='https://hrsummit.com.au/register-now', image_url='https://hrsummit.com.au/hs-fs/hubfs/HRD_084_email.jpg'
+WHERE id='21c0bcc2-256d-4856-9833-401a6ebc28e3'; -- National HR Summit
+
+UPDATE public.events SET registration_url='https://www.qac2026.com/registration', image_url='https://images.squarespace-cdn.com/content/v1/684e9e79e0d97b3dabd6959b/7658b464-788e-4d51-bf81-43df874a2ca7/Untitled+design+%286%29.png'
+WHERE id='cb34a5f1-2b4d-4b04-ad59-5625f2ee1d65'; -- Quantum Australia (2026 past, 2027 TBA)
+
+-- DMWF Australia: no AU instance announced
+
+-- Batch 15
+UPDATE public.events SET registration_url='https://vcworldsummit.com/tickets/sydney-2027/', date='2027-02-23', date_precision='exact'
+WHERE id='89631055-2de9-44e5-b527-ec50705d7b62'; -- VC World Summit Sydney
+
+UPDATE public.events SET registration_url='https://events.humanitix.com/startup-to-scaleup-summit-2025', organizer_email='hello@s2ssummit.com', date='2026-09-01', date_precision='exact'
+WHERE id='0c6fb160-2a2e-4c5c-b6e3-e27151911c3f'; -- S2S Summit
+
+UPDATE public.events SET registration_url='https://anz.datainnovationsummit.com/tickets', organizer_email='apac@datainnovationsummit.com', image_url='https://anz.datainnovationsummit.com/wp-content/uploads/2026/03/Welcome-to-Data-Innovation-Summit-2025.webp', date='2026-09-17', date_precision='exact'
+WHERE id='19d4569d-1c90-4725-9a31-237fdabb3c15'; -- Data Innovation Summit ANZ
+
+-- HR Leaders Summit, National Safety Summit WHS Leaders: sites unreachable


### PR DESCRIPTION
## Summary

End-to-end pass on the events directory. Audit, schema fix, frontend update, and three rounds of agent-driven research backfill on the 87 events that needed it.

The headline fix: 79% of events had a synthetic placeholder date (1st of `typical_month`) that the UI rendered as if it were real, and 35% of stored dates were already in the past. The page sorted by that fake date and offered an "Add to Calendar" button on every one of them.

## What changed

### Schema / data
- New `events.date_precision` column (`'exact' | 'month' | 'tbc'`) with a CHECK constraint, separating real dates from approximations.
- Hard-deleted 11 records (10 stale one-off meetups + CeBIT Australia, discontinued in 2019).
- Rolled the surviving 12 past annual conferences forward via month-precision so they auto-update.
- New `roll_forward_month_precision_events()` function plus pg_cron schedule (02:00 UTC on the 1st of each month) so dates can never re-rot.
- Nulled placeholder strings: `'See website'`, `'TBC'`, `'Varies'` — completeness queries are now honest.
- Nulled 83 dead-token `img.logo.dev` URLs (token returned 401 globally); `CompanyLogo` regenerates working URLs at render time.
- Three rounds of parallel research-agent backfill on 87 priority events: registration URLs, organizer emails, hero images, exhibitor counts, and confirmed start dates. Where an agent confirmed a real date, `date_precision` flips back to `'exact'`.

### Frontend
- New `src/lib/eventDate.ts` with precision-aware helpers (`formatEventDateLong`, `formatEventDateBadge`, `isEventPast`, `daysUntilLabel`, `canAddToCalendar`).
- `EventCard`, `EventDetailHero`, `EventModal`, `EventDetailContent` now render `"Typically March 2027"` for approximate dates, hide the day-of-month chip, suppress Add-to-Calendar when the date isn't real, fall back to "Organizer TBC" when null, and only show the time row when a real time exists.
- `useEvents` upcoming/past split uses `isEventPast` so approximate-date events stop landing in "Past Events".
- `Event` / `EventDetail` interfaces updated; `time` and `organizer` are now correctly nullable.

## Result

| Metric | Before | After |
|---|---|---|
| Total events | 105 | 94 |
| Past dates displayed as upcoming | 37 | 0 |
| Confirmed exact dates | 0 functional | 48 |
| `registration_url` populated | 0 | 50 |
| `organizer_email` populated | 0 | 33 |
| Hero `image_url` populated | 0 | 28 |
| `exhibitors` populated | 0 | 20 |
| Working logos | ~1 | regenerated at render time via live token |

51% of events now show a confirmed real date and a working registration URL.

## Migration files (run in order)

- `20260508120000_events_data_quality_pass_1.sql` — date_precision column + initial rollforward
- `20260508120100_events_legacy_cleanup.sql` — hard-delete dead meetups, convert legacy conferences
- `20260508120200_events_monthly_rollforward_cron.sql` — pg_cron schedule
- `20260508120300_events_clear_dead_logo_token_urls.sql` — null dead logos
- `20260508120400_events_top30_research_backfill.sql` — pass 1 backfill (top 30 by attendees)
- `20260508130000_events_pass2_research_backfill.sql` — pass 2 backfill (next 30)
- `20260508140000_events_pass3_research_backfill.sql` — pass 3 backfill (next 27)

The migrations have already been applied to the live MES Supabase project (xhziwveaiuhzdoutpgrh). The files in this PR are the historical record.

## Test plan

- [ ] Visit `/events` and confirm no events show "MAR / 1" badges with a fake day; approximate-date events should show just `"MAR"` plus a `typical` subtitle.
- [ ] Approximate-date events have no Add-to-Calendar button and no time row.
- [ ] Exact-date events (e.g., AWS Summit Sydney, Ozwater, Mumbrella360, Tech in Gov) show full date string, time if set, registration CTA, and a hero image where present.
- [ ] No event renders a broken logo. The `CompanyLogo` fallback chain — `existingLogoUrl → logo.dev → initials` — should produce something for every card.
- [ ] Past-events tab is empty (no `date < today` rows are surfaced as upcoming).
- [ ] `pg_cron` job fires on 1 June 2026 at 02:00 UTC and the function returns >0 rows updated.

## Notes

- One research agent flagged prompt-injection attempts in two of its WebFetch responses (during the `foodpro` and `cebit` lookups) that tried to inject fake system reminders. The agent ignored them — flagging here for visibility.
- 32 events remain at month-precision because their official sites are unreachable (10 events) or have no public 2026/27 dates yet (~22 events). Worth revisiting in 3–6 months once programs are announced; the monthly cron handles year-rollover automatically.
- `image_url` is populated for 28 events but not yet rendered as a hero image on `EventDetailHero` — currently only used for SEO `ogImage`. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CqwQLurzYwaw5f8eJ2QxbZ)_