### PR TITLE
Trade agencies follow-ups: AMCC, government_level, duplicate merges

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -4032,3 +4032,4 @@ export const Constants = {
     },
   },
 } as const
+

--- a/supabase/migrations/20260513120000_followup_deactivate_amcc.sql
+++ b/supabase/migrations/20260513120000_followup_deactivate_amcc.sql
@@ -1,0 +1,17 @@
+-- Follow-up 1: deactivate the Australia Malaysia Chamber of Commerce (AMCC) row.
+-- The Phase 3 research sub-agent confirmed this organisation does not exist
+-- as a real bilateral body — the listed website (arvensystech.com) was
+-- unrelated to AU-MY trade, and the legitimate AU-MY body is the separate
+-- "Australia Malaysia Business Council (NSW Chapter)" row.
+--
+-- We keep the row (rather than hard-deleting) so any external references
+-- by id continue to resolve cleanly, but it's excluded from the directory
+-- via is_active=false.
+
+UPDATE trade_investment_agencies
+SET
+  is_active = false,
+  needs_re_research = false,
+  last_updated_at = now(),
+  updated_at = now()
+WHERE slug = 'australia-malaysia-chamber-of-commerce-amcc';

--- a/supabase/migrations/20260513120100_followup_normalize_government_level.sql
+++ b/supabase/migrations/20260513120100_followup_normalize_government_level.sql
@@ -1,0 +1,53 @@
+-- Follow-up 2: standardise government_level for foreign agencies vs bilateral chambers.
+--
+-- The Phase 3 research sub-agents produced inconsistent classifications
+-- (KOTRA → 'bilateral', Enterprise Ireland → 'international') for what are
+-- structurally the same kind of entity: foreign federal trade agencies
+-- running an Australian/NZ office.
+--
+-- New convention:
+--   * 'international'  → foreign federal trade agencies (KOTRA, JETRO,
+--                        Enterprise Ireland, Business France, etc.) and
+--                        foreign consulates/embassies. Identified by
+--                        organisation_type = 'foreign_trade_agency'.
+--   * 'bilateral'      → member-funded bilateral business councils /
+--                        chambers of commerce with no formal government
+--                        affiliation (FACCI, AKBC, AmCham, EABC, the
+--                        country-pair business councils). Identified by
+--                        organisation_type = 'bilateral'.
+--   * 'federal'        → domestic AU/NZ federal agencies (Austrade,
+--                        Export Finance Australia, NZTE, Callaghan
+--                        Innovation). Unchanged.
+--   * 'state'          → AU state government bodies. Unchanged.
+--   * 'industry'       → industry peak bodies (FinTech Australia, ECA,
+--                        AiGroup, CCIWA). Unchanged.
+--   * 'local'          → local/regional chambers (Swan). Unchanged.
+--   * 'none'           → private trade consultancies (ALTIOS, Expandys,
+--                        Export Connect). Unchanged.
+
+-- Rule 1: all foreign trade agencies → 'international'
+UPDATE trade_investment_agencies
+SET government_level = 'international',
+    last_updated_at = now(),
+    updated_at = now()
+WHERE organisation_type = 'foreign_trade_agency'
+  AND COALESCE(government_level, '') <> 'international';
+
+-- Rule 2: all bilateral business councils / chambers → 'bilateral'
+-- Excludes rows correctly tagged industry/local (CCIWA, Swan).
+UPDATE trade_investment_agencies
+SET government_level = 'bilateral',
+    last_updated_at = now(),
+    updated_at = now()
+WHERE organisation_type = 'bilateral'
+  AND COALESCE(government_level, '') NOT IN ('bilateral', 'industry', 'local');
+
+-- Rule 3: special case — Invest Northern Ireland uses organisation_type
+-- 'federal_agency' but is a UK regional dev agency, not domestic AU. Tag
+-- it as 'international' to match its peer foreign trade agencies.
+UPDATE trade_investment_agencies
+SET government_level = 'international',
+    last_updated_at = now(),
+    updated_at = now()
+WHERE slug = 'invest-northern-ireland'
+  AND COALESCE(government_level, '') <> 'international';

