### PR TITLE
Replace date chip with prominent event logo on EventCard

### DIFF
--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react";
-import { MapPin, Users, Clock } from "lucide-react";
+import { Calendar, MapPin, Users, Clock } from "lucide-react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -9,7 +9,7 @@ import { Event } from "@/hooks/useEvents";
 import { Link } from "react-router-dom";
 import CompanyLogo from "@/components/shared/CompanyLogo";
 import {
-  formatEventDateBadge,
+  formatEventDateLong,
   isEventPast as computeIsEventPast,
   daysUntilLabel,
   canAddToCalendar,
@@ -23,7 +23,7 @@ interface EventCardProps {
 
 export const EventCard = memo(({ event, onViewDetails, useModal = false }: EventCardProps) => {
   const isEventPast = computeIsEventPast(event);
-  const dateBadge = formatEventDateBadge(event);
+  const dateLabel = formatEventDateLong(event);
   const daysLabel = daysUntilLabel(event);
   const showCalendarButton = !isEventPast && canAddToCalendar(event);
   const isApproximateDate = (event.date_precision ?? "exact") !== "exact";
@@ -43,15 +43,16 @@ export const EventCard = memo(({ event, onViewDetails, useModal = false }: Event
       <CardHeader className="pb-4">
         <div className="flex items-start justify-between gap-3">
           <div className="flex items-start gap-3 flex-1 min-w-0">
-            {/* Date Badge */}
-            <div className="flex-shrink-0 w-14 h-14 rounded-lg bg-primary/10 flex flex-col items-center justify-center text-center">
-              <span className="text-xs font-bold text-primary leading-none">{dateBadge.top}</span>
-              {dateBadge.bottom ? (
-                <span className="text-lg font-bold text-primary leading-tight">{dateBadge.bottom}</span>
-              ) : (
-                <span className="text-[10px] font-medium text-primary/70 leading-tight mt-0.5">typical</span>
-              )}
-            </div>
+            {/* Event logo (replaces the date chip — date moves into the meta stack below) */}
+            <CompanyLogo
+              websiteUrl={event.organizer_website || event.website_url}
+              existingLogoUrl={event.event_logo_url}
+              companyName={organizerLabel || event.title}
+              size="lg"
+              className="w-14 h-14 md:w-16 md:h-16 rounded-lg border border-border flex-shrink-0"
+              fallbackClassName="bg-primary/10 text-primary rounded-lg"
+              imgClassName="object-contain p-1"
+            />
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-2 mb-2">
                 {isEventPast ? (
@@ -91,12 +92,12 @@ export const EventCard = memo(({ event, onViewDetails, useModal = false }: Event
           />
         </div>
       </CardHeader>
-      
+
       <CardContent className="flex-1 flex flex-col pt-0">
         <CardDescription className="line-clamp-2 mb-4 flex-1">
           {event.description}
         </CardDescription>
-        
+
         <div className="flex items-center justify-between gap-2 mb-4">
           <Badge variant="secondary" className="text-xs font-medium">
             {event.category}
@@ -105,8 +106,12 @@ export const EventCard = memo(({ event, onViewDetails, useModal = false }: Event
             {event.type}
           </Badge>
         </div>
-        
+
         <div className="space-y-2 mb-4">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Calendar className="w-4 h-4 flex-shrink-0" />
+            <span>{dateLabel}</span>
+          </div>
           {timeLabel ? (
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
               <Clock className="w-4 h-4 flex-shrink-0" />
@@ -118,17 +123,7 @@ export const EventCard = memo(({ event, onViewDetails, useModal = false }: Event
             <span className="truncate flex-1">{event.location}</span>
           </div>
           <div className="flex items-center justify-between gap-4">
-            <div className="flex items-center gap-2 min-w-0 flex-1">
-              <CompanyLogo
-                websiteUrl={event.organizer_website || event.website_url}
-                existingLogoUrl={event.event_logo_url}
-                companyName={organizerLabel}
-                size="sm"
-                className="rounded-full"
-                fallbackClassName="bg-primary/10 text-primary rounded-full"
-              />
-              <span className="text-sm text-muted-foreground truncate">{organizerLabel}</span>
-            </div>
+            <span className="text-sm text-muted-foreground truncate min-w-0 flex-1">{organizerLabel}</span>
             <div className="flex items-center gap-1 text-sm text-muted-foreground flex-shrink-0">
               <Users className="w-4 h-4" />
               <span>{event.attendees.toLocaleString()}</span>

--- a/src/lib/eventDate.ts
+++ b/src/lib/eventDate.ts
@@ -22,15 +22,6 @@ export const formatEventDateLong = (event: EventDateFields): string => {
   return format(d, "EEEE, d MMMM yyyy");
 };
 
-/** Short two-line date badge used on cards. Returns the day field as `null` when the date is approximate. */
-export const formatEventDateBadge = (event: EventDateFields): { top: string; bottom: string | null } => {
-  const precision = event.date_precision ?? "exact";
-  const d = toDate(event.date);
-  if (precision === "tbc") return { top: "TBC", bottom: null };
-  if (precision === "month") return { top: format(d, "MMM").toUpperCase(), bottom: null };
-  return { top: format(d, "MMM").toUpperCase(), bottom: format(d, "d") };
-};
-
 /** Whether the event is past, accounting for approximate dates (month/TBC precision are never "past"). */
 export const isEventPast = (event: EventDateFields): boolean => {
   const precision = event.date_precision ?? "exact";


### PR DESCRIPTION
## Summary

Replace the small date chip on the event card with a prominent event logo, and move the date into the meta stack alongside time and location.

The previous design dedicated the most visually prominent slot on every card to a low-information element ("MAR 1", or worse, "AUG typical"). For a directory page where users are scanning to recognise events, the brand mark earns that slot.

## Before / After

| | Before | After |
|---|---|---|
| Top-left slot | Date chip (e.g. `JUL 26`) | 64×64 event logo |
| Date | In the chip | Calendar row in meta stack: `"Sun, 26 Jul 2026"` / `"Typically July 2027"` / `"Date TBC"` |
| Status chip under title | "In X days" / "Past" / "Date TBC" | unchanged |
| Bottom row | Tiny logo + organizer name | Organizer name only (logo no longer duplicated) |

## How it works

- Uses the existing `CompanyLogo` component, so the fallback chain — `existingLogoUrl → logo.dev regenerated from website_url → initials block` — is already in place. Events with a working logo show their logo; events with neither show clean initials in the brand colour, not a generic placeholder.
- Date row uses the existing `formatEventDateLong` helper from `src/lib/eventDate.ts` which already branches on `date_precision`.
- `formatEventDateBadge` helper deleted since nothing references it after this change.
- Mobile gets `w-14 h-14` (56×56), desktop `w-16 h-16` (64×64) — the responsive class overrides the lg `SIZE_MAP` container via `cn()` merge.

## Files changed

- `src/components/EventCard.tsx` — header swap, new date row, organizer-only bottom row.
- `src/lib/eventDate.ts` — removed unused `formatEventDateBadge` helper.

Net diff: +21 / -35.

## Test plan

- [ ] `/events` cards show logos in the top-left, not date chips.
- [ ] Approximate-date events render `"Typically <Month> <Year>"` in the new Calendar row and a `"Date TBC"` status chip.
- [ ] Exact-date events render the long date string and an `"In X days"` chip.
- [ ] Past-event cards still show `"Past Event"` chip and reduced opacity.
- [ ] Events with no logo (e.g. AusMine, AHRI) show a clean initials block, not the previous generic placeholder.
- [ ] Mobile (≤768px): the logo is 56×56 and the title doesn't overflow.
- [ ] No second logo appears next to the organizer name in the meta stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CqwQLurzYwaw5f8eJ2QxbZ)_