### PR TITLE
Backfill logo.dev logos + websites for 53 case studies

### DIFF
--- a/reports/case-study-logos-summary-2026-05-08.md
+++ b/reports/case-study-logos-summary-2026-05-08.md
@@ -1,0 +1,82 @@
+# Case-Study Logo Backfill Summary
+
+**Date:** 2026-05-08
+**Branch:** `claude/case-study-logos`
+**Supabase project:** `xhziwveaiuhzdoutpgrh` (MES Platform)
+
+---
+
+## What changed
+
+Backfilled `content_company_profiles.website` and `content_company_profiles.company_logo` for **53 published case studies** that previously had neither field populated. Logos point at logo.dev (the same provider already wired into `src/lib/logoUtils.ts`).
+
+DB delta: 53 rows updated. No schema changes, no other tables touched, no rows added or removed.
+
+| | Before | After |
+|---|---:|---:|
+| Total published case studies | 77 | 77 |
+| Has `website` | 24 | 77 |
+| Has `company_logo` | 0 | 53 |
+| Missing both | 53 | **0** |
+
+The 24 pre-existing rows that already had a `website` were intentionally left alone (per scope: "53 missing only"). They continue to render logos via the runtime `getLogoUrl(website)` fallback in the frontend.
+
+---
+
+## Pipeline
+
+Reproducible from the repo:
+
+1. `scripts/cases_missing_logos_input.json` — snapshot of the 53 cases needing logos (slug, company_name, source URLs).
+2. `scripts/build_case_study_logos.py` — applies a curated `slug → domain` map and validates each domain against `https://img.logo.dev/{domain}?token=...&fallback=404`. The `fallback=404` parameter cleanly distinguishes real logos (200) from monogram fallbacks (404).
+3. `scripts/parsed_case_study_logos.json` — validated mapping (slug, domain, website URL, logo URL, validation result).
+4. `scripts/generate_case_study_logo_sql.py` → `scripts/backfill_case_study_logos.sql` — idempotent UPDATE bundle (53 statements, only update where both fields are still NULL).
+
+Validation: **53/53 domains returned 200 OK from logo.dev** with `fallback=404`. No domain hit a generated monogram fallback.
+
+---
+
+## Curated domain map (53 cases)
+
+Domains were selected from first-hand knowledge of each company plus cross-reference with the company's official site / Wikipedia / Crunchbase. Notable choices:
+
+- `aws.amazon.com` for AWS (separate brand identity from amazon.com)
+- `deliveroo.co.uk` for Deliveroo (registered original)
+- `tpro.io` for T-Pro
+- `secretlab.co`, `sensat.co`, `tractable.ai`, `nplan.io`, `contino.io` for `.co` / `.ai` / `.io` brands
+- `zoom.us` for Zoom (their brand domain)
+- `spectrum.life` for Spectrum.Life
+- `anna.money` for ANNA Money
+- `thoughtmachine.net` for Thought Machine
+- `blueprism.com` for Blue Prism (single token, not hyphenated)
+
+Logo URL format: `https://img.logo.dev/{domain}?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png` (256px for hero quality; the existing publishable token from `src/lib/logoUtils.ts` is reused).
+
+---
+
+## How the frontend uses this
+
+`src/pages/CaseStudyDetail.tsx:211, 279` already implements the logo fallback chain:
+
+```ts
+src={companyProfile?.company_logo
+     || getLogoUrl(companyProfile?.website, 64)
+     || primaryFounder?.image}
+```
+
+So:
+- **For these 53 cases:** the persisted 256px `company_logo` URL is used directly (cleaner OG image, faster paint, lets us override if logo.dev gets one wrong).
+- **For the other 24:** runtime `getLogoUrl(website)` continues to work as before — no regression.
+
+The OG image fallback at `CaseStudyDetail.tsx:168` (`ogImage={heroImageUrl || companyProfile?.company_logo || undefined}`) now picks up the new `company_logo` for social shares.
+
+---
+
+## Files added in this task
+
+- `scripts/cases_missing_logos_input.json` — 53-case snapshot (input)
+- `scripts/build_case_study_logos.py` — curated mapping + logo.dev validator
+- `scripts/parsed_case_study_logos.json` — validated mapping output
+- `scripts/generate_case_study_logo_sql.py` — SQL generator
+- `scripts/backfill_case_study_logos.sql` — idempotent UPDATE bundle (53 statements)
+- `reports/case-study-logos-summary-2026-05-08.md` — this file

--- a/scripts/backfill_case_study_logos.sql
+++ b/scripts/backfill_case_study_logos.sql
@@ -1,0 +1,533 @@
+-- Backfill website + company_logo for 53 published case studies
+-- missing both fields. Idempotent: only updates rows where website
+-- and company_logo are both still NULL.
+
+-- airbnb-australia-market-entry (Airbnb)
+UPDATE content_company_profiles cp
+   SET website = 'https://airbnb.com',
+       company_logo = 'https://img.logo.dev/airbnb.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'airbnb-australia-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- amazon-australia-ecommerce-entry (Amazon.com)
+UPDATE content_company_profiles cp
+   SET website = 'https://amazon.com',
+       company_logo = 'https://img.logo.dev/amazon.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'amazon-australia-ecommerce-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- anna-money-anz-market-entry (ANNA Money)
+UPDATE content_company_profiles cp
+   SET website = 'https://anna.money',
+       company_logo = 'https://img.logo.dev/anna.money?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'anna-money-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- anthropic-australia-market-entry (Anthropic)
+UPDATE content_company_profiles cp
+   SET website = 'https://anthropic.com',
+       company_logo = 'https://img.logo.dev/anthropic.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'anthropic-australia-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- aws-australia-market-entry (Amazon Web Services (AWS))
+UPDATE content_company_profiles cp
+   SET website = 'https://aws.amazon.com',
+       company_logo = 'https://img.logo.dev/aws.amazon.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'aws-australia-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- banked-anz-market-entry (Banked)
+UPDATE content_company_profiles cp
+   SET website = 'https://banked.com',
+       company_logo = 'https://img.logo.dev/banked.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'banked-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- blue-prism-anz-market-entry (Blue Prism)
+UPDATE content_company_profiles cp
+   SET website = 'https://blueprism.com',
+       company_logo = 'https://img.logo.dev/blueprism.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'blue-prism-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- clanwilliam-anz-market-entry (Clanwilliam)
+UPDATE content_company_profiles cp
+   SET website = 'https://clanwilliam.com',
+       company_logo = 'https://img.logo.dev/clanwilliam.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'clanwilliam-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- comfortdelgro-anz-market-entry (ComfortDelGro)
+UPDATE content_company_profiles cp
+   SET website = 'https://comfortdelgro.com',
+       company_logo = 'https://img.logo.dev/comfortdelgro.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'comfortdelgro-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- complyadvantage-anz-market-entry (ComplyAdvantage)
+UPDATE content_company_profiles cp
+   SET website = 'https://complyadvantage.com',
+       company_logo = 'https://img.logo.dev/complyadvantage.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'complyadvantage-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- contino-anz-market-entry (Contino)
+UPDATE content_company_profiles cp
+   SET website = 'https://contino.io',
+       company_logo = 'https://img.logo.dev/contino.io?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'contino-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- daon-anz-market-entry (Daon)
+UPDATE content_company_profiles cp
+   SET website = 'https://daon.com',
+       company_logo = 'https://img.logo.dev/daon.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'daon-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- darktrace-anz-market-entry (Darktrace)
+UPDATE content_company_profiles cp
+   SET website = 'https://darktrace.com',
+       company_logo = 'https://img.logo.dev/darktrace.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'darktrace-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- databricks-australia-market-entry (Databricks)
+UPDATE content_company_profiles cp
+   SET website = 'https://databricks.com',
+       company_logo = 'https://img.logo.dev/databricks.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'databricks-australia-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- daxtra-technologies-anz-market-entry (DaXtra Technologies)
+UPDATE content_company_profiles cp
+   SET website = 'https://daxtra.com',
+       company_logo = 'https://img.logo.dev/daxtra.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'daxtra-technologies-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- deliveroo-anz-market-entry (Deliveroo)
+UPDATE content_company_profiles cp
+   SET website = 'https://deliveroo.co.uk',
+       company_logo = 'https://img.logo.dev/deliveroo.co.uk?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'deliveroo-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- dext-anz-market-entry (Dext)
+UPDATE content_company_profiles cp
+   SET website = 'https://dext.com',
+       company_logo = 'https://img.logo.dev/dext.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'dext-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- docusign-australia-market-entry (DocuSign)
+UPDATE content_company_profiles cp
+   SET website = 'https://docusign.com',
+       company_logo = 'https://img.logo.dev/docusign.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'docusign-australia-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- featurespace-anz-market-entry (Featurespace)
+UPDATE content_company_profiles cp
+   SET website = 'https://featurespace.com',
+       company_logo = 'https://img.logo.dev/featurespace.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'featurespace-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- fenergo-anz-market-entry (Fenergo)
+UPDATE content_company_profiles cp
+   SET website = 'https://fenergo.com',
+       company_logo = 'https://img.logo.dev/fenergo.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'fenergo-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- fexco-anz-market-entry (Fexco)
+UPDATE content_company_profiles cp
+   SET website = 'https://fexco.com',
+       company_logo = 'https://img.logo.dev/fexco.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'fexco-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- fineos-anz-market-entry (FINEOS)
+UPDATE content_company_profiles cp
+   SET website = 'https://fineos.com',
+       company_logo = 'https://img.logo.dev/fineos.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'fineos-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- github-australia-market-entry (GitHub)
+UPDATE content_company_profiles cp
+   SET website = 'https://github.com',
+       company_logo = 'https://img.logo.dev/github.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'github-australia-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- kyckr-anz-market-entry (Kyckr)
+UPDATE content_company_profiles cp
+   SET website = 'https://kyckr.com',
+       company_logo = 'https://img.logo.dev/kyckr.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'kyckr-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- learnupon-anz-market-entry (LearnUpon)
+UPDATE content_company_profiles cp
+   SET website = 'https://learnupon.com',
+       company_logo = 'https://img.logo.dev/learnupon.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'learnupon-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- mimecast-anz-market-entry (Mimecast)
+UPDATE content_company_profiles cp
+   SET website = 'https://mimecast.com',
+       company_logo = 'https://img.logo.dev/mimecast.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'mimecast-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- ncc-group-anz-market-entry (NCC Group)
+UPDATE content_company_profiles cp
+   SET website = 'https://nccgroup.com',
+       company_logo = 'https://img.logo.dev/nccgroup.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'ncc-group-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- nium-anz-market-entry (Nium)
+UPDATE content_company_profiles cp
+   SET website = 'https://nium.com',
+       company_logo = 'https://img.logo.dev/nium.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'nium-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- nplan-anz-market-entry (nPlan)
+UPDATE content_company_profiles cp
+   SET website = 'https://nplan.io',
+       company_logo = 'https://img.logo.dev/nplan.io?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'nplan-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- onfido-anz-market-entry (Onfido)
+UPDATE content_company_profiles cp
+   SET website = 'https://onfido.com',
+       company_logo = 'https://img.logo.dev/onfido.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'onfido-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- openai-australia-market-entry (OpenAI)
+UPDATE content_company_profiles cp
+   SET website = 'https://openai.com',
+       company_logo = 'https://img.logo.dev/openai.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'openai-australia-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- palantir-australia-market-entry (Palantir Technologies)
+UPDATE content_company_profiles cp
+   SET website = 'https://palantir.com',
+       company_logo = 'https://img.logo.dev/palantir.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'palantir-australia-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- propertyguru-anz-market-entry (PropertyGuru)
+UPDATE content_company_profiles cp
+   SET website = 'https://propertyguru.com',
+       company_logo = 'https://img.logo.dev/propertyguru.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'propertyguru-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- quantexa-anz-market-entry (Quantexa)
+UPDATE content_company_profiles cp
+   SET website = 'https://quantexa.com',
+       company_logo = 'https://img.logo.dev/quantexa.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'quantexa-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- revolut-anz-market-entry (Revolut)
+UPDATE content_company_profiles cp
+   SET website = 'https://revolut.com',
+       company_logo = 'https://img.logo.dev/revolut.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'revolut-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- salesforce-australia-market-entry (Salesforce)
+UPDATE content_company_profiles cp
+   SET website = 'https://salesforce.com',
+       company_logo = 'https://img.logo.dev/salesforce.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'salesforce-australia-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- secretlab-anz-market-entry (Secretlab)
+UPDATE content_company_profiles cp
+   SET website = 'https://secretlab.co',
+       company_logo = 'https://img.logo.dev/secretlab.co?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'secretlab-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- sensat-anz-market-entry (Sensat)
+UPDATE content_company_profiles cp
+   SET website = 'https://sensat.co',
+       company_logo = 'https://img.logo.dev/sensat.co?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'sensat-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- servicenow-australia-market-entry (ServiceNow)
+UPDATE content_company_profiles cp
+   SET website = 'https://servicenow.com',
+       company_logo = 'https://img.logo.dev/servicenow.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'servicenow-australia-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- shopback-anz-market-entry (ShopBack)
+UPDATE content_company_profiles cp
+   SET website = 'https://shopback.com',
+       company_logo = 'https://img.logo.dev/shopback.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'shopback-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- snowflake-australia-market-entry (Snowflake)
+UPDATE content_company_profiles cp
+   SET website = 'https://snowflake.com',
+       company_logo = 'https://img.logo.dev/snowflake.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'snowflake-australia-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- spectrum-life-anz-market-entry (Spectrum.Life)
+UPDATE content_company_profiles cp
+   SET website = 'https://spectrum.life',
+       company_logo = 'https://img.logo.dev/spectrum.life?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'spectrum-life-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- t-pro-anz-market-entry (T-Pro)
+UPDATE content_company_profiles cp
+   SET website = 'https://tpro.io',
+       company_logo = 'https://img.logo.dev/tpro.io?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 't-pro-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- tesla-australia-market-entry (Tesla)
+UPDATE content_company_profiles cp
+   SET website = 'https://tesla.com',
+       company_logo = 'https://img.logo.dev/tesla.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'tesla-australia-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- thought-machine-anz-market-entry (Thought Machine)
+UPDATE content_company_profiles cp
+   SET website = 'https://thoughtmachine.net',
+       company_logo = 'https://img.logo.dev/thoughtmachine.net?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'thought-machine-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- tines-anz-market-entry (Tines)
+UPDATE content_company_profiles cp
+   SET website = 'https://tines.com',
+       company_logo = 'https://img.logo.dev/tines.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'tines-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- tractable-anz-market-entry (Tractable)
+UPDATE content_company_profiles cp
+   SET website = 'https://tractable.ai',
+       company_logo = 'https://img.logo.dev/tractable.ai?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'tractable-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- twilio-australia-market-entry (Twilio)
+UPDATE content_company_profiles cp
+   SET website = 'https://twilio.com',
+       company_logo = 'https://img.logo.dev/twilio.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'twilio-australia-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- uipath-australia-market-entry (UiPath)
+UPDATE content_company_profiles cp
+   SET website = 'https://uipath.com',
+       company_logo = 'https://img.logo.dev/uipath.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'uipath-australia-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- wayflyer-anz-market-entry (Wayflyer)
+UPDATE content_company_profiles cp
+   SET website = 'https://wayflyer.com',
+       company_logo = 'https://img.logo.dev/wayflyer.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'wayflyer-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- wise-anz-market-entry (Wise)
+UPDATE content_company_profiles cp
+   SET website = 'https://wise.com',
+       company_logo = 'https://img.logo.dev/wise.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'wise-anz-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- xero-australia-market-entry (Xero)
+UPDATE content_company_profiles cp
+   SET website = 'https://xero.com',
+       company_logo = 'https://img.logo.dev/xero.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'xero-australia-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;
+
+-- zoom-australia-market-entry (Zoom Video Communications)
+UPDATE content_company_profiles cp
+   SET website = 'https://zoom.us',
+       company_logo = 'https://img.logo.dev/zoom.us?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png'
+  FROM content_items ci
+  WHERE cp.content_id = ci.id
+    AND ci.slug = 'zoom-australia-market-entry'
+    AND cp.website IS NULL
+    AND cp.company_logo IS NULL;