--- a/supabase/migrations/20260513120200_followup_merge_duplicate_agencies.sql
+++ b/supabase/migrations/20260513120200_followup_merge_duplicate_agencies.sql
@@ -1,0 +1,91 @@
+-- Follow-up 3: merge the 6 duplicate trade-agency pairs that the Phase 3
+-- research sub-agents independently converged on the same canonical website.
+--
+-- For each pair: reassign agency_contacts to the keeper row, then delete
+-- the dropped row. trade_agencies_enrichment_staging has ON DELETE CASCADE
+-- so its rows for the dropped agency_id auto-clean; same for agency_resources.
+--
+-- Keeper selection rule:
+--   * cleaner / less-abbreviated name where possible
+--   * matches the recommendation in
+--     docs/trade-agencies-staging-review-2026-05-09.md
+--
+-- Pairs (keep / drop / canonical):
+--   1. danish    529439b4 (Danish Trade Council)
+--                / 8cd0bc12 (Danish Trade Council / Danish Connect)
+--                — australien.um.dk
+--   2. dutch_qld c524cd3f (Dutch Chamber of Commerce Queensland)
+--                / 264247f4 (DCCQ - Dutch Chamber of Commerce Queensland)
+--                — dccq.org
+--   3. estonian  28cf410f (Estonian Australian Chamber of Commerce)
+--                / 4da104ef (Estonian Chamber of Commerce)
+--                — eacci.com.au
+--   4. iccwa     55f921a6 (Indonesian Chamber of Commerce Western Australia)
+--                / d8989f98 (ICCWA - Indonesian Chamber of Commerce Western Australia)
+--                — iccwa.net.au
+--   5. jetro     86099799 (JETRO - Japan External Trade Organization)
+--                / dda9886d (JETRO - Japan External Trade Organisation)
+--                — jetro.go.jp (Org/Organisation spelling variant only)
+--   6. nzmebc    2780b091 (New Zealand Middle East Business Council)
+--                / bf951a3e (NZ-Middle East Business Council (NZMEBC))
+--                — nzmebc.org.nz
+
+BEGIN;
+
+-- Step 1: reassign contacts from dropped → keeper.
+-- Keepers will end up with the union of both rows' contacts. agency_contacts
+-- has no UNIQUE (agency_id, full_name) constraint, so duplicate names across
+-- both halves are tolerated — those can be deduped in a separate sweep.
+UPDATE agency_contacts SET agency_id = '529439b4-0571-497f-989f-8326487169fa'
+  WHERE agency_id = '8cd0bc12-d2ea-41ef-b80b-aad91ad3465a';
+UPDATE agency_contacts SET agency_id = 'c524cd3f-ca20-43f1-a634-d00135a9588b'
+  WHERE agency_id = '264247f4-6a79-4ca5-abdf-3f9620ccf069';
+UPDATE agency_contacts SET agency_id = '28cf410f-89d5-418c-b967-bce36330bcdd'
+  WHERE agency_id = '4da104ef-d80f-4992-8701-588fa5ab2837';
+UPDATE agency_contacts SET agency_id = '55f921a6-a25f-40e5-aaa3-33c6bf129ae7'
+  WHERE agency_id = 'd8989f98-9051-4a9a-86a2-3b42f0b4716b';
+UPDATE agency_contacts SET agency_id = '86099799-b451-4811-bb63-b02763b13b12'
+  WHERE agency_id = 'dda9886d-b7f9-46de-80ac-5422c1242371';
+UPDATE agency_contacts SET agency_id = '2780b091-a846-42f8-9dac-c4c960da94cd'
+  WHERE agency_id = 'bf951a3e-1ec1-492c-b102-af89a1b57949';
+
+-- Step 2: ensure each keeper has exactly one is_primary=true contact.
+-- After the merge, the keeper may have 2 primary contacts (one from each
+-- original row). Promote the highest-scoring one and demote the other.
+WITH ranked AS (
+  SELECT ac.id, ac.agency_id,
+    ROW_NUMBER() OVER (
+      PARTITION BY ac.agency_id
+      ORDER BY
+        COALESCE(ac.is_archived, false) ASC,
+        COALESCE(ac.mes_relevance_score, 0) DESC,
+        COALESCE(ac.display_order, 99) ASC
+    ) AS rank_in_agency
+  FROM agency_contacts ac
+  WHERE ac.agency_id IN (
+    '529439b4-0571-497f-989f-8326487169fa',
+    'c524cd3f-ca20-43f1-a634-d00135a9588b',
+    '28cf410f-89d5-418c-b967-bce36330bcdd',
+    '55f921a6-a25f-40e5-aaa3-33c6bf129ae7',
+    '86099799-b451-4811-bb63-b02763b13b12',
+    '2780b091-a846-42f8-9dac-c4c960da94cd'
+  )
+)
+UPDATE agency_contacts ac
+SET is_primary = (r.rank_in_agency = 1)
+FROM ranked r
+WHERE ac.id = r.id;
+
+-- Step 3: delete the dropped duplicates (ON DELETE CASCADE handles the
+-- enrichment_staging entries and any residual resources).
+DELETE FROM trade_investment_agencies
+WHERE id IN (
+  '8cd0bc12-d2ea-41ef-b80b-aad91ad3465a',
+  '264247f4-6a79-4ca5-abdf-3f9620ccf069',
+  '4da104ef-d80f-4992-8701-588fa5ab2837',
+  'd8989f98-9051-4a9a-86a2-3b42f0b4716b',
+  'dda9886d-b7f9-46de-80ac-5422c1242371',
+  'bf951a3e-1ec1-492c-b102-af89a1b57949'
+);
+
+COMMIT;


