### PR TITLE
Remove "Why Teams Choose MES" and trust logos sections from homepage

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,11 +1,9 @@
 import { Helmet } from "react-helmet-async";
 import { HeroSection } from "@/components/sections/HeroSection";
-import { TrustLogosSection } from "@/components/sections/TrustLogosSection";
 import { BeforeAfterSection } from "@/components/sections/BeforeAfterSection";
 import { HowItWorksSection } from "@/components/sections/HowItWorksSection";
 import { SearchSection } from "@/components/sections/SearchSection";
 import { ValueSection } from "@/components/sections/ValueSection";
-import { ComparisonSection } from "@/components/sections/ComparisonSection";
 import { TestimonialsSection } from "@/components/sections/TestimonialsSection";
 import { PricingSection } from "@/components/sections/PricingSection";
 import { CTASection } from "@/components/sections/CTASection";
@@ -68,9 +66,6 @@ const Index = () => {
       {/* Interactive Hero Section */}
       <HeroSection />
 
-      {/* Data Source Trust Logos */}
-      <TrustLogosSection />
-
       {/* Before vs. After Market Entry Section */}
       <BeforeAfterSection />
 
@@ -82,9 +77,6 @@ const Index = () => {
 
       {/* Combined Value Section */}
       <ValueSection />
-
-      {/* MES vs Alternatives Comparison */}
-      <ComparisonSection />
 
       {/* Testimonials Section */}
       <TestimonialsSection />


### PR DESCRIPTION
## Summary
- Removes the "Why Teams Choose MES" comparison block (`ComparisonSection`) and the "Intelligence sourced from trusted institutions" trust logos band (`TrustLogosSection`) from the homepage (`src/pages/Index.tsx`).
- Edit is scoped to the homepage only: two import lines and two JSX blocks (with their preceding comments) deleted. Diff is 8 lines, 1 file.
- Component source files (`src/components/sections/ComparisonSection.tsx`, `src/components/sections/TrustLogosSection.tsx`, and the `src/components/sections/comparison/` subfolder) are intentionally left in place as orphaned code, per the audit-then-remove plan. They can be cleaned up in a separate pass.

## Audit notes
- Both components were used **only** on `Index.tsx` (verified via repo-wide grep).
- No anchor links (`href="#..."`) pointed to either section.
- No analytics / tracking handlers were tied to either block.
- Shared hooks (`useSectionPersona`, `useIntersectionObserver`, `useAnimatedCounter`) are still used by other sections and were not touched.

## Test plan
- [x] `npm run build` — passes (Vite production build, 11s)
- [x] `npx tsc --noEmit` — passes (no type errors)
- [x] `npm run lint` — no new errors introduced (pre-existing 315 problems unchanged; none in changed files)
- [ ] Visual check on deployed Lovable preview — confirm the homepage flows: Hero → Before/After → How It Works → Search → Value → Testimonials → Pricing → CTA, with no spacing collapse where the two removed sections used to sit.

https://claude.ai/code/session_01UXz3X9E2fRAqJdHZUkBcsx

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXz3X9E2fRAqJdHZUkBcsx)_