--- a/scripts/build_case_study_logos.py
+++ b/scripts/build_case_study_logos.py
@@ -1,0 +1,173 @@
+"""Backfill website + company_logo for the 53 published case studies missing both.
+
+Builds a curated slug → domain mapping based on:
+  1. First-hand knowledge of each company from prior import work
+  2. Domains mined from each case's `company_blog` source URLs
+  3. Cross-reference with each company's official corporate site
+
+Validates each domain by fetching the logo.dev URL and inspecting the
+response size — generic letter-avatar fallbacks are typically <5KB PNGs
+while real brand logos are larger.
+
+Outputs:
+  scripts/parsed_case_study_logos.json  - validated mapping (slug → domain, logo URL, validation status)
+  scripts/backfill_case_study_logos.sql - idempotent UPDATE bundle
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INPUT_PATH = REPO_ROOT / "scripts" / "cases_missing_logos_input.json"
+OUT_JSON = REPO_ROOT / "scripts" / "parsed_case_study_logos.json"
+OUT_SQL = REPO_ROOT / "scripts" / "backfill_case_study_logos.sql"
+
+# Logo.dev publishable token (already committed in src/lib/logoUtils.ts).
+LOGO_DEV_TOKEN = "pk_L3JbJjCeT0-mUdhpPlS6SA"
+LOGO_SIZE = 256  # stored size
+
+# Curated slug → corporate domain. Verified from the company's official
+# website / Wikipedia / Crunchbase / their own newsroom pages.
+SLUG_TO_DOMAIN: dict[str, str] = {
+    # Originally imported case studies (older batch)
+    "airbnb-australia-market-entry": "airbnb.com",
+    "amazon-australia-ecommerce-entry": "amazon.com",
+    "anthropic-australia-market-entry": "anthropic.com",
+    "aws-australia-market-entry": "aws.amazon.com",
+    "databricks-australia-market-entry": "databricks.com",
+    "docusign-australia-market-entry": "docusign.com",
+    "github-australia-market-entry": "github.com",
+    "openai-australia-market-entry": "openai.com",
+    "palantir-australia-market-entry": "palantir.com",
+    "salesforce-australia-market-entry": "salesforce.com",
+    "servicenow-australia-market-entry": "servicenow.com",
+    "snowflake-australia-market-entry": "snowflake.com",
+    "tesla-australia-market-entry": "tesla.com",
+    "twilio-australia-market-entry": "twilio.com",
+    "uipath-australia-market-entry": "uipath.com",
+    "xero-australia-market-entry": "xero.com",
+    "zoom-australia-market-entry": "zoom.us",
+
+    # Irish case studies
+    "anna-money-anz-market-entry": "anna.money",
+    "clanwilliam-anz-market-entry": "clanwilliam.com",
+    "daon-anz-market-entry": "daon.com",
+    "daxtra-technologies-anz-market-entry": "daxtra.com",
+    "fenergo-anz-market-entry": "fenergo.com",
+    "fexco-anz-market-entry": "fexco.com",
+    "fineos-anz-market-entry": "fineos.com",
+    "kyckr-anz-market-entry": "kyckr.com",
+    "learnupon-anz-market-entry": "learnupon.com",
+    "spectrum-life-anz-market-entry": "spectrum.life",
+    "t-pro-anz-market-entry": "tpro.io",
+    "tines-anz-market-entry": "tines.com",
+    "tractable-anz-market-entry": "tractable.ai",
+    "wayflyer-anz-market-entry": "wayflyer.com",
+
+    # UK case studies
+    "banked-anz-market-entry": "banked.com",
+    "blue-prism-anz-market-entry": "blueprism.com",
+    "complyadvantage-anz-market-entry": "complyadvantage.com",
+    "contino-anz-market-entry": "contino.io",
+    "darktrace-anz-market-entry": "darktrace.com",
+    "deliveroo-anz-market-entry": "deliveroo.co.uk",
+    "dext-anz-market-entry": "dext.com",
+    "featurespace-anz-market-entry": "featurespace.com",
+    "mimecast-anz-market-entry": "mimecast.com",
+    "ncc-group-anz-market-entry": "nccgroup.com",
+    "nplan-anz-market-entry": "nplan.io",
+    "onfido-anz-market-entry": "onfido.com",
+    "quantexa-anz-market-entry": "quantexa.com",
+    "revolut-anz-market-entry": "revolut.com",
+    "sensat-anz-market-entry": "sensat.co",
+    "thought-machine-anz-market-entry": "thoughtmachine.net",
+    "wise-anz-market-entry": "wise.com",
+
+    # Singapore case studies
+    "comfortdelgro-anz-market-entry": "comfortdelgro.com",
+    "nium-anz-market-entry": "nium.com",
+    "propertyguru-anz-market-entry": "propertyguru.com",
+    "secretlab-anz-market-entry": "secretlab.co",
+    "shopback-anz-market-entry": "shopback.com",
+}
+
+
+def logo_dev_url(domain: str, size: int = LOGO_SIZE) -> str:
+    return f"https://img.logo.dev/{domain}?token={LOGO_DEV_TOKEN}&size={size}&format=png"
+
+
+def website_url(domain: str) -> str:
+    return f"https://{domain}"
+
+
+def validate_domain(domain: str) -> dict:
+    """Hit logo.dev with `?fallback=404` to cleanly detect whether the domain
+    has a real logo (200) vs nothing (404). Logo.dev's default is to generate
+    a monogram avatar for unknown domains; the `fallback=404` parameter makes
+    that explicit."""
+    url = f"https://img.logo.dev/{domain}?token={LOGO_DEV_TOKEN}&size=64&format=png&fallback=404"
+    for attempt in range(2):
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                content = resp.read()
+                return {
+                    "url": url,
+                    "status": resp.status,
+                    "size_bytes": len(content),
+                    "looks_real": True,
+                }
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                return {"url": url, "status": 404, "looks_real": False}
+            return {"url": url, "status": e.code, "error": str(e), "looks_real": False}
+        except Exception as e:
+            if attempt == 0:
+                continue
+            return {"url": url, "status": "error", "error": str(e), "looks_real": False}
+    return {"url": url, "status": "error", "looks_real": False}
+
+
+def main() -> None:
+    cases = json.loads(INPUT_PATH.read_text())
+    print(f"{'slug':50s} {'domain':25s} {'size':>7s}  real?")
+    print("-" * 90)
+    out_rows = []
+    missing_slugs = []
+    for c in cases:
+        slug = c["slug"]
+        domain = SLUG_TO_DOMAIN.get(slug)
+        if not domain:
+            missing_slugs.append(slug)
+            print(f"{slug:50s} (NO MAPPING)")
+            continue
+        check = validate_domain(domain)
+        out_rows.append({
+            "slug": slug,
+            "company_name": c["company_name"],
+            "domain": domain,
+            "website": website_url(domain),
+            "company_logo": logo_dev_url(domain),
+            "validation": check,
+        })
+        size = check.get("size_bytes", 0)
+        real = "✓" if check.get("looks_real") else "✗"
+        print(f"{slug:50s} {domain:25s} {size:>7d}  {real}")
+
+    if missing_slugs:
+        print()
+        print("WARNING — unmapped slugs:", missing_slugs)
+        raise SystemExit(1)
+
+    OUT_JSON.write_text(json.dumps(out_rows, indent=2) + "\n")
+    print()
+    print(f"Wrote {len(out_rows)} rows to {OUT_JSON}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cases_missing_logos_input.json
+++ b/scripts/cases_missing_logos_input.json
@@ -1,0 +1,1164 @@
+[
+  {
+    "slug": "airbnb-australia-market-entry",
+    "company_name": "Airbnb",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://news.airbnb.com/en-au/oxford-economics-report-reveals-airbnbs-20-3-billion-impact-in-australia/"
+    ],
+    "all_source_urls": [
+      "https://news.airbnb.com/en-au/new-country-manager-to-lead-airbnbs-australia-new-zealand-team/",
+      "https://news.airbnb.com/en-au/oxford-economics-report-reveals-airbnbs-20-3-billion-impact-in-australia/",
+      "https://news.airbnb.com/wp-content/uploads/sites/4/2017/07/Economic-effects-of-Airbnb_Australia_Web.pdf",
+      "https://www.airbnb.com.au/press/news/airbnb-appoints-sam-mcdonagh-as-country-manager-for-australia-and-new-zealand",
+      "https://www.ato.gov.au/businesses-and-organisations/preparing-lodging-and-paying/third-party-reporting/sharing-economy-reporting-regime",
+      "https://www.hotelmanagement.com.au/2018/06/06/nsw-government-imposes-180-night-cap-on-short-term-letting-in-sydney/",
+      "https://www.nsw.gov.au/media-releases/changes-to-byron-bay-short-term-rental-rules",
+      "https://www.parliament.vic.gov.au/news/economy/short-stay-levy/",
+      "https://www.planning.nsw.gov.au/News/2018/Short-term-holiday-letting-plan-a-win-win",
+      "https://www.sro.vic.gov.au/owning-property/short-stay-levy/understanding-short-stay-levy"
+    ]
+  },
+  {
+    "slug": "amazon-australia-ecommerce-entry",
+    "company_name": "Amazon.com",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://www.aboutamazon.com.au/news/company-news/amazon-australia-announces-matt-benham-as-new-country-manager",
+      "https://www.aboutamazon.com.au/workplace/facilities"
+    ],
+    "all_source_urls": [
+      "https://amazonau.gcs-web.com/news-releases/news-release-details/amazon-australia-announces-new-fulfilment-centre-brisbane-enable",
+      "https://amazonau.gcs-web.com/news-releases/news-release-details/amazon-australias-first-robotics-fulfilment-centre-western/",
+      "https://amazonau.gcs-web.com/news-releases/news-release-details/amazon-launches-its-retail-offering-australia-fast-convenient/",
+      "https://amazonau.gcs-web.com/news-releases/news-release-details/amazon-launches-prime-australia-offering-free-delivery-fast-two/",
+      "https://insideretail.com.au/business/this-cant-just-be-womens-work-amazon-australia-boss-janet-menzies-202303",
+      "https://insideretail.com.au/news/amazon-country-manager-rocco-braeuniger-to-depart-201908",
+      "https://www.aboutamazon.com.au/news/company-news/amazon-australia-announces-matt-benham-as-new-country-manager",
+      "https://www.aboutamazon.com.au/workplace/facilities",
+      "https://www.cnbc.com/2017/12/05/amazon-finally-launched-in-australia--and-other-retailers-immediately-rallied.html"
+    ]
+  },
+  {
+    "slug": "anna-money-anz-market-entry",
+    "company_name": "ANNA Money",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://anna.money/",
+      "https://anna.money/blog/",
+      "https://www.getcape.com/",
+      "https://anna.money/blog/updates/anna-acquires-getcape-in-australia/"
+    ],
+    "all_source_urls": [
+      "https://anna.money/",
+      "https://anna.money/blog/",
+      "https://anna.money/blog/updates/anna-acquires-getcape-in-australia/",
+      "https://newshub.medianet.com.au/2024/03/uk-fintech-anna-money-expands-into-australia-with-acquisition-of-getcape/41061/",
+      "https://techcrunch.com/",
+      "https://www.abs.gov.au/",
+      "https://www.afr.com/",
+      "https://www.finextra.com/",
+      "https://www.finextra.com/pressarticle/100024/uk-fintech-anna-money-acquires-sydney-based-getcape",
+      "https://www.fintechfutures.com/",
+      "https://www.getcape.com/"
+    ]
+  },
+  {
+    "slug": "anthropic-australia-market-entry",
+    "company_name": "Anthropic",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://www.anthropic.com/news/sydney-fourth-office-asia-pacific"
+    ],
+    "all_source_urls": [
+      "https://aws.amazon.com/about-aws/whats-new/2025/02/anthropics-upgraded-claude-3-5-sonnet-sydney-region/",
+      "https://itbrief.com.au/story/anthropic-opens-sydney-office-names-nz-australia-chief",
+      "https://mumbrella.com.au/anthropic-appoints-gm-for-anz-and-opens-sydney-office-921617",
+      "https://www.anthropic.com/news/australia-MOU",
+      "https://www.anthropic.com/news/sydney-fourth-office-asia-pacific",
+      "https://www.anthropic.com/news/theo-hourmouzis-general-manager-australia-new-zealand",
+      "https://www.arnnet.com.au/article/4163981/anthropic-opens-in-sydney-with-theo-hourmouzis-at-the-helm.html",
+      "https://www.edtechinnovationhub.com/news/anthropic-touches-down-in-sydney-with-former-snowflake-vp-theo-hourmouzis-at-the-helm",
+      "https://www.industry.gov.au/news/australian-government-has-signed-memorandum-understanding-mou-global-ai-innovator-anthropic",
+      "https://www.marketing-interactive.com/anthropic-appoints-theo-hourmouzis-to-lead-anz-as-sydney-office-officially-opens"
+    ]
+  },
+  {
+    "slug": "aws-australia-market-entry",
+    "company_name": "Amazon Web Services (AWS)",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://aws.amazon.com/blogs/aws/now-open-aws-asia-pacific-melbourne-region-in-australia/",
+      "https://aws.amazon.com/about-aws/whats-new/2012/11/12/announcing-the-aws-asia-pacific-sydney-region/",
+      "https://www.allthingsdistributed.com/2012/11/asia-pacifc-sydney-region.html",
+      "https://aws.amazon.com/local/australia/"
+    ],
+    "all_source_urls": [
+      "https://aws.amazon.com/about-aws/whats-new/2012/11/12/announcing-the-aws-asia-pacific-sydney-region/",
+      "https://aws.amazon.com/blogs/aws/now-open-aws-asia-pacific-melbourne-region-in-australia/",
+      "https://aws.amazon.com/local/australia/",
+      "https://breakingdefense.com/2024/07/2-billion-aud-deal-for-top-secret-aussie-cloud-with-aws/",
+      "https://international.austrade.gov.au/en/news-and-analysis/news/aws-to-invest-13-2-billion-aud-in-cloud-infrastructure-in-australia",
+      "https://press.aboutamazon.com/2023/1/aws-launches-second-infrastructure-region-in-australia",
+      "https://www.aboutamazon.com.au/aws-launches-aws-region-in-melbourne-invests-6-8-billion-by-2037",
+      "https://www.aboutamazon.com/news/aws/amazon-data-center-investment-in-australia",
+      "https://www.allthingsdistributed.com/2012/11/asia-pacifc-sydney-region.html"
+    ]
+  },
+  {
+    "slug": "banked-anz-market-entry",
+    "company_name": "Banked",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://banked.com/news/",
+      "https://banked.com/",
+      "https://www.auspayplus.com.au/"
+    ],
+    "all_source_urls": [
+      "https://banked.com/",
+      "https://banked.com/news/",
+      "https://news.nab.com.au/",
+      "https://paymentsindustryintelligence.com/nab-launch-pay-by-bank-in-australia/",
+      "https://thedigitalbanker.com/banked-and-nab-join-hands-to-accelerate-pay-by-bank-adoption-in-australia/",
+      "https://www.auspayplus.com.au/",
+      "https://www.finextra.com/",
+      "https://www.itnews.com.au/news/nab-aims-to-fast-track-merchant-payments-607764",
+      "https://www.paymentscardsandmobile.com/",
+      "https://www.rba.gov.au/"
+    ]
+  },
+  {
+    "slug": "blue-prism-anz-market-entry",
+    "company_name": "Blue Prism",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://www.blueprism.com/resources/",
+      "https://www.blueprism.com/",
+      "https://www.ssctech.com/about/news",
+      "https://www.telstra.com.au/",
+      "https://www.infosys.com/",
+      "https://www.infosys.com/about/alliances/blue-prism.html",
+      "https://www.infosys.com/newsroom/press-releases/2021/delivering-intelligent-automation-based-solutions-awards2021.html"
+    ],
+    "all_source_urls": [
+      "https://www.arnnet.com.au/article/1265281/5-uk-tech-providers-ploughed-130m-into-australia-during-2017.html",
+      "https://www.austrade.gov.au/",
+      "https://www.blueprism.com/",
+      "https://www.blueprism.com/resources/",
+      "https://www.consultancy.com.au/news/3833/infosys-wins-global-award-for-cx-automation-project-with-telstra",
+      "https://www.infosys.com/",
+      "https://www.infosys.com/about/alliances/blue-prism.html",
+      "https://www.infosys.com/newsroom/press-releases/2021/delivering-intelligent-automation-based-solutions-awards2021.html",
+      "https://www.itnews.com.au/",
+      "https://www.ssctech.com/about/news",
+      "https://www.telstra.com.au/"
+    ]
+  },
+  {
+    "slug": "clanwilliam-anz-market-entry",
+    "company_name": "Clanwilliam",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://www.minterellison.com/articles/minterellison-advises-clanwilliam-on-telstra-health-acquisition",
+      "https://www.telstrahealth.com/healthlink-acquires-telstra-health-argus-connecting-care-and-ereferrals-business/",
+      "https://www.waterman.co.nz/news/healthlink-acquired-by-global-healthcare-technology-specialist/",
+      "https://www.healthlink.com.au/clanwilliams-healthlink-acquires-telstra-healths-argus-connecting-care-and-ereferrals-business/"
+    ],
+    "all_source_urls": [
+      "https://insurtechnz.org.nz/2024/03/12/clanwilliam-launches-anz-division-in-a-commitment-to-the-future-of-healthcare-across-australia-and-new-zealand/",
+      "https://www.healthlink.com.au/clanwilliams-healthlink-acquires-telstra-healths-argus-connecting-care-and-ereferrals-business/",
+      "https://www.minterellison.com/articles/minterellison-advises-clanwilliam-on-telstra-health-acquisition",
+      "https://www.pulseit.news/australian-digital-health/healthlink-swoops-on-telstra-healths-secure-messaging-and-ereferrals-business/",
+      "https://www.telstrahealth.com/healthlink-acquires-telstra-health-argus-connecting-care-and-ereferrals-business/",
+      "https://www.waterman.co.nz/news/healthlink-acquired-by-global-healthcare-technology-specialist/"
+    ]
+  },
+  {
+    "slug": "comfortdelgro-anz-market-entry",
+    "company_name": "ComfortDelGro",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://www.comfortdelgro.com/news/a2b-australia-shareholders-approve-comfortdelgros-acquisition-proposal/",
+      "https://www.comfortdelgro.com/wp-content/uploads/2024/04/Media-Release-ComfortDelGro-Australia-completes-A2B-Australia-Acquisition.pdf"
+    ],
+    "all_source_urls": [
+      "https://www.comfortdelgro.com/news/a2b-australia-shareholders-approve-comfortdelgros-acquisition-proposal/",
+      "https://www.comfortdelgro.com/wp-content/uploads/2024/04/Media-Release-ComfortDelGro-Australia-completes-A2B-Australia-Acquisition.pdf",
+      "https://www.straitstimes.com/business/companies-markets/comfortdelgro-to-fully-acquire-taxi-network-operator-a2b-australia-for-1"
+    ]
+  },
+  {
+    "slug": "complyadvantage-anz-market-entry",
+    "company_name": "ComplyAdvantage",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://complyadvantage.com/insights/",
+      "https://complyadvantage.com/",
+      "https://complyadvantage.com/insights/tranche-2-aml-reforms/",
+      "https://complyadvantage.com/insights/australian-aml-cft-regulatory-framework/"
+    ],
+    "all_source_urls": [
+      "https://complyadvantage.com/",
+      "https://complyadvantage.com/insights/",
+      "https://complyadvantage.com/insights/australian-aml-cft-regulatory-framework/",
+      "https://complyadvantage.com/insights/tranche-2-aml-reforms/",
+      "https://techcrunch.com/",
+      "https://www.afr.com/",
+      "https://www.ag.gov.au/",
+      "https://www.austrac.gov.au/",
+      "https://www.fintechaustralia.org.au/",
+      "https://www.linkedin.com/posts/complyadvantage_tranche-2-amlcft-reforms-land-1-activity-7430431069931200512-jpNF"
+    ]
+  },
+  {
+    "slug": "contino-anz-market-entry",
+    "company_name": "Contino",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://news.cognizant.com/",
+      "https://www.nebulr.com.au/",
+      "https://www.contino.io/insights/contino-acquires-australian-devops-leaders-nebulr-to-accelerate-growth-in-apac-region",
+      "https://www.contino.io/case-studies"
+    ],
+    "all_source_urls": [
+      "https://aws.amazon.com/partners/",
+      "https://news.cognizant.com/",
+      "https://www.arnnet.com.au/article/1266156/contino-steps-up-australian-play-with-nebulr-acquisition.html",
+      "https://www.businesswire.com/",
+      "https://www.contino.io/case-studies",
+      "https://www.contino.io/insights/contino-acquires-australian-devops-leaders-nebulr-to-accelerate-growth-in-apac-region",
+      "https://www.itnews.com.au/",
+      "https://www.nebulr.com.au/"
+    ]
+  },
+  {
+    "slug": "daon-anz-market-entry",
+    "company_name": "Daon",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://www.daon.com/industry/public-sector/"
+    ],
+    "all_source_urls": [
+      "http://www.staroceans.org/wiki/A/Daon,_Inc.",
+      "https://alchetron.com/Daon,-Inc.",
+      "https://ciobulletin.com/magazine/profile/innovate-while-you-authenticate-daon-inc",
+      "https://en.wikipedia.org/wiki/Daon,_Inc.",
+      "https://identityweek.net/daon-chosen-for-nz-govts-realme-now-app/",
+      "https://securitybrief.com.au/story/daon-s-xsentinel-tackles-synthetic-audio-threats-through-real-time-detection",
+      "https://theorg.com/org/daon/org-chart/craig-katz",
+      "https://theorg.com/org/daon/org-chart/john-duggan",
+      "https://www.biometricupdate.com/201808/daon-provides-biometric-onboarding-for-new-zealand-government-backed-mobile-credential",
+      "https://www.biometricupdate.com/202311/daon-wins-contract-to-provide-face-biometrics-for-nz-social-benefits",
+      "https://www.daon.com/industry/public-sector/",
+      "https://www.dia.govt.nz/Regulatory-Stewardship---Identity-and-Passports",
+      "https://www.highperformr.ai/company/daon",
+      "https://www.wikiwand.com/en/articles/Daon,_Inc."
+    ]
+  },
+  {
+    "slug": "darktrace-anz-market-entry",
+    "company_name": "Darktrace",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://darktrace.com/news",
+      "https://darktrace.com/company/investors",
+      "https://darktrace.com/customers",
+      "https://www.darktrace.com/news/darktrace-expands-in-australia-as-demand-for-self-learning-ai-surges",
+      "https://www.darktrace.com/news/darktrace-expands-in-australia-as-customer-demand-soars"
+    ],
+    "all_source_urls": [
+      "https://darktrace.com/company/investors",
+      "https://darktrace.com/customers",
+      "https://darktrace.com/news",
+      "https://www.crn.com.au/",
+      "https://www.cyber.gov.au/",
+      "https://www.darktrace.com/news/darktrace-expands-in-australia-as-customer-demand-soars",
+      "https://www.darktrace.com/news/darktrace-expands-in-australia-as-demand-for-self-learning-ai-surges",
+      "https://www.itnews.com.au/",
+      "https://www.oaic.gov.au/",
+      "https://www.technologydecisions.com.au/content/security/news/darktrace-expands-aussie-presence-following-60-yoy-growth-1528659210"
+    ]
+  },
+  {
+    "slug": "databricks-australia-market-entry",
+    "company_name": "Databricks",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://www.databricks.com/customers/tabcorp",
+      "https://www.databricks.com/customers/atlassian/security-lakehouse"
+    ],
+    "all_source_urls": [
+      "https://docs.databricks.com/aws/en/resources/supported-regions",
+      "https://itbrief.com.au/story/databricks-accelerates-apj-expansion-following-250-million-funding-round",
+      "https://www.arnnet.com.au/article/668514/databricks-hires-tenable-bede-hackney-new-nz-leader/",
+      "https://www.databricks.com/company/newsroom/press-releases/databricks-announces-appointment-adam-beavis-head-australia-and-new",
+      "https://www.databricks.com/company/newsroom/press-releases/databricks-deepens-leadership-bench-across-asia-pacific-and-japan",
+      "https://www.databricks.com/company/newsroom/press-releases/databricks-doubles-anz-headcount-signalling-growing-demand",
+      "https://www.databricks.com/company/newsroom/press-releases/databricks-momentum-continues-anz-organisations-demand-more-ai-data",
+      "https://www.databricks.com/company/newsroom/press-releases/databricks-sees-over-70-annual-growth-anz-market-enterprise-ai",
+      "https://www.databricks.com/customers/atlassian/security-lakehouse",
+      "https://www.databricks.com/customers/tabcorp"
+    ]
+  },
+  {
+    "slug": "daxtra-technologies-anz-market-entry",
+    "company_name": "DaXtra Technologies",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://www.daxtra.com/",
+      "https://www.daxtra.com/news/",
+      "https://nucleusresearch.com/",
+      "https://www.peoplebank.com.au/",
+      "https://www.jobadder.com/",
+      "https://info.daxtra.com/blog/2010/06/20/australia-now-benefits-from-daxtra-parsing",
+      "https://www.daxtra.com/testimonials/"
+    ],
+    "all_source_urls": [
+      "https://info.daxtra.com/blog/2010/06/20/australia-now-benefits-from-daxtra-parsing",
+      "https://nucleusresearch.com/",
+      "https://www.benzinga.com/pressreleases/24/10/g41569699/daxtra-named-an-accelerator-in-nucleus-researchs-2024-standalone-talent-acquisition-technology-val",
+      "https://www.daxtra.com/",
+      "https://www.daxtra.com/news/",
+      "https://www.daxtra.com/testimonials/",
+      "https://www.jobadder.com/",
+      "https://www.peoplebank.com.au/",
+      "https://www.recruitmentnews.com.au/"
+    ]
+  },
+  {
+    "slug": "deliveroo-anz-market-entry",
+    "company_name": "Deliveroo",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://corporate.deliveroo.co.uk/media-centre/",
+      "https://about.doordash.com/",
+      "https://corporate.deliveroo.co.uk/",
+      "https://kordamentha.com/",
+      "https://corporate.deliveroo.co.uk/investors/news/deliveroo-announces-decision-end-operations-australia/"
+    ],
+    "all_source_urls": [
+      "https://about.doordash.com/",
+      "https://corporate.deliveroo.co.uk/",
+      "https://corporate.deliveroo.co.uk/investors/news/deliveroo-announces-decision-end-operations-australia/",
+      "https://corporate.deliveroo.co.uk/media-centre/",
+      "https://en.wikipedia.org/wiki/Deliveroo",
+      "https://ia.acs.org.au/article/2022/deliveroo-shuts-down-in-australia.html",
+      "https://kordamentha.com/",
+      "https://www.abc.net.au/news",
+      "https://www.afr.com/",
+      "https://www.indailyqld.com.au/news/archive/2022/11/17/thousands-out-of-work-as-delivery-pioneer-folds-its-tent-and-closes",
+      "https://www.smartcompany.com.au/"
+    ]
+  },
+  {
+    "slug": "dext-anz-market-entry",
+    "company_name": "Dext",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://dext.com/en/news/",
+      "https://dext.com/",
+      "https://apps.xero.com/",
+      "https://www.xero.com/",
+      "https://www.xero.com/events/",
+      "https://dext.com/en/blog/single/transforming-the-accounting-industry-a-xerocon-to-remember"
+    ],
+    "all_source_urls": [
+      "https://apps.xero.com/",
+      "https://dext.com/",
+      "https://dext.com/en/blog/single/transforming-the-accounting-industry-a-xerocon-to-remember",
+      "https://dext.com/en/news/",
+      "https://www.canadian-accountant.com/content/technology/receipt-bank-passes-1-million-users",
+      "https://www.scalesuite.com.au/resources/xero-market-share-australian-businesses",
+      "https://www.xero.com/",
+      "https://www.xero.com/events/"
+    ]
+  },
+  {
+    "slug": "docusign-australia-market-entry",
+    "company_name": "DocuSign",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://www.docusign.com/en-au/customer-stories/docusign-helps-cba-accelerate-its-digital-strategy",
+      "https://www.docusign.com/en-au/blog/esignatures-a-compelling-opportunity-for-the-australian-government"
+    ],
+    "all_source_urls": [
+      "http://telecomtimes.com.au/files/2018/06/17/docusign-steps-up-australian-market-play-flags-first-local-dcs-confirms-sydney-as-apac-hq/",
+      "https://idm.net.au/article/009760-docusign-heads-downunder",
+      "https://itbrief.com.au/story/docusign-launches-three-new-data-centre-locations-australia",
+      "https://www.arnnet.com.au/article/686528/docusign-brad-newton-takes-over-head-cohesity-nz/",
+      "https://www.cohesity.com/newsroom/press/cohesity-appoints-brad-newton-as-head-of-australia-and-new-zealand/",
+      "https://www.docusign.com/en-au/blog/esignatures-a-compelling-opportunity-for-the-australian-government",
+      "https://www.docusign.com/en-au/customer-stories/docusign-helps-cba-accelerate-its-digital-strategy",
+      "https://www.govtechreview.com.au/content/gov-datacentre/news/docusign-launches-australian-data-centres-730674429",
+      "https://www.itnews.com.au/news/cba-targets-docusign-for-all-its-commercial-loans-578621",
+      "https://www.prnewswire.com/apac/news-releases/docusign-plans-australian-data-centre-answering-national-push-for-digital-sovereignty-and-data-security-302528681.html"
+    ]
+  },
+  {
+    "slug": "featurespace-anz-market-entry",
+    "company_name": "Featurespace",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://www.featurespace.com/newsroom/",
+      "https://www.featurespace.com/customers/",
+      "https://www.auspayplus.com.au/",
+      "https://www.featurespace.com/",
+      "https://www.featurespace.com/newsroom/eftpos-flicks-the-switch-on-world-class-ai-anti-fraud-technology"
+    ],
+    "all_source_urls": [
+      "https://australiancybersecuritymagazine.com.au/eftpos-taps-into-ai-anti-fraud-technology/",
+      "https://ecommercenews.com.au/story/ai-driven-counter-fraud-platform-utilised-by-eftpos-to-help-prevent-cybercrime",
+      "https://via.ritzau.dk/pressemeddelelse/13655463/featurespace?publisherId=90456",
+      "https://www.anu.edu.au/",
+      "https://www.auspayplus.com.au/",
+      "https://www.featurespace.com/",
+      "https://www.featurespace.com/customers/",
+      "https://www.featurespace.com/newsroom/",
+      "https://www.featurespace.com/newsroom/eftpos-flicks-the-switch-on-world-class-ai-anti-fraud-technology",
+      "https://www.finextra.com/newsarticle/38599/australias-eftpos-boosts-online-payment-security",
+      "https://www.hsbc.com/news-and-media",
+      "https://www.linkedin.com/company/featurespace/",
+      "https://www.paymentscardsandmobile.com/",
+      "https://www.technologydecisions.com.au/content/security/news/eftpos-using-ai-to-fight-online-shopping-fraud-303249929"
+    ]
+  },
+  {
+    "slug": "fenergo-anz-market-entry",
+    "company_name": "Fenergo",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://resources.fenergo.com/newsroom/fenergo-profits-almost-double-as-irish-fintech-continues-to-expand",
+      "https://resources.fenergo.com/newsroom/fenergo-expands-operations-to-apac-to-solve-regulatory-pressures",
+      "https://resources.fenergo.com/newsroom/fenergo-selected-by-4-of-the-largest-australian-banks"
+    ],
+    "all_source_urls": [
+      "https://builtinsydney.au/company/fenergo",
+      "https://canvasbusinessmodel.com/blogs/brief-history/fenergo-brief-history",
+      "https://resources.fenergo.com/newsroom/fenergo-expands-operations-to-apac-to-solve-regulatory-pressures",
+      "https://resources.fenergo.com/newsroom/fenergo-profits-almost-double-as-irish-fintech-continues-to-expand",
+      "https://resources.fenergo.com/newsroom/fenergo-selected-by-4-of-the-largest-australian-banks",
+      "https://www.canstar.com.au/home-loans/compare-the-big-four-banks-in-australia/",
+      "https://www.digital-first.com.au/insights/regulatory-compliance-in-a-modern-digital-landscape-the-challenges-and-the-solutions/",
+      "https://www.finews.asia/finance/33874-fenergo-boosts-apac-presence-amid-growing-regtech-demand",
+      "https://www.finextra.com/pressarticle/71063/fenergo-selected-by-four-of-australias-top-five-banks"
+    ]
+  },
+  {
+    "slug": "fexco-anz-market-entry",
+    "company_name": "Fexco",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://www.fexco.com/news-and-insights/fexco-expands-global-presence-with-launch-of-two-new-no1-currency-stores-in-sydney-australia/",
+      "https://www.fexco.com"
+    ],
+    "all_source_urls": [
+      "https://nz.linkedin.com/company/fexco-pacific-ltd",
+      "https://www.fexco.com",
+      "https://www.fexco.com/news-and-insights/fexco-expands-global-presence-with-launch-of-two-new-no1-currency-stores-in-sydney-australia/"
+    ]
+  },
+  {
+    "slug": "fineos-anz-market-entry",
+    "company_name": "FINEOS",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://www.fineos.com/2020/01/09/fineos-an-industry-leader-driven-by-innovation/",
+      "https://www.fineos.com/clients/acc-3/",
+      "https://www.fineos.com/blog/expansion-anz-fineos-sponsors-salesforce-world-tour/",
+      "https://www.fineos.com/2017/03/16/fineos-sequential-announce-strategic-partnership-anz/",
+      "https://www.fineos.com/2019/08/16/fineos-lists-on-the-australian-securities-exchange/"
+    ],
+    "all_source_urls": [
+      "https://matrixbcg.com/blogs/brief-history/fineos",
+      "https://matrixbcg.com/blogs/growth-strategy/fineos",
+      "https://www.fineos.com/2017/03/16/fineos-sequential-announce-strategic-partnership-anz/",
+      "https://www.fineos.com/2019/08/16/fineos-lists-on-the-australian-securities-exchange/",
+      "https://www.fineos.com/2020/01/09/fineos-an-industry-leader-driven-by-innovation/",
+      "https://www.fineos.com/blog/expansion-anz-fineos-sponsors-salesforce-world-tour/",
+      "https://www.fineos.com/clients/acc-3/",
+      "https://www.finextra.com/pressarticle/3144/fineos-wins-nz39m-accident-compensation-corporation-contract",
+      "https://www.insurancebusinessmag.com/au/guides/the-top-5-life-insurance-companies-in-australia-440994.aspx",
+      "https://www.reuters.com/article/business/irish-fintech-fineos-asxs-biggest-ipo-this-year-opens-higher-on-debut-idUSKCN1V6075/",
+      "https://www.techmonitor.ai/technology/fineos_streamlines_claims_management_for_acc"
+    ]
+  },
+  {
+    "slug": "github-australia-market-entry",
+    "company_name": "GitHub",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://github.blog/changelog/2025-02-04-github-enterprise-cloud-data-residency-in-australia-is-generally-available/",
+      "https://github.com/customer-stories/rea-group",
+      "https://developer.microsoft.com/en-us/reactor/events/21150/"
+    ],
+    "all_source_urls": [
+      "https://arxiv.org/abs/2402.05636",
+      "https://developer.microsoft.com/en-us/reactor/events/21150/",
+      "https://github.blog/changelog/2025-02-04-github-enterprise-cloud-data-residency-in-australia-is-generally-available/",
+      "https://github.com/customer-stories/rea-group",
+      "https://github.com/govau",
+      "https://github.com/newsroom/press-releases/data-residency-in-australia",
+      "https://itbrief.com.au/story/australia-13th-largest-user-of-open-source-in-the-world",
+      "https://www.itnews.com.au/news/anz-targets-3000-engineers-to-use-github-copilot-601195",
+      "https://www.sydney.edu.au/news-opinion/news/2017/10/20/first-university-in-australia-to-offer-code-development-software.html",
+      "https://www.theregister.com/2024/02/10/anz_bank_github_copilot/"
+    ]
+  },
+  {
+    "slug": "kyckr-anz-market-entry",
+    "company_name": "Kyckr",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": null,
+    "all_source_urls": [
+      "https://addisons.com/announcement/addisons-advises-kyckr-asx-kyk-on-its-acquisition-by-realwise/",
+      "https://en.wikipedia.org/wiki/Kyckr",
+      "https://finovate.com/category/kyckr/",
+      "https://fora.ie/kyckr-waterford-ipo-2968390-Sep2016/",
+      "https://in.marketscreener.com/quote/stock/KYCKR-LIMITED-27546659/news/Richard-White-completed-the-acquisition-of-the-remaining-77.24-stake-in-Kyckr-Limited-42171348/"
+    ]
+  },
+  {
+    "slug": "learnupon-anz-market-entry",
+    "company_name": "LearnUpon",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://www.learnupon.com/newsroom/learnupon-accelerates-apac-expansion/"
+    ],
+    "all_source_urls": [
+      "https://itbrief.com.au/story/learnupon-boosts-apac-growth-with-ai-course-platform",
+      "https://newshub.medianet.com.au/2026/03/learnupon-accelerates-apac-expansion-with-new-sydney-headquarters-and-ai-native-courseau/144128/",
+      "https://www.businesswire.com/news/home/20260129847362/en/LearnUpon-Ends-2025-With-Breakthrough-Growth-Product-Innovation-and-Global-Recognition",
+      "https://www.learnupon.com/newsroom/learnupon-accelerates-apac-expansion/",
+      "https://www.miragenews.com/learnupon-expands-apac-with-sydney-hq-ai-1637940/"
+    ]
+  },
+  {
+    "slug": "mimecast-anz-market-entry",
+    "company_name": "Mimecast",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://www.mimecast.com/company/news/",
+      "https://www.mimecast.com/partners/",
+      "https://www.permira.com/news-and-insights/",
+      "https://www.mimecast.com/"
+    ],
+    "all_source_urls": [
+      "https://channellife.co.nz/story/mimecast-s-top-a-nz-channel-partners-of-2019",
+      "https://channellife.com.au/story/mimecast-nz-names-top-partners-second-partner-awards",
+      "https://channellife.com.au/story/mimecast-takes-leap-nz-five-local-hires",
+      "https://www.arnnet.com.au/",
+      "https://www.arnnet.com.au/article/1261864/mimecast-honours-a-nz-partners-as-channel-investment-rises.html",
+      "https://www.crn.com.au/",
+      "https://www.mimecast.com/",
+      "https://www.mimecast.com/company/news/",
+      "https://www.mimecast.com/partners/",
+      "https://www.permira.com/news-and-insights/"
+    ]
+  },
+  {
+    "slug": "ncc-group-anz-market-entry",
+    "company_name": "NCC Group",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://www.nccgroup.com/us/newsroom/",
+      "https://www.nccgroup.com/",
+      "https://www.nccgroup.com/newsroom/ncc-group-inputs-into-next-phase-of-australia-s-cyber-security-strategy/"
+    ],
+    "all_source_urls": [
+      "https://en.wikipedia.org/wiki/NCC_Group",
+      "https://www.arnnet.com.au/article/1265281/5-uk-tech-providers-ploughed-130m-into-australia-during-2017.html",
+      "https://www.austrade.gov.au/",
+      "https://www.cyber.gov.au/",
+      "https://www.homeaffairs.gov.au/",
+      "https://www.londonstockexchange.com/",
+      "https://www.nccgroup.com/",
+      "https://www.nccgroup.com/newsroom/ncc-group-inputs-into-next-phase-of-australia-s-cyber-security-strategy/",
+      "https://www.nccgroup.com/us/newsroom/"
+    ]
+  },
+  {
+    "slug": "nium-anz-market-entry",
+    "company_name": "Nium",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://www.nium.com/newsroom/nium-registered-financial-service-provider-in-new-zealand"
+    ],
+    "all_source_urls": [
+      "https://ibsintelligence.com/ibsi-news/nium-approved-as-a-registered-financial-service-provider-in-new-zealand/",
+      "https://www.nium.com/newsroom/nium-registered-financial-service-provider-in-new-zealand",
+      "https://www.prnewswire.com/news-releases/nium-approved-as-a-registered-financial-service-provider-in-new-zealand-302117055.html"
+    ]
+  },
+  {
+    "slug": "nplan-anz-market-entry",
+    "company_name": "nPlan",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://www.nplan.io/news",
+      "https://www.nplan.io/",
+      "https://www.nplan.io/press-releases/nplan-raises-16m-series-b-to-scale-its-ai-led-transformation-of-capital-project-delivery",
+      "https://www.nplan.io/press-releases/spark-nel-ignites-ai-partnership-with-nplan-to-assure-and-de-risk-victorias-largest-highways-project"
+    ],
+    "all_source_urls": [
+      "https://bigbuild.vic.gov.au/",
+      "https://bigbuild.vic.gov.au/projects/north-east-link-program",
+      "https://www.globalconstructionreview.com/melbournes-11bn-north-east-link-project-adopts-nplans-ai-planning-tools/",
+      "https://www.infrastructureaustralia.gov.au/",
+      "https://www.nplan.io/",
+      "https://www.nplan.io/news",
+      "https://www.nplan.io/press-releases/nplan-raises-16m-series-b-to-scale-its-ai-led-transformation-of-capital-project-delivery",
+      "https://www.nplan.io/press-releases/spark-nel-ignites-ai-partnership-with-nplan-to-assure-and-de-risk-victorias-largest-highways-project"
+    ]
+  },
+  {
+    "slug": "onfido-anz-market-entry",
+    "company_name": "Onfido",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://onfido.com/resources/",
+      "https://onfido.com/",
+      "https://www.entrust.com/company/newsroom",
+      "https://onfido.com/customers/",
+      "https://www.revolut.com/en-AU/news/",
+      "https://blog.voveid.com/onfido-alternative-vove-id-vs-onfido-for-emerging-market-fintechs/"
+    ],
+    "all_source_urls": [
+      "https://asic.gov.au/",
+      "https://blog.voveid.com/onfido-alternative-vove-id-vs-onfido-for-emerging-market-fintechs/",
+      "https://cfotech.com.au/story/revolut-hits-1m-aussie-users-plans-aud-400m-push",
+      "https://fintechmagazine.com/fraud-id-verification/onfido-global-leader-in-id-verification",
+      "https://onfido.com/",
+      "https://onfido.com/customers/",
+      "https://onfido.com/resources/",
+      "https://www.austrac.gov.au/",
+      "https://www.entrust.com/company/newsroom",
+      "https://www.revolut.com/en-AU/news/"
+    ]
+  },
+  {
+    "slug": "openai-australia-market-entry",
+    "company_name": "OpenAI",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://openai.com/global-affairs/openai-for-australia/"
+    ],
+    "all_source_urls": [
+      "https://channellife.com.au/story/openai-hires-brent-thomas-to-lead-public-policy-in-anz",
+      "https://ia.acs.org.au/article/2025/openai--nextdc-ink--7b-australian-data-centre-deal.html",
+      "https://openai.com/global-affairs/openai-for-australia/",
+      "https://www.bandt.com.au/openai-opens-first-australian-office/",
+      "https://www.commbank.com.au/articles/newsroom/2025/08/tech-ai-partnership.html",
+      "https://www.marketing-interactive.com/openai-opens-first-australian-office-local-leadership-details-under-wraps",
+      "https://www.marketing-interactive.com/openai-to-open-sydney-office-as-chatgpt-adoption-surges",
+      "https://www.nextdc.com/news/building-the-next-generation-of-sovereign-ai-infrastructure-in-australia",
+      "https://www.nsw.gov.au/ministerial-releases/minns-labor-government-welcomes-openais-investment-to-nsw",
+      "https://www.smartcompany.com.au/artificial-intelligence/openai-australia-startup-program-sydney-office/"
+    ]
+  },
+  {
+    "slug": "palantir-australia-market-entry",
+    "company_name": "Palantir Technologies",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": null,
+    "all_source_urls": [
+      "https://investors.palantir.com/news-details/2025/Palantir-Achieves-Information-Security-Registered-Assessors-Program-IRAP-PROTECTED-Level-Unlocking-New-Opportunities-in-Australia/",
+      "https://michaelwest.com.au/we-kill-enemies-spy-firm-palantir-secures-top-australian-security-clearance/",
+      "https://www.australiandefence.com.au/defence/cyber-space/eos-and-palantir-australia-partner-on-space-operations-exercise",
+      "https://www.canberratimes.com.au/story/6752504/mike-kelly-defends-new-role-with-palantir-after-quitting-parliament-due-to-health-issues/",
+      "https://www.canberratimes.com.au/story/6753280/who-is-palantir-the-us-tech-company-mike-kelly-now-works-for/",
+      "https://www.canberratimes.com.au/story/9178631/defence-awards-palantir-76m-defence-contract/",
+      "https://www.canberratimes.com.au/story/9231465/austrac-awards-palantir-506m-deal-in-non-competitive-tender/",
+      "https://www.crikey.com.au/2026/02/17/australian-defence-department-palantir-biggest-ever-contract/",
+      "https://www.crikey.com.au/2026/04/27/palantir-australia-manual-gotham-intelligence-agency-acic/",
+      "https://www.tenders.gov.au/Cn/Show/abce7d48-265e-4b3c-aa77-7fbc197e84f2"
+    ]
+  },
+  {
+    "slug": "propertyguru-anz-market-entry",
+    "company_name": "PropertyGuru",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": null,
+    "all_source_urls": [
+      "https://announcements.asx.com.au/asxpdf/20240816/pdf/066psw9tn13xtw.pdf",
+      "https://en.wikipedia.org/wiki/REA_Group",
+      "https://www.onlinemarketplaces.com/articles/propertyguru-completes-iproperty-deal/"
+    ]
+  },
+  {
+    "slug": "quantexa-anz-market-entry",
+    "company_name": "Quantexa",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://www.quantexa.com/newsroom/",
+      "https://www.quantexa.com/customers/",
+      "https://www.quantexa.com/solutions/financial-crime/"
+    ],
+    "all_source_urls": [
+      "https://ffnews.com/newsarticle/big-data-scale-up-quantexa-formally-recognised-for-its-commitment-to-financial-crime-detection-for-the-worlds-biggest-banks/",
+      "https://pressreleases.responsesource.com/news/101315/global-rising-tech-star-quantexa-grows-and-expands-new-products/",
+      "https://www.afr.com/companies/financial-services",
+      "https://www.apra.gov.au/",
+      "https://www.austrac.gov.au/",
+      "https://www.biia.com/aml-fraud-solution-of-the-year-quantexa-asia-risk-awards-2021/",
+      "https://www.finextra.com/",
+      "https://www.quantexa.com/customers/",
+      "https://www.quantexa.com/newsroom/",
+      "https://www.quantexa.com/solutions/financial-crime/"
+    ]
+  },
+  {
+    "slug": "revolut-anz-market-entry",
+    "company_name": "Revolut",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://www.revolut.com/en-AU/news/"
+    ],
+    "all_source_urls": [
+      "https://cfotech.com.au/story/revolut-hits-1m-aussie-users-plans-aud-400m-push",
+      "https://connectonline.asic.gov.au/",
+      "https://treasury.gov.au/sites/default/files/2023-12/c2023-403207-revolutaustralia.pdf",
+      "https://treasury.gov.au/sites/default/files/2024-04/c2023-436961-revolut-australia.pdf",
+      "https://www.afr.com/companies/financial-services",
+      "https://www.invest.vic.gov.au/news-and-events/news/2020/august/global-fintech-giant-finds-a-new-gear-in-victoria",
+      "https://www.invest.vic.gov.au/news-events/news/2020/revolut-launches-in-australia",
+      "https://www.linkedin.com/posts/revolut_1-million-revolut-customers-now-in-australia-activity-7427000964706140162-dIJ8",
+      "https://www.rba.gov.au/statistics/",
+      "https://www.revolut.com/en-AU/news/",
+      "https://www.rfigroup.com/"
+    ]
+  },
+  {
+    "slug": "salesforce-australia-market-entry",
+    "company_name": "Salesforce",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://www.salesforce.com/au/blog/agentforce-world-tour-sydney-what-if-your-workforce-had-no-limits/",
+      "https://www.salesforce.com/au/customer-stories/telstra/"
+    ],
+    "all_source_urls": [
+      "https://www.anz.com.au/newsroom/media/2026/february/anz-launches-agentic-ai-powered-crm-to-transform-business-banking/",
+      "https://www.fosterandpartners.com/projects/salesforce-tower-sydney/",
+      "https://www.itnews.com.au/news/how-nab-is-transforming-the-worlds-most-complex-salesforce-structure-520421",
+      "https://www.itnews.com.au/news/salesforce-anz-ceo-pip-marlow-to-leave-598755",
+      "https://www.salesforce.com/au/blog/agentforce-world-tour-sydney-what-if-your-workforce-had-no-limits/",
+      "https://www.salesforce.com/au/blog/salesforce-economy-set-to-generate-1-6t-usd-in-new-revenue-and-over-9m-new-jobs-by-2026-study-reveals/",
+      "https://www.salesforce.com/au/customer-stories/telstra/",
+      "https://www.salesforce.com/au/news/press-releases/2025/02/26/salesforce-australia-investment-2025/",
+      "https://www.salesforce.com/news/press-releases/2019/10/01/salesforce-announces-salesforce-tower-sydney-commits-to-adding-1000-new-local-jobs/",
+      "https://www.salesforce.com/news/stories/salesforce-auckland-office/"
+    ]
+  },
+  {
+    "slug": "secretlab-anz-market-entry",
+    "company_name": "Secretlab",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://secretlabchairs.com.au/pages/about-us",
+      "https://secretlabchairs.com.au/pages/regions",
+      "https://secretlab.co"
+    ],
+    "all_source_urls": [
+      "https://secretlab.co",
+      "https://secretlabchairs.com.au/pages/about-us",
+      "https://secretlabchairs.com.au/pages/regions"
+    ]
+  },
+  {
+    "slug": "sensat-anz-market-entry",
+    "company_name": "Sensat",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://www.sensat.co/news",
+      "https://www.sensat.co/"
+    ],
+    "all_source_urls": [
+      "https://bigbuild.vic.gov.au/projects/north-east-link",
+      "https://technation.io/",
+      "https://www.infrastructureaustralia.gov.au/",
+      "https://www.linkedin.com/company/sensat/",
+      "https://www.linkedin.com/in/andylake1",
+      "https://www.nsw.gov.au/",
+      "https://www.sensat.co/",
+      "https://www.sensat.co/news",
+      "https://www.theurbandeveloper.com/"
+    ]
+  },
+  {
+    "slug": "servicenow-australia-market-entry",
+    "company_name": "ServiceNow",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://www.servicenow.com/customers/dta.html",
+      "https://www.servicenow.com/customers/nab.html",
+      "https://www.servicenow.com/au/company/locations.html"
+    ],
+    "all_source_urls": [
+      "https://channellife.co.nz/story/servicenow-ramps-kiwi-focus-first-local-country-manager",
+      "https://channellife.com.au/story/servicenow-holds-nz-partner-summit-newly-opened-sydney-office",
+      "https://www.arnnet.com.au/article/533070/servicenow_open_apac_support_centre_sydney/",
+      "https://www.arnnet.com.au/article/687849/servicenow-appoints-microsoft-veteran-eric-swift-lead-nz/",
+      "https://www.cio.com/article/3509002/doing-business-with-david-oakley-of-servicenow-digital-disruption-is-a-silicon-valley-term-for-final.html",
+      "https://www.itnews.com.au/news/inside-telstras-effort-to-slash-nbn-complaint-wait-times-481205",
+      "https://www.servicenow.com/au/company/locations.html",
+      "https://www.servicenow.com/customers/dta.html",
+      "https://www.servicenow.com/customers/nab.html"
+    ]
+  },
+  {
+    "slug": "shopback-anz-market-entry",
+    "company_name": "ShopBack",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://www.westpac.com.au/news/making-news/2022/12/westpac-dives-into-online-shopping-with-shopback-deal/",
+      "https://www.westpac.com.au/about-westpac/media/media-releases/2022/8-december/",
+      "https://corporate.shopback.com/press/"
+    ],
+    "all_source_urls": [
+      "https://corporate.shopback.com/press/",
+      "https://www.65equitypartners.com/rewards-platform-shopback-bags-30m-from-westpac-to-close-series-f/",
+      "https://www.westpac.com.au/about-westpac/media/media-releases/2022/8-december/",
+      "https://www.westpac.com.au/news/making-news/2022/12/westpac-dives-into-online-shopping-with-shopback-deal/"
+    ]
+  },
+  {
+    "slug": "snowflake-australia-market-entry",
+    "company_name": "Snowflake",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": null,
+    "all_source_urls": [
+      "https://channellife.com.au/story/snowflake-honours-top-tier-aussie-partners",
+      "https://channellife.com.au/story/video-10-minute-it-jams-who-is-snowflake",
+      "https://prwire.com.au/pr/75557/snowflake-computing-accelerates-apj-expansion-with-sydney-and-melbourne-office-launch-and-two-senior-executive-appointments",
+      "https://www.computerweekly.com/news/252448438/Snowflake-making-headway-in-Australia",
+      "https://www.computerweekly.com/news/366615242/Snowflake-brings-AI-to-data-for-Australian-businesses",
+      "https://www.govtechreview.com.au/content/gov-digital/article/interview-peter-o-connor-snowflake-764003577",
+      "https://www.intelligentcio.com/apac/2020/07/31/get-to-know-peter-oconnor-of-snowflake/",
+      "https://www.itnews.com.au/news/carsales-drives-real-time-data-599862",
+      "https://www.prnewswire.com/news-releases/snowflake-continues-global-expansion-with-australian-data-center-deployment-300518145.html"
+    ]
+  },
+  {
+    "slug": "spectrum-life-anz-market-entry",
+    "company_name": "Spectrum.Life",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://www.spectrum.life/resources/press-releases/spectrum-life-expands-into-australia-with-long-term-strategic-commitment/",
+      "https://www.spectrum.life/resources/spectrum-life-funding-announcement-may-2024/",
+      "https://valionhealth.com.au/about-valion/"
+    ],
+    "all_source_urls": [
+      "https://aihs.org.au/Web/Web/Advocacy-Media/All-News/2024/03-March/Mental-health-conditions-jump-37-per-cent-in-workers-compensation-claims.aspx",
+      "https://businessandfinance.com/news/my-primary-focus-is-delivering-on-our-mission-to-save-and-change-as-many-lives-as-possible-qanda-with-stephen-costello/",
+      "https://cfotech.com.au/story/spectrum-life-buys-three-aussie-digital-health-firms",
+      "https://healthcareandprotection.com/spectrum-life-expands-into-australia-through-mindfit-we-lysn-and-valion-acquisitions/",
+      "https://melbourne-insider.au/spectrum-life-australia-expansion/",
+      "https://techbuzzireland.com/2024/10/09/spectrum-life-surpasses-300-employees-and-eyes-growth-to-500-by-end-of-2025/",
+      "https://valionhealth.com.au/about-valion/",
+      "https://www.einpresswire.com/article/714935154/spectrum-life-closes-17m-investment-round-to-accelerate-international-growth",
+      "https://www.insurtechinsights.com/startup-story-spectrum-life-ceo-and-co-founder-stephen-costello-talks-technology-and-wellbeing/",
+      "https://www.sbs.com.au/news/small-business-secrets/article/how-start-up-lysn-is-removing-the-stigma-surrounding-seeking-mental-health-support/0x1cd1dtu",
+      "https://www.siliconrepublic.com/start-ups/spectrum-life-funding-digital-health-ireland-uk",
+      "https://www.spectrum.life/resources/press-releases/spectrum-life-expands-into-australia-with-long-term-strategic-commitment/",
+      "https://www.spectrum.life/resources/spectrum-life-funding-announcement-may-2024/",
+      "https://www.wirenn.com/post/spectrum-life-ranked-41st-in-the-deloitte-ireland-2024-technology-fast-50-awards"
+    ]
+  },
+  {
+    "slug": "t-pro-anz-market-entry",
+    "company_name": "T-Pro",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://blog.tpro.io/sbs-part-of-tpro",
+      "https://www.livingbridge.com/livingroom/t-pro-acquires-sound-business-systems-expanding-global-healthcare-ai-reach",
+      "https://soundbusiness.co.nz"
+    ],
+    "all_source_urls": [
+      "https://blog.tpro.io/sbs-part-of-tpro",
+      "https://soundbusiness.co.nz",
+      "https://www.livingbridge.com/livingroom/t-pro-acquires-sound-business-systems-expanding-global-healthcare-ai-reach",
+      "https://www.siliconrepublic.com/business/t-pro-syberscribe-acquisition-australia-speech-transcription-technology",
+      "https://www.thinkbusiness.ie/articles/tpro-voice-ai-speech-technology/"
+    ]
+  },
+  {
+    "slug": "tesla-australia-market-entry",
+    "company_name": "Tesla",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": null,
+    "all_source_urls": [
+      "https://electricvehiclecouncil.com.au/portfolio/sam-mclean/",
+      "https://en.wikipedia.org/wiki/Hornsdale_Power_Reserve",
+      "https://hornsdalepowerreserve.com.au/",
+      "https://insideevs.com/news/324516/tesla-model-s-launches-in-australia-first-australian-supercharger-comes-online/",
+      "https://reneweconomy.com.au/genex-picks-tesla-megapacks-for-100mwh-standalone-battery-in-queensland/",
+      "https://reneweconomy.com.au/tesla-to-launch-in-australia-in-early-december-34518/",
+      "https://reneweconomy.com.au/transgrid-to-build-australias-first-tesla-megapack-big-battery-in-western-sydney-55391/",
+      "https://thedriven.io/2024/09/15/tesla-to-add-30-new-supercharger-sites-around-australia-in-big-boost-to-ev-network/",
+      "https://www.carexpert.com.au/car-news/vfacts-2023-tesla-model-y-was-australias-best-selling-new-car-with-private-buyers",
+      "https://www.energy-storage.news/undeniable-success-south-australias-129mwh-tesla-battery/"
+    ]
+  },
+  {
+    "slug": "thought-machine-anz-market-entry",
+    "company_name": "Thought Machine",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://www.thoughtmachine.net/news",
+      "https://www.thoughtmachine.net/customers",
+      "https://www.kiwibank.co.nz/",
+      "https://www.judo.bank/",
+      "https://www.synpulse.com/",
+      "https://www.thoughtmachine.net/case-studies/judo-bank",
+      "https://www.thoughtmachine.net/press-releases/judo-bank"
+    ],
+    "all_source_urls": [
+      "https://financialit.net/news/banking/judo-bank-upgrades-its-lending-business-banking-platform-thought-machine-technology",
+      "https://www.apra.gov.au/",
+      "https://www.judo.bank/",
+      "https://www.kiwibank.co.nz/",
+      "https://www.synpulse.com/",
+      "https://www.synpulse.com/en/insights/synpulse-successfully-partners-with-judo-bank-to-complete-its-core-banking-transformation",
+      "https://www.thoughtmachine.net/case-studies/judo-bank",
+      "https://www.thoughtmachine.net/customers",
+      "https://www.thoughtmachine.net/news",
+      "https://www.thoughtmachine.net/press-releases/judo-bank"
+    ]
+  },
+  {
+    "slug": "tines-anz-market-entry",
+    "company_name": "Tines",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://www.tines.com/case-studies/canva/"
+    ],
+    "all_source_urls": [
+      "https://itbrief.com.au/story/tines-to-double-australia-headcount-as-apac-hub-opens",
+      "https://newshub.medianet.com.au/2026/04/irish-unicorn-tines-to-double-headcount-in-australia-as-organisations-embrace-intelligent-workflows/144557/",
+      "https://research.contrary.com/company/tines",
+      "https://www.casestudies.com/company/tines",
+      "https://www.linkedin.com/posts/tines-io_how-canva-secures-employee-identities-with-activity-7184600792568340480-iPGg",
+      "https://www.linkedin.com/posts/trevor-van-essen-411ab758_2026-is-going-to-be-a-big-year-for-tines-activity-7416309943269507072--cSP",
+      "https://www.prnewswire.com/news-releases/tines-secures-125m-in-series-c-financing-bringing-total-valuation-to-1-125b-302372726.html",
+      "https://www.siliconrepublic.com/start-ups/tines-unicorn-series-c-funding",
+      "https://www.tines.com/case-studies/canva/"
+    ]
+  },
+  {
+    "slug": "tractable-anz-market-entry",
+    "company_name": "Tractable",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://tractable.ai/news/",
+      "https://tractable.ai/",
+      "https://www.iag.com.au/newsroom",
+      "https://www.iag.com.au/",
+      "https://tractable.ai/insurers/"
+    ],
+    "all_source_urls": [
+      "https://insurtechdigital.com/articles/insurance-claims-ai-unicorn-tractable-closes-65m-series-e",
+      "https://tractable.ai/",
+      "https://tractable.ai/insurers/",
+      "https://tractable.ai/news/",
+      "https://www.iag.com.au/",
+      "https://www.iag.com.au/newsroom",
+      "https://www.ibisworld.com/au/",
+      "https://www.insurancebusinessmag.com/au/",
+      "https://www.insurancebusinessmag.com/au/news/claims/iag-lifts-lid-on-casi-a-new-ai-claims-assistant-522369.aspx",
+      "https://www.insurancebusinessmag.com/au/news/technology/ai-extinction-or-better-motor-claims-449654.aspx",
+      "https://www.insurtechinsights.com/"
+    ]
+  },
+  {
+    "slug": "twilio-australia-market-entry",
+    "company_name": "Twilio",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://www.twilio.com/en-us/blog/events/signal-sydney-2025-recap",
+      "https://www.twilio.com/en-us/blog/events/twilio-builders-arcade-syd25",
+      "https://signal.twilio.com/sydney2025"
+    ],
+    "all_source_urls": [
+      "https://channellife.com.au/story/twilio-boosts-local-presence-first-aussie-office",
+      "https://signal.twilio.com/sydney2025",
+      "https://www.arnnet.com.au/article/1265899/twilio-makes-aussie-push-with-former-symantec-channel-talent.html",
+      "https://www.mmoser.com/projects/twilio-sydney/",
+      "https://www.smartcompany.com.au/startupsmart/news/cloud-communications-giant-twilio-opens-two-offices-in-australia/",
+      "https://www.startupdaily.net/topic/cloud-communications-provider-twilio-opens-australian-office-push-growth/",
+      "https://www.twilio.com/en-us/blog/events/signal-sydney-2025-recap",
+      "https://www.twilio.com/en-us/blog/events/twilio-builders-arcade-syd25",
+      "https://www.twilio.com/en-us/press/releases/cloud-communications-platform-twilio-establishes-presence-in-australia-and-appoints-new-regional-director"
+    ]
+  },
+  {
+    "slug": "uipath-australia-market-entry",
+    "company_name": "UiPath",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://www.uipath.com/resources/automation-case-studies/australian-unity",
+      "https://www.uipath.com/resources/automation-case-studies/heritage-bank-banking-rpa",
+      "https://www.uipath.com/resources/automation-case-studies/gold-coast-health-uses-automation-to-deliver-real-time-patient-care",
+      "https://www.uipath.com/blog/rpa/together-sydney-event-2019",
+      "https://www.uipath.com/legal/trust-and-security/irap"
+    ],
+    "all_source_urls": [
+      "https://channellife.com.au/story/exclusive-uipath-sees-roi-pressure-in-anz-ai-shift",
+      "https://itbrief.com.au/story/gold-coast-health-boosts-patient-care-with-uipath-automation",
+      "https://www.itnews.com.au/news/optus-uses-internal-academy-to-scale-up-automation-531428",
+      "https://www.itnews.com.au/news/uipath-appoints-twillios-lee-hawksley-as-svp-and-managing-director-apj-586142",
+      "https://www.uipath.com/blog/rpa/together-sydney-event-2019",
+      "https://www.uipath.com/legal/trust-and-security/irap",
+      "https://www.uipath.com/newsroom/uipath-announces-ipo-pricing",
+      "https://www.uipath.com/resources/automation-case-studies/australian-unity",
+      "https://www.uipath.com/resources/automation-case-studies/gold-coast-health-uses-automation-to-deliver-real-time-patient-care",
+      "https://www.uipath.com/resources/automation-case-studies/heritage-bank-banking-rpa"
+    ]
+  },
+  {
+    "slug": "wayflyer-anz-market-entry",
+    "company_name": "Wayflyer",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://wayflyer.com/au/blog/with-successful-seed-funding-round-wayflyer-is-growing-to-meet-brands-needs-and-global-demand",
+      "https://wayflyer.com/au/about-us",
+      "https://wayflyer.com/our-customers/bohemian-traders",
+      "https://wayflyer.com/au/press-releases/j-p-morgan",
+      "https://wayflyer.com/press-releases/fifth-anniversary"
+    ],
+    "all_source_urls": [
+      "https://canvasbusinessmodel.com/blogs/brief-history/wayflyer-brief-history",
+      "https://ecommercenews.com.au/story/ireland-fintech-firm-wayflyer-eyes-up-aussie-ecommerce-market-boom",
+      "https://stripe.com/customers/wayflyer",
+      "https://wayflyer.com/au/about-us",
+      "https://wayflyer.com/au/blog/with-successful-seed-funding-round-wayflyer-is-growing-to-meet-brands-needs-and-global-demand",
+      "https://wayflyer.com/au/press-releases/j-p-morgan",
+      "https://wayflyer.com/our-customers/bohemian-traders",
+      "https://wayflyer.com/press-releases/fifth-anniversary",
+      "https://www.fintechfutures.com/commercial-sme-lending/irish-unicorn-wayflyer-lands-new-250m-credit-facility-agreement",
+      "https://www.youtube.com/watch?v=fZgvRXpII-k"
+    ]
+  },
+  {
+    "slug": "wise-anz-market-entry",
+    "company_name": "Wise",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://wise.com/gb/blog",
+      "https://wise.com/gb/investors/",
+      "https://wise.com/au/blog",
+      "https://newsroom.wise.com/en-CAS/223579-wise-unveils-new-look-as-it-reaches-16-million-customers-served-worldwide-and-continues-global-expansion/",
+      "https://wise.com/au/about/our-story",
+      "https://newsroom.wise.com/en-CAS/249592-a-30-million-already-invested-wise-launches-interest-in-australia/"
+    ],
+    "all_source_urls": [
+      "https://connectonline.asic.gov.au/",
+      "https://newsroom.wise.com/en-CAS/223579-wise-unveils-new-look-as-it-reaches-16-million-customers-served-worldwide-and-continues-global-expansion/",
+      "https://newsroom.wise.com/en-CAS/249592-a-30-million-already-invested-wise-launches-interest-in-australia/",
+      "https://smbtech.au/news/wise-granted-afsl-for-investments-surpasses-one-million-active-customers/",
+      "https://wise.com/au/about/our-story",
+      "https://wise.com/au/blog",
+      "https://wise.com/gb/blog",
+      "https://wise.com/gb/investors/",
+      "https://www.abs.gov.au/",
+      "https://www.afr.com/companies/financial-services",
+      "https://www.austrac.gov.au/",
+      "https://www.bankingday.com/wise-hits-the-accelerator",
+      "https://www.londonstockexchange.com/",
+      "https://www.rba.gov.au/statistics/"
+    ]
+  },
+  {
+    "slug": "xero-australia-market-entry",
+    "company_name": "Xero",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://www.listcorp.com/asx/xro/xero-limited/news/fy26-interim-results-investor-presentation-3275274.html",
+      "https://www.xero.com/au/media/factsheet/"
+    ],
+    "all_source_urls": [
+      "https://blog.xero.com/news-events/xero-announces-ceo-succession/",
+      "https://blog.xero.com/news-events/xero-to-acquire-melio/",
+      "https://www.accountingtoday.com/news/xero-announces-1-2-billion-in-revenue",
+      "https://www.accountingtoday.com/news/xero-to-focus-on-accounting-payroll-payments-in-us-uk-and-australia-says-ceo",
+      "https://www.listcorp.com/asx/xro/xero-limited/news/fy26-interim-results-investor-presentation-3275274.html",
+      "https://www.nzherald.co.nz/business/markets/shares/rod-drury-why-xero-is-leaving-the-nzx/TB44XCK6O5JJT5BKA5GAI2NDRI/",
+      "https://www.stuff.co.nz/business/industries/98702227/xero-to-delist-from-nzx",
+      "https://www.xero.com/au/media-releases/xerocon-returns-australia-supercharged-brisbane-event/",
+      "https://www.xero.com/au/media/factsheet/",
+      "https://www.xero.com/blog/2021/03/xero-to-acquire-planday/"
+    ]
+  },
+  {
+    "slug": "zoom-australia-market-entry",
+    "company_name": "Zoom Video Communications",
+    "website": null,
+    "company_logo": null,
+    "company_blog_urls": [
+      "https://www.atlassian.com/customers/zoom"
+    ],
+    "all_source_urls": [
+      "https://blog.zoom.us/zoom-announces-134-percent-revenue-growth-australia-new-zealand/",
+      "https://blog.zoom.us/zoom-reaches-1-million-australia-via-aarnet/",
+      "https://channellife.com.au/story/exclusive-interview-targeting-university-sector-aarnet-and-zoom",
+      "https://channellife.com.au/story/video-communication-service-zoom-posts-134-revenue-growth-nz",
+      "https://itbrief.com.au/story/video-communication-service-zoom-posts-134-revenue-growth-nz",
+      "https://itbrief.com.au/story/zoom-virtual-agent-launch-promises-big-things-for-anz-businesses",
+      "https://theorg.com/org/zoom/org-chart/michael-chetner",
+      "https://www.aarnet.edu.au/transforming-online-collaboration-for-australian-universities",
+      "https://www.aarnet.edu.au/zoom",
+      "https://www.arnnet.com.au/article/705793/zoom-anz-head-michael-chetner-resigns/",
+      "https://www.atlassian.com/customers/zoom"
+    ]
+  }
+]

--- a/scripts/generate_case_study_logo_sql.py
+++ b/scripts/generate_case_study_logo_sql.py
@@ -1,0 +1,53 @@
+"""Generate idempotent UPDATE SQL to backfill website + company_logo for the
+53 published case studies that are missing both fields.
+
+Reads:  scripts/parsed_case_study_logos.json (output of build_case_study_logos.py)
+Writes: scripts/backfill_case_study_logos.sql
+
+The UPDATEs are idempotent and only touch rows where both fields are still
+NULL — re-running is a no-op, and existing rows that already have a website
+or logo are deliberately left alone (per the task scope of 53-only).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INPUT = REPO_ROOT / "scripts" / "parsed_case_study_logos.json"
+OUTPUT = REPO_ROOT / "scripts" / "backfill_case_study_logos.sql"
+
+
+def sql_str(s: str) -> str:
+    return "'" + s.replace("'", "''") + "'"
+
+
+def main() -> None:
+    rows = json.loads(INPUT.read_text())
+    lines: list[str] = [
+        "-- Backfill website + company_logo for 53 published case studies",
+        "-- missing both fields. Idempotent: only updates rows where website",
+        "-- and company_logo are both still NULL.",
+        "",
+    ]
+    for r in rows:
+        slug = r["slug"]
+        website = r["website"]
+        logo = r["company_logo"]
+        lines.append(f"-- {slug} ({r['company_name']})")
+        lines.append("UPDATE content_company_profiles cp")
+        lines.append(f"   SET website = {sql_str(website)},")
+        lines.append(f"       company_logo = {sql_str(logo)}")
+        lines.append("  FROM content_items ci")
+        lines.append("  WHERE cp.content_id = ci.id")
+        lines.append(f"    AND ci.slug = {sql_str(slug)}")
+        lines.append("    AND cp.website IS NULL")
+        lines.append("    AND cp.company_logo IS NULL;")
+        lines.append("")
+    OUTPUT.write_text("\n".join(lines))
+    print(f"Wrote {len(rows)} UPDATE statements to {OUTPUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/parsed_case_study_logos.json
+++ b/scripts/parsed_case_study_logos.json
@@ -1,0 +1,691 @@
+[
+  {
+    "slug": "airbnb-australia-market-entry",
+    "company_name": "Airbnb",
+    "domain": "airbnb.com",
+    "website": "https://airbnb.com",
+    "company_logo": "https://img.logo.dev/airbnb.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/airbnb.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 1988,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "amazon-australia-ecommerce-entry",
+    "company_name": "Amazon.com",
+    "domain": "amazon.com",
+    "website": "https://amazon.com",
+    "company_logo": "https://img.logo.dev/amazon.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/amazon.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 1589,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "anna-money-anz-market-entry",
+    "company_name": "ANNA Money",
+    "domain": "anna.money",
+    "website": "https://anna.money",
+    "company_logo": "https://img.logo.dev/anna.money?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/anna.money?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 2942,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "anthropic-australia-market-entry",
+    "company_name": "Anthropic",
+    "domain": "anthropic.com",
+    "website": "https://anthropic.com",
+    "company_logo": "https://img.logo.dev/anthropic.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/anthropic.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 2602,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "aws-australia-market-entry",
+    "company_name": "Amazon Web Services (AWS)",
+    "domain": "aws.amazon.com",
+    "website": "https://aws.amazon.com",
+    "company_logo": "https://img.logo.dev/aws.amazon.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/aws.amazon.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 1589,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "banked-anz-market-entry",
+    "company_name": "Banked",
+    "domain": "banked.com",
+    "website": "https://banked.com",
+    "company_logo": "https://img.logo.dev/banked.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/banked.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 753,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "blue-prism-anz-market-entry",
+    "company_name": "Blue Prism",
+    "domain": "blueprism.com",
+    "website": "https://blueprism.com",
+    "company_logo": "https://img.logo.dev/blueprism.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/blueprism.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 5474,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "clanwilliam-anz-market-entry",
+    "company_name": "Clanwilliam",
+    "domain": "clanwilliam.com",
+    "website": "https://clanwilliam.com",
+    "company_logo": "https://img.logo.dev/clanwilliam.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/clanwilliam.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 3401,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "comfortdelgro-anz-market-entry",
+    "company_name": "ComfortDelGro",
+    "domain": "comfortdelgro.com",
+    "website": "https://comfortdelgro.com",
+    "company_logo": "https://img.logo.dev/comfortdelgro.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/comfortdelgro.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 2053,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "complyadvantage-anz-market-entry",
+    "company_name": "ComplyAdvantage",
+    "domain": "complyadvantage.com",
+    "website": "https://complyadvantage.com",
+    "company_logo": "https://img.logo.dev/complyadvantage.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/complyadvantage.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 1193,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "contino-anz-market-entry",
+    "company_name": "Contino",
+    "domain": "contino.io",
+    "website": "https://contino.io",
+    "company_logo": "https://img.logo.dev/contino.io?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/contino.io?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 2101,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "daon-anz-market-entry",
+    "company_name": "Daon",
+    "domain": "daon.com",
+    "website": "https://daon.com",
+    "company_logo": "https://img.logo.dev/daon.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/daon.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 1971,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "darktrace-anz-market-entry",
+    "company_name": "Darktrace",
+    "domain": "darktrace.com",
+    "website": "https://darktrace.com",
+    "company_logo": "https://img.logo.dev/darktrace.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/darktrace.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 2394,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "databricks-australia-market-entry",
+    "company_name": "Databricks",
+    "domain": "databricks.com",
+    "website": "https://databricks.com",
+    "company_logo": "https://img.logo.dev/databricks.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/databricks.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 536,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "daxtra-technologies-anz-market-entry",
+    "company_name": "DaXtra Technologies",
+    "domain": "daxtra.com",
+    "website": "https://daxtra.com",
+    "company_logo": "https://img.logo.dev/daxtra.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/daxtra.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 3366,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "deliveroo-anz-market-entry",
+    "company_name": "Deliveroo",
+    "domain": "deliveroo.co.uk",
+    "website": "https://deliveroo.co.uk",
+    "company_logo": "https://img.logo.dev/deliveroo.co.uk?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/deliveroo.co.uk?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 2727,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "dext-anz-market-entry",
+    "company_name": "Dext",
+    "domain": "dext.com",
+    "website": "https://dext.com",
+    "company_logo": "https://img.logo.dev/dext.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/dext.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 1812,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "docusign-australia-market-entry",
+    "company_name": "DocuSign",
+    "domain": "docusign.com",
+    "website": "https://docusign.com",
+    "company_logo": "https://img.logo.dev/docusign.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/docusign.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 2320,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "featurespace-anz-market-entry",
+    "company_name": "Featurespace",
+    "domain": "featurespace.com",
+    "website": "https://featurespace.com",
+    "company_logo": "https://img.logo.dev/featurespace.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/featurespace.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 1554,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "fenergo-anz-market-entry",
+    "company_name": "Fenergo",
+    "domain": "fenergo.com",
+    "website": "https://fenergo.com",
+    "company_logo": "https://img.logo.dev/fenergo.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/fenergo.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 1464,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "fexco-anz-market-entry",
+    "company_name": "Fexco",
+    "domain": "fexco.com",
+    "website": "https://fexco.com",
+    "company_logo": "https://img.logo.dev/fexco.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/fexco.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 1257,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "fineos-anz-market-entry",
+    "company_name": "FINEOS",
+    "domain": "fineos.com",
+    "website": "https://fineos.com",
+    "company_logo": "https://img.logo.dev/fineos.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/fineos.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 1986,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "github-australia-market-entry",
+    "company_name": "GitHub",
+    "domain": "github.com",
+    "website": "https://github.com",
+    "company_logo": "https://img.logo.dev/github.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/github.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 2237,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "kyckr-anz-market-entry",
+    "company_name": "Kyckr",
+    "domain": "kyckr.com",
+    "website": "https://kyckr.com",
+    "company_logo": "https://img.logo.dev/kyckr.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/kyckr.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 2323,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "learnupon-anz-market-entry",
+    "company_name": "LearnUpon",
+    "domain": "learnupon.com",
+    "website": "https://learnupon.com",
+    "company_logo": "https://img.logo.dev/learnupon.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/learnupon.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 3020,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "mimecast-anz-market-entry",
+    "company_name": "Mimecast",
+    "domain": "mimecast.com",
+    "website": "https://mimecast.com",
+    "company_logo": "https://img.logo.dev/mimecast.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/mimecast.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 1278,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "ncc-group-anz-market-entry",
+    "company_name": "NCC Group",
+    "domain": "nccgroup.com",
+    "website": "https://nccgroup.com",
+    "company_logo": "https://img.logo.dev/nccgroup.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/nccgroup.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 4302,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "nium-anz-market-entry",
+    "company_name": "Nium",
+    "domain": "nium.com",
+    "website": "https://nium.com",
+    "company_logo": "https://img.logo.dev/nium.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/nium.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 1911,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "nplan-anz-market-entry",
+    "company_name": "nPlan",
+    "domain": "nplan.io",
+    "website": "https://nplan.io",
+    "company_logo": "https://img.logo.dev/nplan.io?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/nplan.io?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 2723,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "onfido-anz-market-entry",
+    "company_name": "Onfido",
+    "domain": "onfido.com",
+    "website": "https://onfido.com",
+    "company_logo": "https://img.logo.dev/onfido.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/onfido.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 3768,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "openai-australia-market-entry",
+    "company_name": "OpenAI",
+    "domain": "openai.com",
+    "website": "https://openai.com",
+    "company_logo": "https://img.logo.dev/openai.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/openai.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 2206,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "palantir-australia-market-entry",
+    "company_name": "Palantir Technologies",
+    "domain": "palantir.com",
+    "website": "https://palantir.com",
+    "company_logo": "https://img.logo.dev/palantir.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/palantir.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 2545,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "propertyguru-anz-market-entry",
+    "company_name": "PropertyGuru",
+    "domain": "propertyguru.com",
+    "website": "https://propertyguru.com",
+    "company_logo": "https://img.logo.dev/propertyguru.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/propertyguru.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 3282,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "quantexa-anz-market-entry",
+    "company_name": "Quantexa",
+    "domain": "quantexa.com",
+    "website": "https://quantexa.com",
+    "company_logo": "https://img.logo.dev/quantexa.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/quantexa.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 1490,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "revolut-anz-market-entry",
+    "company_name": "Revolut",
+    "domain": "revolut.com",
+    "website": "https://revolut.com",
+    "company_logo": "https://img.logo.dev/revolut.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/revolut.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 1273,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "salesforce-australia-market-entry",
+    "company_name": "Salesforce",
+    "domain": "salesforce.com",
+    "website": "https://salesforce.com",
+    "company_logo": "https://img.logo.dev/salesforce.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/salesforce.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 1990,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "secretlab-anz-market-entry",
+    "company_name": "Secretlab",
+    "domain": "secretlab.co",
+    "website": "https://secretlab.co",
+    "company_logo": "https://img.logo.dev/secretlab.co?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/secretlab.co?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 6342,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "sensat-anz-market-entry",
+    "company_name": "Sensat",
+    "domain": "sensat.co",
+    "website": "https://sensat.co",
+    "company_logo": "https://img.logo.dev/sensat.co?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/sensat.co?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 4249,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "servicenow-australia-market-entry",
+    "company_name": "ServiceNow",
+    "domain": "servicenow.com",
+    "website": "https://servicenow.com",
+    "company_logo": "https://img.logo.dev/servicenow.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/servicenow.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 5798,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "shopback-anz-market-entry",
+    "company_name": "ShopBack",
+    "domain": "shopback.com",
+    "website": "https://shopback.com",
+    "company_logo": "https://img.logo.dev/shopback.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/shopback.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 2974,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "snowflake-australia-market-entry",
+    "company_name": "Snowflake",
+    "domain": "snowflake.com",
+    "website": "https://snowflake.com",
+    "company_logo": "https://img.logo.dev/snowflake.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/snowflake.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 4989,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "spectrum-life-anz-market-entry",
+    "company_name": "Spectrum.Life",
+    "domain": "spectrum.life",
+    "website": "https://spectrum.life",
+    "company_logo": "https://img.logo.dev/spectrum.life?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/spectrum.life?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 1138,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "t-pro-anz-market-entry",
+    "company_name": "T-Pro",
+    "domain": "tpro.io",
+    "website": "https://tpro.io",
+    "company_logo": "https://img.logo.dev/tpro.io?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/tpro.io?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 2465,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "tesla-australia-market-entry",
+    "company_name": "Tesla",
+    "domain": "tesla.com",
+    "website": "https://tesla.com",
+    "company_logo": "https://img.logo.dev/tesla.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/tesla.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 2080,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "thought-machine-anz-market-entry",
+    "company_name": "Thought Machine",
+    "domain": "thoughtmachine.net",
+    "website": "https://thoughtmachine.net",
+    "company_logo": "https://img.logo.dev/thoughtmachine.net?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/thoughtmachine.net?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 2261,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "tines-anz-market-entry",
+    "company_name": "Tines",
+    "domain": "tines.com",
+    "website": "https://tines.com",
+    "company_logo": "https://img.logo.dev/tines.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/tines.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 5508,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "tractable-anz-market-entry",
+    "company_name": "Tractable",
+    "domain": "tractable.ai",
+    "website": "https://tractable.ai",
+    "company_logo": "https://img.logo.dev/tractable.ai?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/tractable.ai?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 3113,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "twilio-australia-market-entry",
+    "company_name": "Twilio",
+    "domain": "twilio.com",
+    "website": "https://twilio.com",
+    "company_logo": "https://img.logo.dev/twilio.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/twilio.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 3549,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "uipath-australia-market-entry",
+    "company_name": "UiPath",
+    "domain": "uipath.com",
+    "website": "https://uipath.com",
+    "company_logo": "https://img.logo.dev/uipath.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/uipath.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 1747,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "wayflyer-anz-market-entry",
+    "company_name": "Wayflyer",
+    "domain": "wayflyer.com",
+    "website": "https://wayflyer.com",
+    "company_logo": "https://img.logo.dev/wayflyer.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/wayflyer.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 1509,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "wise-anz-market-entry",
+    "company_name": "Wise",
+    "domain": "wise.com",
+    "website": "https://wise.com",
+    "company_logo": "https://img.logo.dev/wise.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/wise.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 2143,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "xero-australia-market-entry",
+    "company_name": "Xero",
+    "domain": "xero.com",
+    "website": "https://xero.com",
+    "company_logo": "https://img.logo.dev/xero.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/xero.com?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 2864,
+      "looks_real": true
+    }
+  },
+  {
+    "slug": "zoom-australia-market-entry",
+    "company_name": "Zoom Video Communications",
+    "domain": "zoom.us",
+    "website": "https://zoom.us",
+    "company_logo": "https://img.logo.dev/zoom.us?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=256&format=png",
+    "validation": {
+      "url": "https://img.logo.dev/zoom.us?token=pk_L3JbJjCeT0-mUdhpPlS6SA&size=64&format=png&fallback=404",
+      "status": 200,
+      "size_bytes": 3813,
+      "looks_real": true
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- Backfills `content_company_profiles.website` and `content_company_profiles.company_logo` for the 53 published case studies that previously had neither field set.
- Logos point at logo.dev (`https://img.logo.dev/{domain}?token=...&size=256&format=png`) using the same publishable token already wired into `src/lib/logoUtils.ts`.
- Pure data backfill — no schema changes, no code changes, no other tables touched.

## Why
The frontend already implements a logo fallback chain at `src/pages/CaseStudyDetail.tsx:211, 279`:

```ts
src={companyProfile?.company_logo
     || getLogoUrl(companyProfile?.website, 64)
     || primaryFounder?.image}
```

But every one of the 53 net-new case studies imported in recent PRs (#181, #185, #186, #188) and several older ones had no `website` or `company_logo`, so they were rendering the founder image or a placeholder. This PR fills that gap.

## How
Reproducible from the repo:

| File | Purpose |
|---|---|
| `scripts/cases_missing_logos_input.json` | Snapshot of the 53 cases needing logos |
| `scripts/build_case_study_logos.py` | Curated `slug → domain` map + logo.dev validator (uses `?fallback=404` to cleanly distinguish real logos from monogram fallbacks) |
| `scripts/parsed_case_study_logos.json` | Validated mapping output |
| `scripts/generate_case_study_logo_sql.py` | Emits the SQL bundle |
| `scripts/backfill_case_study_logos.sql` | 53 idempotent UPDATEs (only touches rows where both fields are still NULL) |
| `reports/case-study-logos-summary-2026-05-08.md` | Full summary with curated domain choices |

## Test plan
- [x] All 53 domains return 200 OK from logo.dev with `?fallback=404` (no monogram fallbacks)
- [x] Curated domain choices verified against each company's official site (e.g. `tpro.io`, `secretlab.co`, `spectrum.life`, `anna.money`, `thoughtmachine.net`)
- [x] DB state after merge: `has_website` 24 → 77, `has_logo` 0 → 53, `missing both` 53 → 0
- [x] SQL is idempotent — only updates `WHERE website IS NULL AND company_logo IS NULL`
- [x] Pre-existing 24 case studies with `website` set untouched (scope: 53 missing only)
- [x] Frontend wiring unchanged — no risk to existing render paths

https://claude.ai/code/session_019XostAF5uUGrgbR4nwtHft

---
_Generated by [Claude Code](https://claude.ai/code/session_019XostAF5uUGrgbR4nwtHft)_