### PR DESCRIPTION
## Summary

Four small follow-ups flagged in the cleanup-complete report from #194:

1. **Deactivate AMCC** — `Australia Malaysia Chamber of Commerce` row set to `is_active=false`. Phase 3 research confirmed the org doesn't exist (the legitimate AU-MY body is the separate `Australia Malaysia Business Council (NSW Chapter)`). Row kept (not hard-deleted) so external references still resolve.

2. **Normalize `government_level` for foreign agencies.** Phase 3 sub-agents had been inconsistent (KOTRA → `bilateral`, Enterprise Ireland → `international`). New convention applied via rule-based UPDATE:
   - `organisation_type = 'foreign_trade_agency'` → `international` (foreign trade agencies, consulates, embassies)
   - `organisation_type = 'bilateral'` → `bilateral` (member-funded business councils, chambers)
   - Plus Invest Northern Ireland special-cased to `international` (it's an `organisation_type='federal_agency'` but actually a UK regional body)

   **Final distribution:** 82 bilateral, 39 international, 5 state, 5 industry, 4 federal, 3 none, 1 local.

3. **Merge 6 duplicate pairs** flagged in Phase 3 research. For each pair: reassign `agency_contacts.agency_id` to the keeper, re-rank `is_primary` to exactly one per keeper, then DELETE the dropped row. `ON DELETE CASCADE` handles `trade_agencies_enrichment_staging` cleanup.

   | Keeper | Dropped | Canonical site |
   |---|---|---|
   | Danish Trade Council | Danish Trade Council / Danish Connect | australien.um.dk |
   | Dutch Chamber of Commerce Queensland | DCCQ - Dutch Chamber of Commerce Queensland | dccq.org |
   | Estonian Australian Chamber of Commerce | Estonian Chamber of Commerce | eacci.com.au |
   | Indonesian Chamber of Commerce Western Australia | ICCWA - Indonesian Chamber of Commerce Western Australia | iccwa.net.au |
   | JETRO - Japan External Trade Organization | JETRO - Japan External Trade Organisation | jetro.go.jp |
   | New Zealand Middle East Business Council | NZ-Middle East Business Council (NZMEBC) | nzmebc.org.nz |

4. **Regenerate `src/integrations/supabase/types.ts`** to reflect the Phase 4 schema additions on `agency_contacts` (`is_archived`, `mes_relevance_score`, `tier`). `tsc --noEmit` clean.

## Counts after this PR

| Metric | Value |
|---|---|
| Total `trade_investment_agencies` rows | 134 (was 140 — 6 duplicates dropped) |
| Active agencies | 133 (134 − 1 inactive AMCC) |
| Total `agency_contacts` | 415 (preserved through the merge) |
| Primary contacts | 134 (exactly one per agency) |
| Agencies with contacts | 134 |

## ⚠️ Migrations already applied to live DB

Same as #194 — all three migrations have already been applied to the live MES Supabase project (`xhziwveaiuhzdoutpgrh`) via the Supabase MCP server. The `.sql` files are checked-in artifacts mirroring what's deployed. They're idempotent (slug-scoped UPDATEs, conditional WHERE clauses) so re-running is safe.

## Test plan

- [x] Acceptance check: 133 active agencies, 134 primary contacts (one per agency), 6/6 keepers have exactly 1 primary
- [x] `tsc --noEmit` — no errors
- [x] Supabase Preview should replay cleanly (all three migrations are simple UPDATE/DELETE against tables that exist in the prior migration history)

## Still-outstanding follow-up

- **Legacy column retirement** (`contact_persons`, `website`, `founded`, `location_country`) — the cleanup-complete report recommended doing this "after one release". Intentionally deferred to a future PR.

https://claude.ai/code/session_01Miv7qy8arV9pn1DDuqXESa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Miv7qy8arV9pn1DDuqXESa)_